### PR TITLE
Fix scoring for digit-bearing technical pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/score-phrase.test.ts
+++ b/tests/score-phrase.test.ts
@@ -1,0 +1,49 @@
+import { expect, it } from "bun:test"
+import { generateNetName } from "lib/generateNetName"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores known technical labels before the generic digit fallback", () => {
+  expect(scorePhrase("GPIO1")).toBe(1.1)
+  expect(scorePhrase("GPIO1_RX")).toBe(1.15)
+  expect(scorePhrase("J42")).toBe(0.5)
+})
+
+it("uses digit-bearing technical hints when generating net names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "C1",
+      ftype: "simple_capacitor",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["GPIO1_RX"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode"],
+    },
+  ] as any
+
+  expect(
+    generateNetName({
+      circuitJson,
+      connectedIds: ["source_port_0", "source_port_1"],
+    }),
+  ).toBe("U1_GPIO1_RX")
+})


### PR DESCRIPTION
## Summary
- Score known technical vocabulary before applying the generic digit fallback in `scorePhrase`
- Preserve the low fallback for unknown digit-bearing labels such as `J42`
- Add regression coverage showing `GPIO1_RX` wins net-name generation over low-information passive hints like `pos`

## Verification
- `npx --yes bun@1.3.13 test`
- `npx --yes bun@1.3.13 run build`
- `npx tsc --noEmit`
- `npx biome check lib/scorePhrase.ts tests/score-phrase.test.ts`
- `git diff --check`

/claim #4