### PR TITLE
Fix passive labels without display values

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,39 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const joinDescriptionParts = (
+  parts: Array<string | number | null | undefined>,
+) =>
+  parts
+    .filter((part) => part !== undefined && part !== null && part !== "")
+    .join(" ")
+
+const formatPassiveDescription = ({
+  displayValue,
+  footprint,
+  kind,
+}: {
+  displayValue?: string | number | null
+  footprint?: string | null
+  kind: "resistor" | "capacitor"
+}) => {
+  const details = joinDescriptionParts([displayValue, footprint])
+  return details ? `${details} ${kind}` : kind
+}
+
+const formatPassiveHeader = ({
+  name,
+  displayValue,
+  footprint,
+}: {
+  name: string
+  displayValue?: string | number | null
+  footprint?: string | null
+}) => {
+  const details = joinDescriptionParts([displayValue, footprint])
+  return details ? `${name} (${details})` : name
+}
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -36,13 +69,17 @@ export const convertCircuitJsonToReadableNetlist = (
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
+      componentDescription = formatPassiveDescription({
+        displayValue: component.display_resistance,
+        footprint,
+        kind: "resistor",
+      })
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
+      componentDescription = formatPassiveDescription({
+        displayValue: component.display_capacitance,
+        footprint,
+        kind: "capacitor",
+      })
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -145,9 +182,17 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = formatPassiveHeader({
+          name: component.name,
+          displayValue: component.display_resistance,
+          footprint,
+        })
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = formatPassiveHeader({
+          name: component.name,
+          displayValue: component.display_capacitance,
+          footprint,
+        })
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-missing-passive-values.test.ts
+++ b/tests/test4-missing-passive-values.test.ts
@@ -1,0 +1,81 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("passives missing display values don't output undefined", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_r1",
+      ftype: "simple_resistor",
+      name: "R1",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_c1",
+      ftype: "simple_capacitor",
+      name: "C1",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_r1",
+      source_component_id: "source_component_r1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_c1",
+      source_component_id: "source_component_c1",
+      footprinter_string: "0603",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "1", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_c1_1",
+      source_component_id: "source_component_c1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "1", "pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_r1_1", "source_port_c1_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - R1: 0402 resistor
+     - C1: 0603 capacitor
+
+    NET: C1_pos
+      - R1 pin1
+      - C1 pin1 (+)
+
+
+    COMPONENT_PINS:
+    R1 (0402)
+    - pin1(left): NETS(C1_pos)
+
+    C1 (0603)
+    - pin1(pos): NETS(C1_pos)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- avoid rendering `undefined` when simple resistors/capacitors are missing `display_resistance` or `display_capacitance`
- preserve any available footprint in COMPONENTS descriptions and COMPONENT_PINS headers
- add regression coverage for value-missing passive components

## Tests
- `npx --yes bun test`
- `npx --yes bun run format:check`
- `npx --yes bun run build`

/claim #4