### PR TITLE
Fix named single-pin source nets

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -74,7 +74,7 @@ export const convertCircuitJsonToReadableNetlist = (
       id.startsWith("source_port"),
     ).length
 
-    if (connectedPortCount <= 1) continue
+    if (connectedPortCount <= 1 && !net?.name) continue
 
     // Add net header
     netlist.push(`NET: ${netName}`)
@@ -100,7 +100,8 @@ export const convertCircuitJsonToReadableNetlist = (
     const connectedPortCount = connectedIds.filter((id) =>
       id.startsWith("source_port"),
     ).length
-    if (connectedPortCount === 1) {
+    const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
+    if (connectedPortCount === 1 && !net?.name) {
       if (!hasEmptyNets) {
         netlist.push("")
         netlist.push("EMPTY NET PINS:")

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -61,10 +61,12 @@ it("test2 chip", () => {
       - U1 GPIO2 (SDA)
       - R1 pin2
 
-
-    EMPTY NET PINS:
+    NET: GPIO4
       - U1 GPIO3
+
+    NET: V5
       - U1 VDD
+
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)

--- a/tests/test4-named-single-pin-net.test.tsx
+++ b/tests/test4-named-single-pin-net.test.tsx
@@ -1,0 +1,22 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("renders named single-pin source nets as nets", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{
+          pin1: ["VDD"],
+        }}
+      />
+      <trace from=".U1 .VDD" to="net.V5" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+  expect(netlist).toContain("NET: V5\n  - U1 VDD")
+  expect(netlist).not.toContain("EMPTY NET PINS:\n  - U1 VDD")
+})


### PR DESCRIPTION
## Summary
- render named single-pin source nets as `NET:` sections instead of `EMPTY NET PINS`
- keep unnamed one-pin nets in `EMPTY NET PINS`
- add focused regression coverage and update the chip snapshot

## Tests
- `npx bun test`
- `npm run build`
- `npx biome check .`
- `git diff --check`

/claim #4