### PR TITLE
Fix unnamed port fallback labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -157,7 +157,9 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.pin_number !== undefined
+            ? `pin${port.pin_number}`
+            : (port.name ?? "unnamed_pin")
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -34,7 +34,9 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName =
+    port.name ??
+    (port.pin_number !== undefined ? `Pin${port.pin_number}` : "unnamed pin")
 
   const additionalPinLabels: string[] = []
 

--- a/tests/test4-unnamed-port.test.ts
+++ b/tests/test4-unnamed-port.test.ts
@@ -1,0 +1,55 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("unnamed unnumbered ports on named nets do not output undefined", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "TEST_CHIP",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      port_hints: [],
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_1",
+      name: "RESET",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1"],
+      connected_source_net_ids: ["source_net_1"],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: TEST_CHIP
+
+
+    EMPTY NET PINS:
+      - U1 unnamed pin
+
+    COMPONENT_PINS:
+    U1 (TEST_CHIP)
+    - unnamed_pin: NETS(RESET)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- Adds stable fallback labels for source ports that have neither `name` nor `pin_number`.
- Prevents current-main output like `U1 Pinundefined` and `- undefined: NETS(RESET)` when that unnamed/unnumbered port is connected to a named net.
- Adds a focused regression test using raw circuit JSON for the named-net case.

## Why this is distinct
Recent follow-up attempts cover generated net-name crashes, whitespace labels, passive value/footprint labels, and pin scoring. This case does not need `generateNetName` because the source net is already named; the undefined text comes from pin display fallbacks in the net entry and component pin table.

## Verification
- `npx tsc --noEmit` passes.
- Focused `npx tsx` reproduction prints `U1 unnamed pin` and `- unnamed_pin: NETS(RESET)` and exits non-zero if the output contains `undefined`.
- `npx bun test` could not complete the existing render-based suite in this Windows checkout because dependency resolution fails before assertions with: `Export named 'distanceBetweenCircleAndPolygon' not found in module '@tscircuit/circuit-json-util/dist/index.js'`. The new focused test itself passes before those pre-existing suite errors are reported.