### PR TITLE
Fix unnamed component labels in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,7 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+// Convert Circuit JSON into readable netlist text with stable display-name fallbacks.
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -27,6 +28,7 @@ export const convertCircuitJsonToReadableNetlist = (
   netlist.push("COMPONENTS:")
   for (const component of source_components) {
     let componentDescription = ""
+    const componentName = component.name ?? component.source_component_id
 
     // Get the cad_component associated with the source_component
     const cadComponent = su(circuitJson).cad_component.getWhere({
@@ -54,7 +56,7 @@ export const convertCircuitJsonToReadableNetlist = (
         .join(", ")
     }
 
-    netlist.push(` - ${component.name}: ${componentDescription}`)
+    netlist.push(` - ${componentName}: ${componentDescription}`)
   }
   netlist.push("")
 
@@ -143,13 +145,14 @@ export const convertCircuitJsonToReadableNetlist = (
         source_component_id: component.source_component_id,
       })
       const footprint = cadComponent?.footprinter_string
-      let header = component.name
+      const componentName = component.name ?? component.source_component_id
+      let header = componentName
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${componentName} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${componentName} (${component.display_capacitance} ${footprint})`
       } else if (component.manufacturer_part_number) {
-        header = `${component.name} (${component.manufacturer_part_number})`
+        header = `${componentName} (${component.manufacturer_part_number})`
       }
       netlist.push(header)
       const ports = source_ports

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,7 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+// Build a readable source-port label, falling back to component ID when needed.
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -24,6 +25,7 @@ export const getReadableNameForPin = ({
     (c) => c.source_component_id === port.source_component_id,
   )
   if (!component) return ""
+  const componentName = component.name ?? component.source_component_id
 
   // Determine pin polarity from hints
   const isPositive = port.port_hints?.some((hint) =>
@@ -55,5 +57,5 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  return `${componentName} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/tests/test4-unnamed-component.test.ts
+++ b/tests/test4-unnamed-component.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses source component id when component name is missing", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_unnamed",
+      ftype: "simple_chip",
+      manufacturer_part_number: "MCU-123",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_reset",
+      source_component_id: "source_component_unnamed",
+      name: "RESET",
+      pin_number: 1,
+      port_hints: ["RESET"],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain(" - source_component_unnamed: MCU-123")
+  expect(netlist).toContain("source_component_unnamed (MCU-123)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- Use `source_component_id` as a stable fallback when `source_component.name` is missing.
- Prevent readable netlists from rendering `undefined` in `COMPONENTS`, `COMPONENT_PINS`, and readable pin labels for unnamed components.
- Add a focused raw Circuit JSON regression test for the unnamed-component case.

## Verification
- `npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun run build`
- `npx --yes bun run format:check`

Transparency note: this patch was prepared with AI-assisted coding and verified locally.