### PR TITLE
fix: prefer descriptive pin labels over generic pin numbers for chip components

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -33,8 +33,39 @@ export const getReadableNameForPin = ({
     ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
   )
 
-  // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  // Check if the port name is just a generic pin number label like "pin14"
+  // Only replace generic names for chip-type components (not resistors/capacitors)
+  const isGenericPinName =
+    !port.name ||
+    /^pin\d+$/i.test(port.name) ||
+    port.name === String(port.pin_number)
+
+  const isPassiveComponent =
+    component.ftype === "simple_resistor" ||
+    component.ftype === "simple_capacitor" ||
+    component.ftype === "simple_inductor" ||
+    component.ftype === "simple_diode"
+
+  // For chips with generic pin names, find the best descriptive hint from port_hints
+  const bestHint =
+    isGenericPinName &&
+    !isPassiveComponent &&
+    port.port_hints &&
+    port.port_hints.length > 0
+      ? port.port_hints
+          .filter(
+            (h) =>
+              h !== String(port.pin_number) && !/^pin\d+$/i.test(h),
+          )
+          .sort((a, b) => scorePhrase(b) - scorePhrase(a))[0]
+      : null
+
+  // Format pin description: prefer descriptive hint over generic "pin14" for chips
+  const mainPinName = bestHint
+    ? bestHint
+    : port.name
+      ? port.name
+      : `pin${port.pin_number}`
 
   const additionalPinLabels: string[] = []
 
@@ -46,6 +77,8 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (port_hint === String(port.pin_number)) continue
+    if (/^pin\d+$/i.test(port_hint) && port_hint !== mainPinName) continue
     const score = scorePhrase(port_hint)
     if (score > 1) {
       additionalPinLabels.push(port_hint)

--- a/tests/test4-pin-label-improvement.test.tsx
+++ b/tests/test4-pin-label-improvement.test.tsx
@@ -1,0 +1,89 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("chip with many pins uses descriptive labels instead of pin14", () => {
+  const circuitJson = renderCircuit(
+    <board width="20mm" height="20mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="STM32F103"
+        pinLabels={{
+          pin1: ["VDD"],
+          pin2: ["GND"],
+          pin3: ["PA0", "GPIO0", "ADC0"],
+          pin4: ["PA1", "GPIO1", "ADC1"],
+          pin5: ["PA2", "GPIO2", "UART_TX"],
+          pin6: ["PA3", "GPIO3", "UART_RX"],
+          pin7: ["PB0", "SPI_SCK", "GPIO4"],
+          pin8: ["PB1", "SPI_MOSI", "GPIO5"],
+          pin9: ["PB2", "SPI_MISO", "GPIO6"],
+          pin10: ["PB3", "GPIO7"],
+          pin11: ["PB4", "GPIO8"],
+          pin12: ["PC0", "I2C_SDA", "GPIO9"],
+          pin13: ["PC1", "I2C_SCL", "GPIO10"],
+          pin14: ["NRST"],
+          pin15: ["BOOT0"],
+          pin16: ["VDDA"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <trace from=".U1 .VDD" to="net.VCC" />
+      <trace from=".U1 .GND" to="net.GND" />
+      <trace from=".U1 .UART_TX" to=".R1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  // Should not contain raw "pin14" or "pin15" etc when descriptive labels exist
+  expect(netlist).not.toContain("U1 pin14")
+  expect(netlist).not.toContain("U1 pin3")
+  expect(netlist).not.toContain("U1 pin5")
+
+  // Should use the descriptive labels
+  expect(netlist).toContain("NRST")
+  expect(netlist).toContain("UART_TX")
+
+  // Should not contain "undefined"
+  expect(netlist).not.toContain("undefined")
+})
+
+it("pin labels from port_hints are preferred over generic pin numbers for chip nets", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U2"
+        footprint="soic8"
+        manufacturerPartNumber="MCP3204"
+        pinLabels={{
+          pin1: ["CH0"],
+          pin2: ["CH1"],
+          pin3: ["CH2"],
+          pin4: ["CH3"],
+          pin5: ["GND"],
+          pin6: ["DOUT", "SPI_MISO"],
+          pin7: ["DIN", "SPI_MOSI"],
+          pin8: ["VDD"],
+        }}
+      />
+      <chip name="U3" footprint="soic8" manufacturerPartNumber="SPI_MASTER" />
+      <trace from=".U2 .DOUT" to=".U3 .pin1" />
+      <trace from=".U2 .VDD" to="net.VCC" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  // U2's pin6 (DOUT/SPI_MISO) should show as a descriptive name, not "pin6"
+  expect(netlist).not.toContain("U2 pin6")
+  expect(netlist).toContain("DOUT")
+  expect(netlist).not.toContain("undefined")
+})


### PR DESCRIPTION
/claim #4

## Problem

When a chip component has named pins (like `UART_TX`, `SPI_MISO`, `NRST`, `GPIO1`), the netlist was showing generic labels like `U1 pin14` instead of the descriptive name.

## Fix

In `getReadableNameForPin`, when a port name is just a generic pin number (e.g., `pin14`), look through `port_hints` to find the best descriptive label using `scorePhrase` to rank candidates.

For passive components (resistors, capacitors, etc.) the existing `pin1`/`pin2` behavior is preserved since those names are meaningful for 2-pin passives.

## Changes

- `lib/getReadableNameForPin.ts`: When port name is generic (like `pin14`), pick the highest-scoring non-generic hint from `port_hints` as the main label
- `tests/test4-pin-label-improvement.test.tsx`: Two new tests covering chips with descriptive pin labels

All 5 tests pass.