### PR TITLE
Fix case-insensitive pin hint scoring

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.toUpperCase()
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-case-insensitive-pin-labels.test.tsx
+++ b/tests/test4-case-insensitive-pin-labels.test.tsx
@@ -1,0 +1,70 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses lowercase known pin hints when generating readable netlists", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_chip",
+      name: "U2",
+      manufacturer_part_number: "HEADER",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "14", "gpio10"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "1", "pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: RP2040
+     - U2: HEADER
+
+    NET: U1_gpio10
+      - U1 pin14 (gpio10)
+      - U2 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (RP2040)
+    - pin14(gpio10): NETS(U1_gpio10)
+
+    U2 (HEADER)
+    - pin1(pos): NETS(U1_gpio10)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

This fixes a remaining pin-label scoring edge case: known labels are matched case-sensitively, so lowercase hints like `gpio10` score below low-information hints such as `pos`. That can produce `NET: U2_pos` and `U1 pin14` even though the source data has the full label.

Changes:
- Normalize phrases when matching the known word-quality table
- Keep the numeric fallback after known-term matching
- Add regression coverage for lowercase `gpio10`

Verification:
- `bun test`
- `bun run build`
- `bunx tsc --noEmit`
- `bun run format:check`