### PR TITLE
Fix unnamed source port netlist fallback

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -45,9 +45,8 @@ export const convertCircuitJsonToReadableNetlist = (
       } capacitor`
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
-      componentDescription = [manufacturerPartNumber, footprint]
-        .filter(Boolean)
-        .join(", ")
+      componentDescription =
+        [manufacturerPartNumber, footprint].filter(Boolean).join(", ") || "chip"
     } else {
       componentDescription = [component.name, component.type]
         .filter(Boolean)
@@ -157,7 +156,9 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.pin_number !== undefined
+            ? `pin${port.pin_number}`
+            : port.name || port.source_port_id
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -61,6 +61,22 @@ export const generateNetName = ({
       ),
     )
     .concat(nets.map((n) => n.name))
+    .filter(Boolean)
+
+  if (possibleNames.length === 0) {
+    const fallbackPort = ports[0]
+    const fallbackComponent = all_source_components.find(
+      (c) => c.source_component_id === fallbackPort?.source_component_id,
+    )
+    return [
+      fallbackComponent?.name,
+      fallbackPort?.pin_number !== undefined
+        ? `pin${fallbackPort.pin_number}`
+        : fallbackPort?.source_port_id,
+    ]
+      .filter(Boolean)
+      .join("_")
+  }
 
   const phrases = possibleNames.map((name) => ({
     name,

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -34,7 +34,11 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = port.name
+    ? port.name
+    : port.pin_number !== undefined
+      ? `pin${port.pin_number}`
+      : port.source_port_id
 
   const additionalPinLabels: string[] = []
 

--- a/tests/test4-unnamed-source-ports.test.ts
+++ b/tests/test4-unnamed-source-ports.test.ts
@@ -1,0 +1,64 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("unnamed source ports still render a readable netlist", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_chip",
+      name: "U2",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: chip
+     - U2: chip
+
+    NET: U1_source_port_0
+      - U1 source_port_0
+      - U2 source_port_1
+
+
+    COMPONENT_PINS:
+    U1
+    - source_port_0: NETS(U1_source_port_0)
+
+    U2
+    - source_port_1: NETS(U1_source_port_0)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- Prevent `generateNetName` from crashing when connected source ports have no usable name, pin number, or hints.
- Fall back to stable source-port identifiers for unnamed ports in net and component-pin output.
- Add a regression test for unnamed source ports so readable netlist generation does not throw or emit blank pin labels.

## Verification
- `bun test`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`

This is intentionally scoped to a remaining edge case in issue #4 and does not duplicate the pending footprint/passive-header fixes.