### PR TITLE
Trim readable netlist labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -8,6 +8,10 @@ import type {
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import {
+  normalizeReadableLabel,
+  normalizeReadableLabels,
+} from "./normalizeReadableLabel"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -63,7 +67,7 @@ export const convertCircuitJsonToReadableNetlist = (
     // Get net name
     const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
 
-    let netName = net?.name
+    let netName = normalizeReadableLabel(net?.name)
 
     if (!netName) {
       // Generate a net name from the connected port names
@@ -125,7 +129,7 @@ export const convertCircuitJsonToReadableNetlist = (
     const portIds = connectedIds.filter((id) => id.startsWith("source_port"))
     if (portIds.length === 0) continue
     const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
-    let netName = net?.name
+    let netName = normalizeReadableLabel(net?.name)
     if (!netName) {
       netName = generateNetName({ circuitJson, connectedIds })
     }
@@ -156,13 +160,16 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
+        const portName = normalizeReadableLabel(port.name)
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.pin_number !== undefined
+            ? `pin${port.pin_number}`
+            : (portName ?? "unnamed_pin")
         const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
-        for (const hint of port.port_hints ?? []) {
+        if (portName && portName !== mainPin) aliases.push(portName)
+        for (const hint of normalizeReadableLabels(port.port_hints ?? [])) {
           if (hint === String(port.pin_number)) continue
-          if (hint !== mainPin && hint !== port.name) aliases.push(hint)
+          if (hint !== mainPin && hint !== portName) aliases.push(hint)
         }
         const aliasPart =
           aliases.length > 0

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -1,6 +1,10 @@
 import { su } from "@tscircuit/circuit-json-util"
 import type { AnyCircuitElement, AnySourceComponent } from "circuit-json"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import {
+  normalizeReadableLabel,
+  normalizeReadableLabels,
+} from "./normalizeReadableLabel"
 import { scorePhrase } from "./scorePhrase"
 
 // Order components by how much better they are as a reference (chips are
@@ -54,28 +58,42 @@ export const generateNetName = ({
     connectedIds.includes(t.source_trace_id),
   )
 
-  const possibleNames = ports
-    .flatMap((p) =>
-      Array.from(
-        new Set([...(p.name ? [p.name] : []), ...(p.port_hints ?? [])]),
-      ),
-    )
-    .concat(nets.map((n) => n.name))
+  const possibleNames: Array<{ name: string; source_port_id?: string }> = []
+  for (const port of ports) {
+    for (const name of normalizeReadableLabels([
+      port.name,
+      ...(port.port_hints ?? []),
+    ])) {
+      possibleNames.push({
+        name,
+        source_port_id: port.source_port_id,
+      })
+    }
+  }
+  for (const net of nets) {
+    const name = normalizeReadableLabel(net.name)
+    if (name) {
+      possibleNames.push({ name })
+    }
+  }
 
   const phrases = possibleNames.map((name) => ({
-    name,
-    score: scorePhrase(name),
+    ...name,
+    score: scorePhrase(name.name),
   }))
 
-  const bestPortName = phrases.sort((a, b) => b.score - a.score)[0].name
+  const bestPhrase = phrases.sort((a, b) => b.score - a.score)[0]
+  if (!bestPhrase) return "unnamed_net"
 
   // Find the component that has the best port name
   const bestPort = ports.find(
-    (p) => p.name === bestPortName || p.port_hints?.includes(bestPortName),
+    (p) => p.source_port_id === bestPhrase.source_port_id,
   )
 
   const componentWithBestPort = all_source_components.find(
     (c) => c.source_component_id === bestPort?.source_component_id,
   )
-  return [componentWithBestPort?.name, bestPortName].filter(Boolean).join("_")
+  return [componentWithBestPort?.name, bestPhrase.name]
+    .filter(Boolean)
+    .join("_")
 }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -5,6 +5,10 @@ import type {
   SourceNet,
   SourcePort,
 } from "circuit-json"
+import {
+  normalizeReadableLabel,
+  normalizeReadableLabels,
+} from "./normalizeReadableLabel"
 import { scorePhrase } from "./scorePhrase"
 
 export const getReadableNameForPin = ({
@@ -26,15 +30,19 @@ export const getReadableNameForPin = ({
   if (!component) return ""
 
   // Determine pin polarity from hints
-  const isPositive = port.port_hints?.some((hint) =>
+  const portHints = normalizeReadableLabels(port.port_hints ?? [])
+
+  const isPositive = portHints.some((hint) =>
     ["anode", "pos", "positive"].includes(hint.toLowerCase()),
   )
-  const isNegative = port.port_hints?.some((hint) =>
+  const isNegative = portHints.some((hint) =>
     ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName =
+    normalizeReadableLabel(port.name) ??
+    (port.pin_number !== undefined ? `Pin${port.pin_number}` : "unnamed_pin")
 
   const additionalPinLabels: string[] = []
 
@@ -44,7 +52,7 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
-  for (const port_hint of port.port_hints ?? []) {
+  for (const port_hint of portHints) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
     if (score > 1) {

--- a/lib/normalizeReadableLabel.ts
+++ b/lib/normalizeReadableLabel.ts
@@ -1,0 +1,15 @@
+export const normalizeReadableLabel = (label?: string | null) => {
+  const trimmed = label?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+export const normalizeReadableLabels = (
+  labels: Array<string | null | undefined>,
+) =>
+  Array.from(
+    new Set(
+      labels
+        .map((label) => normalizeReadableLabel(label))
+        .filter((label): label is string => Boolean(label)),
+    ),
+  )

--- a/tests/test4-trimmed-readable-labels.test.ts
+++ b/tests/test4-trimmed-readable-labels.test.ts
@@ -1,0 +1,76 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("ignores whitespace-only source labels and trims readable aliases", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_u1",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_j1",
+      ftype: "simple_chip",
+      name: "J1",
+      manufacturer_part_number: "HEADER",
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_signal",
+      name: "   ",
+      member_source_group_ids: [],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_reset",
+      source_component_id: "source_component_u1",
+      name: "   ",
+      pin_number: 14,
+      port_hints: ["   ", " SCL ", "SCL"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_pos",
+      source_component_id: "source_component_j1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_signal",
+      connected_source_port_ids: ["source_port_u1_reset", "source_port_j1_pos"],
+      connected_source_net_ids: ["source_net_signal"],
+    },
+  ] as any
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: MCU
+     - J1: HEADER
+
+    NET: U1_SCL
+      - U1 Pin14 (SCL)
+      - J1 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (MCU)
+    - pin14(SCL): NETS(U1_SCL)
+
+    J1 (HEADER)
+    - pin1(pos): NETS(U1_SCL)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- trim source net names, port names, and port hints before using them in readable netlist output
- treat trim-empty labels as missing so generated net names do not become blank-looking `NET:` headers
- preserve normalized aliases in `COMPONENT_PINS` and add a focused regression test for whitespace labels

/claim #4

## Verification
- `bun test`
- `bun run build`
- `bunx tsc --noEmit`
- `bunx biome check lib/normalizeReadableLabel.ts lib/convertCircuitJsonToReadableNetlist.ts lib/generateNetName.ts lib/getReadableNameForPin.ts tests/test4-trimmed-readable-labels.test.ts`

Transparency note: this PR was prepared with AI-assisted coding and manually verified.