### PR TITLE
Fix undefined footprint display in netlist

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -36,14 +36,23 @@ export const convertCircuitJsonToReadableNetlist = (
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance} ${footprint} resistor`
+      componentDescription = `${component.display_resistance}${
+        footprint ? ` ${footprint}` : ""} resistor`
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance} ${footprint} capacitor`
+      componentDescription = `${component.display_capacitance}${
+        footprint ? ` ${footprint}` : ""} capacitor`
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
-      componentDescription = `${manufacturerPartNumber}, ${footprint}`
+      componentDescription = [
+        manufacturerPartNumber,
+        footprint,
+      ]
+        .filter(Boolean)
+        .join(", ")
     } else {
-      componentDescription = `${component.name}, ${component.type}`
+      componentDescription = [component.name, component.type]
+        .filter(Boolean)
+        .join(", ")
     }
 
     netlist.push(` - ${component.name}: ${componentDescription}`)

--- a/tests/test3-no-footprint-chip.test.tsx
+++ b/tests/test3-no-footprint-chip.test.tsx
@@ -1,0 +1,24 @@
+import { renderCircuit } from "tests/fixtures/render-circuit"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { it, expect } from "bun:test"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("chip without footprint doesn't output undefined", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm">
+      <chip name="LED1" manufacturerPartNumber="WS2812B_2020" />
+    </board>,
+  )
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - LED1: WS2812B_2020
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- avoid printing `undefined` values in component descriptions
- add regression test for chips without footprints

## Testing
- `bun test`
- `bun test tests/test3-no-footprint-chip.test.tsx`

------
https://chatgpt.com/codex/tasks/task_b_68451123e244832e8ecdd1852a7e4c92