### PR TITLE
Fix readable netlists for custom source port ids

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -20,6 +20,8 @@ export const convertCircuitJsonToReadableNetlist = (
   const source_components = su(circuitJson).source_component.list()
   const source_nets = su(circuitJson).source_net.list()
   const source_traces = su(circuitJson).source_trace.list()
+  const sourcePortIds = new Set(source_ports.map((p) => p.source_port_id))
+  const isSourcePortId = (id: string) => sourcePortIds.has(id)
   // Build readable netlist
   const netlist: string[] = []
 
@@ -70,9 +72,7 @@ export const convertCircuitJsonToReadableNetlist = (
       netName = generateNetName({ circuitJson, connectedIds })
     }
 
-    const connectedPortCount = connectedIds.filter((id) =>
-      id.startsWith("source_port"),
-    ).length
+    const connectedPortCount = connectedIds.filter(isSourcePortId).length
 
     if (connectedPortCount <= 1) continue
 
@@ -97,18 +97,14 @@ export const convertCircuitJsonToReadableNetlist = (
   // Process nets with only one connection
   let hasEmptyNets = false
   for (const [netId, connectedIds] of Object.entries(netMap)) {
-    const connectedPortCount = connectedIds.filter((id) =>
-      id.startsWith("source_port"),
-    ).length
+    const connectedPortCount = connectedIds.filter(isSourcePortId).length
     if (connectedPortCount === 1) {
       if (!hasEmptyNets) {
         netlist.push("")
         netlist.push("EMPTY NET PINS:")
         hasEmptyNets = true
       }
-      const source_port_id = netMap[netId].find((id) =>
-        id.startsWith("source_port"),
-      )!
+      const source_port_id = netMap[netId].find(isSourcePortId)!
       const pinName = getReadableNameForPin({
         circuitJson,
         source_port_id,
@@ -122,7 +118,7 @@ export const convertCircuitJsonToReadableNetlist = (
   // build map of port ids to the nets they connect to
   const portIdToNetNames: Record<string, string[]> = {}
   for (const [netId, connectedIds] of Object.entries(netMap)) {
-    const portIds = connectedIds.filter((id) => id.startsWith("source_port"))
+    const portIds = connectedIds.filter(isSourcePortId)
     if (portIds.length === 0) continue
     const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
     let netName = net?.name

--- a/tests/test4-custom-port-ids.test.ts
+++ b/tests/test4-custom-port-ids.test.ts
@@ -1,0 +1,71 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("detects connected ports without relying on source_port_id prefixes", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "chip_a",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "chip_b",
+      name: "U2",
+      manufacturer_part_number: "SENSOR",
+    },
+    {
+      type: "source_port",
+      source_port_id: "u1-port-sda",
+      source_component_id: "chip_a",
+      name: "SDA",
+      pin_number: 1,
+      port_hints: ["SDA"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "u2-port-data",
+      source_component_id: "chip_b",
+      name: "DATA",
+      pin_number: 1,
+      port_hints: ["DATA"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "trace-between-custom-port-ids",
+      connected_source_port_ids: ["u1-port-sda", "u2-port-data"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: MCU
+     - U2: SENSOR
+
+    NET: U1_SDA
+      - U1 SDA
+      - U2 DATA
+
+
+    COMPONENT_PINS:
+    U1 (MCU)
+    - pin1(SDA): NETS(U1_SDA)
+
+    U2 (SENSOR)
+    - pin1(DATA): NETS(U1_SDA)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- detect connected source ports from the actual `source_port` elements instead of assuming ids start with `source_port`
- fix NET and COMPONENT_PINS output for valid Circuit JSON that uses custom `source_port_id` strings
- add a raw Circuit JSON regression test for custom source port ids

## Testing
- `bun test`
- `bun run build`
- `bunx tsc --noEmit`

/claim #4