### PR TITLE
Fix readable netlist pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,10 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const joinDescriptionParts = (
+  parts: Array<string | number | null | undefined>,
+) => parts.filter(Boolean).join(" ")
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -145,9 +149,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${joinDescriptionParts([
+          component.display_resistance,
+          footprint,
+        ])})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${joinDescriptionParts([
+          component.display_capacitance,
+          footprint,
+        ])})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,48 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const lowInformationPinHints = new Set([
+  "anode",
+  "cathode",
+  "neg",
+  "negative",
+  "pos",
+  "positive",
+  "left",
+  "right",
+])
+
+const isGenericPinName = (name: string, pinNumber?: number) => {
+  const normalizedName = name.toLowerCase()
+  return (
+    normalizedName === "pin" ||
+    normalizedName === `pin${pinNumber}` ||
+    normalizedName === String(pinNumber)
+  )
+}
+
+const shouldIncludePinHint = ({
+  hint,
+  mainPinName,
+  pinNumber,
+}: {
+  hint: string
+  mainPinName: string
+  pinNumber?: number
+}) => {
+  const normalizedHint = hint.toLowerCase()
+  if (hint === mainPinName) return false
+  if (isGenericPinName(hint, pinNumber)) return false
+
+  const score = scorePhrase(hint)
+  if (score > 1) return true
+
+  if (!isGenericPinName(mainPinName, pinNumber)) return false
+  if (lowInformationPinHints.has(normalizedHint)) return false
+
+  return /[a-z]/i.test(hint)
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -45,9 +87,13 @@ export const getReadableNameForPin = ({
   }
 
   for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (
+      shouldIncludePinHint({
+        hint: port_hint,
+        mainPinName,
+        pinNumber: port.pin_number,
+      })
+    ) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/test3-no-footprint-chip.test.tsx
+++ b/tests/test3-no-footprint-chip.test.tsx
@@ -1,5 +1,6 @@
 import { expect, it } from "bun:test"
 import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
 import { renderCircuit } from "tests/fixtures/render-circuit"
 
 declare module "bun:test" {
@@ -25,4 +26,45 @@ it("chip without footprint doesn't output undefined", () => {
     LED1 (WS2812B_2020)
     "
   `)
+})
+
+it("passives without footprints don't output undefined in component pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <resistor resistance="1k" name="R1" />
+      <capacitor capacitance="1nF" name="C1" />
+      <trace from=".R1 > .pin1" to=".C1 > .pin1" />
+    </board>,
+  )
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("R1 (1kΩ)")
+  expect(netlist).toContain("C1 (1nF)")
+})
+
+it("generic pin names include useful alphanumeric hints", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "14", "GPIO0", "VBUS"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (GPIO0,VBUS)")
 })


### PR DESCRIPTION
/claim #4

This PR fixes two remaining readable-netlist edge cases tied to #4:

- Avoids printing `undefined` in `COMPONENT_PINS` headers for simple resistors/capacitors that do not have a footprint.
- Preserves useful alphanumeric pin hints like `GPIO0` and `VBUS` when the primary source port name is only a generic `pinN`, while still filtering low-information hints such as `left`, `right`, `pos`, and `neg`.

Tests added:

- no-footprint passive component headers do not contain `undefined`
- generic `pinN` names include useful alphanumeric hints

Verification:

- `npx --yes bun test`
- `npx --yes bun run build`
- `git diff --check`

Transparency note: this patch was prepared with AI-assisted coding and manually verified with the commands above.