### PR TITLE
Deduplicate readable pin aliases

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -8,6 +8,7 @@ import type {
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { getUniqueReadableLabels } from "./getUniqueReadableLabels"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -158,16 +159,11 @@ export const convertCircuitJsonToReadableNetlist = (
       for (const port of ports) {
         const mainPin =
           port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
-        const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
-        for (const hint of port.port_hints ?? []) {
-          if (hint === String(port.pin_number)) continue
-          if (hint !== mainPin && hint !== port.name) aliases.push(hint)
-        }
-        const aliasPart =
-          aliases.length > 0
-            ? `(${Array.from(new Set(aliases)).join(", ")})`
-            : ""
+        const aliases = getUniqueReadableLabels(
+          [port.name, ...(port.port_hints ?? [])],
+          [mainPin, String(port.pin_number)],
+        )
+        const aliasPart = aliases.length > 0 ? `(${aliases.join(", ")})` : ""
         const nets = portIdToNetNames[port.source_port_id] ?? []
         const netsPart =
           nets.length > 0 ? `NETS(${nets.join(", ")})` : "NOT_CONNECTED"

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -5,6 +5,7 @@ import type {
   SourceNet,
   SourcePort,
 } from "circuit-json"
+import { getUniqueReadableLabels } from "./getUniqueReadableLabels"
 import { scorePhrase } from "./scorePhrase"
 
 export const getReadableNameForPin = ({
@@ -55,5 +56,6 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  const readablePinLabels = getUniqueReadableLabels(additionalPinLabels)
+  return `${component.name} ${mainPinName}${readablePinLabels.length > 0 ? ` (${readablePinLabels.join(", ")})` : ""}${displayValue}`
 }

--- a/lib/getUniqueReadableLabels.ts
+++ b/lib/getUniqueReadableLabels.ts
@@ -1,0 +1,27 @@
+export const getUniqueReadableLabels = (
+  labels: Array<string | null | undefined>,
+  blockedLabels: Array<string | null | undefined> = [],
+): string[] => {
+  const blockedLabelKeys = new Set(
+    blockedLabels
+      .map((label) => label?.trim().toLowerCase())
+      .filter((label): label is string => Boolean(label)),
+  )
+  const seenLabelKeys = new Set<string>()
+  const uniqueLabels: string[] = []
+
+  for (const rawLabel of labels) {
+    const label = rawLabel?.trim()
+    if (!label) continue
+
+    const labelKey = label.toLowerCase()
+    if (blockedLabelKeys.has(labelKey) || seenLabelKeys.has(labelKey)) {
+      continue
+    }
+
+    seenLabelKeys.add(labelKey)
+    uniqueLabels.push(label)
+  }
+
+  return uniqueLabels
+}

--- a/tests/test4-dedupe-pin-labels.test.ts
+++ b/tests/test4-dedupe-pin-labels.test.ts
@@ -1,0 +1,76 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("dedupes repeated pin aliases in net and component pin output", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "DUPLICATE_LABEL_CHIP",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "GPIO2",
+      pin_number: 1,
+      port_hints: ["GPIO2", "gpio2", "SDA", "SDA", "sda"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any[]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: DUPLICATE_LABEL_CHIP
+     - R1: 1kΩ 0402 resistor
+
+    NET: U1_SDA
+      - U1 GPIO2 (SDA)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (DUPLICATE_LABEL_CHIP)
+    - pin1(GPIO2, SDA): NETS(U1_SDA)
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_SDA)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- add a shared readable-label normalization helper
- dedupe and trim pin aliases case-insensitively for NET entries and COMPONENT_PINS
- add a raw Circuit JSON regression covering duplicate/case-variant aliases

## Validation
- `npx biome check .`
- `npx tsc --noEmit`
- `npx bun test tests/test4-dedupe-pin-labels.test.ts`
- `npx bun run build`

## Note
- `npx bun test` still fails in the pre-existing TSX fixture tests before the converter code runs: `@tscircuit/core` tries to mutate a frozen React element in `tests/fixtures/render-circuit.ts`. The new regression uses raw Circuit JSON and passes locally.