### PR TITLE
Fix readable netlist labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -1,13 +1,12 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { cleanLabel } from "./pin-labels"
+
+const formatLabelParts = (...parts: Array<string | undefined | null>) =>
+  parts.map(cleanLabel).filter(Boolean).join(" ")
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -19,30 +18,28 @@ export const convertCircuitJsonToReadableNetlist = (
   const source_ports = su(circuitJson).source_port.list()
   const source_components = su(circuitJson).source_component.list()
   const source_nets = su(circuitJson).source_net.list()
-  const source_traces = su(circuitJson).source_trace.list()
-  // Build readable netlist
   const netlist: string[] = []
 
-  // Add COMPONENTS section
   netlist.push("COMPONENTS:")
   for (const component of source_components) {
     let componentDescription = ""
-
-    // Get the cad_component associated with the source_component
     const cadComponent = su(circuitJson).cad_component.getWhere({
       source_component_id: component.source_component_id,
     })
-
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
+      componentDescription = formatLabelParts(
+        component.display_resistance,
+        footprint,
+        "resistor",
+      )
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
+      componentDescription = formatLabelParts(
+        component.display_capacitance,
+        footprint,
+        "capacitor",
+      )
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -58,28 +55,19 @@ export const convertCircuitJsonToReadableNetlist = (
   }
   netlist.push("")
 
-  // Process each net
-  for (const [netId, connectedIds] of Object.entries(netMap)) {
-    // Get net name
+  for (const connectedIds of Object.values(netMap)) {
     const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
-
-    let netName = net?.name
-
+    let netName = cleanLabel(net?.name)
     if (!netName) {
-      // Generate a net name from the connected port names
       netName = generateNetName({ circuitJson, connectedIds })
     }
 
     const connectedPortCount = connectedIds.filter((id) =>
       id.startsWith("source_port"),
     ).length
-
     if (connectedPortCount <= 1) continue
 
-    // Add net header
     netlist.push(`NET: ${netName}`)
-
-    // Process connected components
     for (const id of connectedIds) {
       const pinName = getReadableNameForPin({
         circuitJson,
@@ -89,12 +77,9 @@ export const convertCircuitJsonToReadableNetlist = (
         netlist.push(`  - ${pinName}`)
       }
     }
-
-    // Add blank line between nets
     netlist.push("")
   }
 
-  // Process nets with only one connection
   let hasEmptyNets = false
   for (const [netId, connectedIds] of Object.entries(netMap)) {
     const connectedPortCount = connectedIds.filter((id) =>
@@ -119,13 +104,12 @@ export const convertCircuitJsonToReadableNetlist = (
     }
   }
 
-  // build map of port ids to the nets they connect to
   const portIdToNetNames: Record<string, string[]> = {}
-  for (const [netId, connectedIds] of Object.entries(netMap)) {
+  for (const connectedIds of Object.values(netMap)) {
     const portIds = connectedIds.filter((id) => id.startsWith("source_port"))
     if (portIds.length === 0) continue
     const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
-    let netName = net?.name
+    let netName = cleanLabel(net?.name)
     if (!netName) {
       netName = generateNetName({ circuitJson, connectedIds })
     }
@@ -145,9 +129,17 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = formatLabelParts(
+          component.display_resistance,
+          footprint,
+        )
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = formatLabelParts(
+          component.display_capacitance,
+          footprint,
+        )
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }
@@ -156,13 +148,18 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
+        const portName = cleanLabel(port.name)
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.pin_number !== undefined ? `pin${port.pin_number}` : portName
         const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
+        if (portName && portName !== mainPin) aliases.push(portName)
         for (const hint of port.port_hints ?? []) {
-          if (hint === String(port.pin_number)) continue
-          if (hint !== mainPin && hint !== port.name) aliases.push(hint)
+          const cleanHint = cleanLabel(hint)
+          if (!cleanHint) continue
+          if (cleanHint === String(port.pin_number)) continue
+          if (cleanHint !== mainPin && cleanHint !== portName) {
+            aliases.push(cleanHint)
+          }
         }
         const aliasPart =
           aliases.length > 0

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -1,6 +1,6 @@
 import { su } from "@tscircuit/circuit-json-util"
 import type { AnyCircuitElement, AnySourceComponent } from "circuit-json"
-import { getReadableNameForPin } from "./getReadableNameForPin"
+import { cleanLabel, getReadablePinLabel } from "./pin-labels"
 import { scorePhrase } from "./scorePhrase"
 
 // Order components by how much better they are as a reference (chips are
@@ -42,32 +42,41 @@ export const generateNetName = ({
     )
 
   const all_source_nets = su(circuitJson).source_net.list()
-  const all_source_traces = su(circuitJson).source_trace.list()
-
   const ports = all_source_ports.filter((p) =>
     connectedIds.includes(p.source_port_id),
   )
   const nets = all_source_nets.filter((n) =>
     connectedIds.includes(n.source_net_id),
   )
-  const traces = all_source_traces.filter((t) =>
-    connectedIds.includes(t.source_trace_id),
-  )
 
   const possibleNames = ports
     .flatMap((p) =>
       Array.from(
-        new Set([...(p.name ? [p.name] : []), ...(p.port_hints ?? [])]),
+        new Set([
+          getReadablePinLabel(p),
+          ...(p.name ? [p.name] : []),
+          ...(p.port_hints ?? []),
+        ]),
       ),
     )
     .concat(nets.map((n) => n.name))
+    .map(cleanLabel)
+    .filter((name): name is string => Boolean(name))
 
   const phrases = possibleNames.map((name) => ({
     name,
     score: scorePhrase(name),
   }))
 
-  const bestPortName = phrases.sort((a, b) => b.score - a.score)[0].name
+  const bestPortName = phrases.sort((a, b) => b.score - a.score)[0]?.name
+  if (!bestPortName) {
+    const firstComponent = all_source_components.find((component) =>
+      ports.some(
+        (port) => port.source_component_id === component.source_component_id,
+      ),
+    )
+    return [firstComponent?.name, "net"].filter(Boolean).join("_")
+  }
 
   // Find the component that has the best port name
   const bestPort = ports.find(

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -1,11 +1,10 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
-import { scorePhrase } from "./scorePhrase"
+import type { AnyCircuitElement } from "circuit-json"
+import {
+  getReadablePinAliases,
+  getReadablePinLabel,
+  isLowInformationPinLabel,
+} from "./pin-labels"
 
 export const getReadableNameForPin = ({
   circuitJson,
@@ -25,7 +24,6 @@ export const getReadableNameForPin = ({
   )
   if (!component) return ""
 
-  // Determine pin polarity from hints
   const isPositive = port.port_hints?.some((hint) =>
     ["anode", "pos", "positive"].includes(hint.toLowerCase()),
   )
@@ -33,27 +31,29 @@ export const getReadableNameForPin = ({
     ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
   )
 
-  // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const preferDescriptiveHints =
+    component.ftype !== "simple_resistor" &&
+    component.ftype !== "simple_capacitor"
+  const mainPinName = getReadablePinLabel(port, { preferDescriptiveHints })
 
   const additionalPinLabels: string[] = []
-
   if (isPositive && component.ftype !== "simple_resistor") {
     additionalPinLabels.push("+")
   } else if (isNegative && component.ftype !== "simple_resistor") {
     additionalPinLabels.push("-")
   }
 
-  for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
-      additionalPinLabels.push(port_hint)
-    }
-  }
+  additionalPinLabels.push(
+    ...getReadablePinAliases(port, mainPinName, {
+      includeAllDescriptiveHints:
+        preferDescriptiveHints &&
+        Boolean(port.name && isLowInformationPinLabel(port.name, port)),
+    }),
+  )
 
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  const pinLabels = Array.from(new Set(additionalPinLabels))
+  return `${component.name} ${mainPinName}${pinLabels.length > 0 ? ` (${pinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/lib/pin-labels.ts
+++ b/lib/pin-labels.ts
@@ -1,0 +1,96 @@
+import type { SourcePort } from "circuit-json"
+import { scorePhrase } from "./scorePhrase"
+
+export const cleanLabel = (label?: string | null): string | undefined => {
+  const trimmed = label?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+const getPhysicalPinName = (port: SourcePort): string | undefined =>
+  port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+
+const isNumericPinLabel = (label: string, port: SourcePort): boolean =>
+  port.pin_number !== undefined && label === String(port.pin_number)
+
+const isPhysicalPinLabel = (label: string, port: SourcePort): boolean => {
+  const physicalPinName = getPhysicalPinName(port)
+  return (
+    physicalPinName !== undefined &&
+    label.toLowerCase() === physicalPinName.toLowerCase()
+  )
+}
+
+export const isLowInformationPinLabel = (
+  label: string,
+  port: SourcePort,
+): boolean => isNumericPinLabel(label, port) || isPhysicalPinLabel(label, port)
+
+const uniqueLabels = (labels: Array<string | undefined>): string[] =>
+  Array.from(new Set(labels.filter((label): label is string => Boolean(label))))
+
+export const getReadablePinLabel = (
+  port: SourcePort,
+  {
+    preferDescriptiveHints = true,
+  }: {
+    preferDescriptiveHints?: boolean
+  } = {},
+): string => {
+  const portName = cleanLabel(port.name)
+  if (
+    portName &&
+    (!preferDescriptiveHints || !isLowInformationPinLabel(portName, port))
+  ) {
+    return portName
+  }
+
+  if (preferDescriptiveHints) {
+    const descriptiveHints = uniqueLabels(
+      (port.port_hints ?? []).map(cleanLabel),
+    ).filter((hint) => !isLowInformationPinLabel(hint, port))
+    const bestHint = descriptiveHints
+      .map((hint, index) => ({
+        hint,
+        index,
+        score: scorePhrase(hint),
+      }))
+      .sort((a, b) => b.score - a.score || a.index - b.index)[0]?.hint
+    if (bestHint) return bestHint
+  }
+
+  return portName ?? getPhysicalPinName(port) ?? ""
+}
+
+export const getReadablePinAliases = (
+  port: SourcePort,
+  mainPinName: string,
+  {
+    includeAllDescriptiveHints = false,
+  }: {
+    includeAllDescriptiveHints?: boolean
+  } = {},
+): string[] => {
+  const aliases: string[] = []
+  const portName = cleanLabel(port.name)
+
+  if (
+    portName &&
+    portName !== mainPinName &&
+    !isNumericPinLabel(portName, port)
+  ) {
+    aliases.push(portName)
+  }
+
+  for (const rawHint of port.port_hints ?? []) {
+    const hint = cleanLabel(rawHint)
+    if (!hint) continue
+    if (hint === mainPinName || hint === portName) continue
+    if (isNumericPinLabel(hint, port)) continue
+
+    if (includeAllDescriptiveHints || scorePhrase(hint) > 1) {
+      aliases.push(hint)
+    }
+  }
+
+  return Array.from(new Set(aliases))
+}

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,11 +36,12 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
+  const normalizedPhrase = phrase.trim().toUpperCase()
+  if (normalizedPhrase.match(/^\d+$/)) {
     return 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
   }

--- a/tests/test4-readable-label-regressions.test.tsx
+++ b/tests/test4-readable-label-regressions.test.tsx
@@ -1,0 +1,98 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses descriptive chip pin labels when source port names are generic", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "ATMEGA328P",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      resistance: 1000,
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "GPIO17", "PWM5A"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_GPIO17")
+  expect(netlist).toContain("  - U1 GPIO17 (pin14,PWM5A)")
+  expect(netlist).not.toContain("  - U1 pin14")
+})
+
+it("omits undefined passive component details", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_0",
+      name: "R1",
+      resistance: 1000,
+    },
+    {
+      type: "source_component",
+      ftype: "simple_capacitor",
+      source_component_id: "source_component_1",
+      name: "C1",
+      display_capacitance: "1nF",
+      capacitance: 1e-9,
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain(" - R1: resistor")
+  expect(netlist).toContain("C1 (1nF)")
+})


### PR DESCRIPTION
## Summary
- omit missing passive component values and footprints instead of rendering `undefined`
- prefer descriptive chip pin hints like `GPIO17` over generic `pin14` labels while preserving the physical pin as an alias when the source name is generic
- trim blank labels before naming nets or component-pin aliases, and add a fallback for unnamed nets
- add focused Circuit JSON regression coverage for generic chip pins and missing passive details

## Tests
- `npx tsc --noEmit`
- `npx --yes bun test tests/test4-readable-label-regressions.test.tsx`
- `npx --yes bun run build`
- GitHub Actions on `0f28e13`: `test`, `format-check`, `type-check`, and `dependency-check` passed

Fixes #4
/claim #4