### PR TITLE
Fix undefined in readable netlists and improve pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,9 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${[component.display_resistance, footprint].filter(Boolean).join(" ")})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${[component.display_capacitance, footprint].filter(Boolean).join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }
@@ -157,7 +157,9 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.pin_number !== undefined
+            ? `pin${port.pin_number}`
+            : port.name ?? port.source_port_id
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -61,6 +61,11 @@ export const generateNetName = ({
       ),
     )
     .concat(nets.map((n) => n.name))
+    .filter(Boolean)
+
+  if (possibleNames.length === 0) {
+    return "unnamed_net"
+  }
 
   const phrases = possibleNames.map((name) => ({
     name,

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -34,7 +34,11 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = port.name
+    ? port.name
+    : port.pin_number !== undefined
+      ? `Pin${port.pin_number}`
+      : port.source_port_id
 
   const additionalPinLabels: string[] = []
 
@@ -47,7 +51,7 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score >= 1) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }


### PR DESCRIPTION
## Summary
- Fix `scorePhrase` to check word quality list before digit regex, so labels like "GPIO1" score 1.1 (matching "GPIO") instead of 0.5, and appear in pin descriptions
- Lower pin label inclusion threshold from `> 1` to `>= 1` so custom pin names are included
- Handle undefined `footprint` in COMPONENT_PINS header (was showing "1kΩ undefined" when no footprint)
- Handle undefined `port.name` fallback in COMPONENT_PINS `mainPin` and in `getReadableNameForPin`
- Handle empty `possibleNames` array in `generateNetName` to prevent crash

Closes #4

## Test plan
- [x] All 3 existing tests pass with no snapshot changes
- [ ] Verify on circuit with many pins (e.g. pico-w) that pin labels now show full names like "GPIO1" instead of just "pin14"
- [ ] Verify no "undefined" text appears in netlist output for components without footprints

🤖 Generated with [Claude Code](https://claude.com/claude-code)