### PR TITLE
Disable board routing in all tests

### DIFF
--- a/tests/test1-basic-circuit.test.tsx
+++ b/tests/test1-basic-circuit.test.tsx
@@ -10,7 +10,7 @@ declare module "bun:test" {
 
 it("test1 should render a basic circuit", () => {
   const circuitJson = renderCircuit(
-    <board width="10mm" height="10mm">
+    <board width="10mm" height="10mm" routingDisabled>
       <resistor resistance="1k" footprint="0402" name="R1" schX={3} pcbX={3} />
       <capacitor
         capacitance="1nF"

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -10,7 +10,7 @@ declare module "bun:test" {
 
 it("test2 chip", () => {
   const circuitJson = renderCircuit(
-    <board width="10mm" height="10mm">
+    <board width="10mm" height="10mm" routingDisabled>
       <chip
         name="U1"
         footprint="soic8"

--- a/tests/test3-no-footprint-chip.test.tsx
+++ b/tests/test3-no-footprint-chip.test.tsx
@@ -10,7 +10,7 @@ declare module "bun:test" {
 
 it("chip without footprint doesn't output undefined", () => {
   const circuitJson = renderCircuit(
-    <board width="10mm" height="10mm">
+    <board width="10mm" height="10mm" routingDisabled>
       <chip name="LED1" manufacturerPartNumber="WS2812B_2020" />
     </board>,
   )
@@ -19,6 +19,10 @@ it("chip without footprint doesn't output undefined", () => {
   expect(netlist).toMatchInlineSnapshot(`
     "COMPONENTS:
      - LED1: WS2812B_2020
+
+
+    COMPONENT_PINS:
+    LED1 (WS2812B_2020)
     "
   `)
 })


### PR DESCRIPTION
## Summary
- disable routing on all boards used in tests
- update snapshot for no-footprint chip test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68451d4c8d84832ea939c2d925322793