### PR TITLE
Fix readable pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,9 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${[component.display_resistance, footprint].filter(Boolean).join(" ")})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${[component.display_capacitance, footprint].filter(Boolean).join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }
@@ -157,7 +157,9 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.pin_number !== undefined
+            ? `pin${port.pin_number}`
+            : (port.name ?? "unnamed_pin")
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -67,7 +67,8 @@ export const generateNetName = ({
     score: scorePhrase(name),
   }))
 
-  const bestPortName = phrases.sort((a, b) => b.score - a.score)[0].name
+  const bestPortName = phrases.sort((a, b) => b.score - a.score)[0]?.name
+  if (!bestPortName) return "unnamed_net"
 
   // Find the component that has the best port name
   const bestPort = ports.find(

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,17 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinLabel = (label: string, pinNumber?: number) => {
+  if (/^pin\d+$/i.test(label)) return true
+  return pinNumber !== undefined && label === String(pinNumber)
+}
+
+const getFallbackPinName = (port: SourcePort) => {
+  if (port.name) return port.name
+  if (port.pin_number !== undefined) return `pin${port.pin_number}`
+  return "unnamed_pin"
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +45,14 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const pinLabels = Array.from(
+    new Set([port.name, ...(port.port_hints ?? [])].filter(Boolean)),
+  ) as string[]
+  const mainPinName =
+    pinLabels.find(
+      (label) =>
+        !isGenericPinLabel(label, port.pin_number) && scorePhrase(label) >= 1,
+    ) ?? getFallbackPinName(port)
 
   const additionalPinLabels: string[] = []
 
@@ -47,7 +65,7 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score >= 1 && !isGenericPinLabel(port_hint, port.pin_number)) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-readable-pin-labels.test.tsx
+++ b/tests/test4-readable-pin-labels.test.tsx
@@ -1,0 +1,77 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses full pin labels when a port name is only a physical pin number", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic20"
+        manufacturerPartNumber="RP2040"
+        pinLabels={{
+          pin14: ["GPIO10"],
+        }}
+      />
+      <resistor resistance="1k" name="R1" />
+      <trace from=".U1 .GPIO10" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  const gpio10Port = circuitJson.find(
+    (element) => element.type === "source_port" && element.name === "GPIO10",
+  )
+  if (gpio10Port?.type === "source_port") {
+    gpio10Port.name = `pin${gpio10Port.pin_number}`
+  }
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("U1 GPIO10")
+  expect(netlist).not.toContain("U1 pin14")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: RP2040, soic20
+     - R1: 1kΩ resistor
+
+    NET: U1_GPIO10
+      - U1 GPIO10
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (RP2040)
+    - pin1: NOT_CONNECTED
+    - pin2: NOT_CONNECTED
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+    - pin9: NOT_CONNECTED
+    - pin10: NOT_CONNECTED
+    - pin11: NOT_CONNECTED
+    - pin12: NOT_CONNECTED
+    - pin13: NOT_CONNECTED
+    - pin14(GPIO10): NETS(U1_GPIO10)
+    - pin15: NOT_CONNECTED
+    - pin16: NOT_CONNECTED
+    - pin17: NOT_CONNECTED
+    - pin18: NOT_CONNECTED
+    - pin19: NOT_CONNECTED
+    - pin20: NOT_CONNECTED
+
+    R1 (1kΩ)
+    - pin1(anode, pos, left): NETS(U1_GPIO10)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary

- Prefer meaningful pin labels such as `GPIO10` over generic physical names such as `pin14` in readable net entries.
- Score labels containing known words before treating every label with digits as low-quality, so names like `GPIO10` can be selected.
- Avoid `undefined` in component pin headers when a resistor or capacitor has no footprint.
- Add a regression test for the bounty case where a port's base name is only a physical pin number.

Closes #4
/claim #4

## Test plan

- `npx bun test`
- `npx bun x tsc --noEmit`
- `npx bun x biome check lib\convertCircuitJsonToReadableNetlist.ts lib\generateNetName.ts lib\getReadableNameForPin.ts lib\scorePhrase.ts tests\test4-readable-pin-labels.test.tsx`
