### PR TITLE
Fix blank component names in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -7,6 +7,7 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
+import { getReadableComponentName } from "./getReadableComponentName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
 export const convertCircuitJsonToReadableNetlist = (
@@ -26,6 +27,7 @@ export const convertCircuitJsonToReadableNetlist = (
   // Add COMPONENTS section
   netlist.push("COMPONENTS:")
   for (const component of source_components) {
+    const componentName = getReadableComponentName(component)
     let componentDescription = ""
 
     // Get the cad_component associated with the source_component
@@ -49,12 +51,12 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter(Boolean)
         .join(", ")
     } else {
-      componentDescription = [component.name, component.type]
+      componentDescription = [componentName, component.type]
         .filter(Boolean)
         .join(", ")
     }
 
-    netlist.push(` - ${component.name}: ${componentDescription}`)
+    netlist.push(` - ${componentName}: ${componentDescription}`)
   }
   netlist.push("")
 
@@ -139,17 +141,18 @@ export const convertCircuitJsonToReadableNetlist = (
     netlist.push("")
     netlist.push("COMPONENT_PINS:")
     for (const component of source_components) {
+      const componentName = getReadableComponentName(component)
       const cadComponent = su(circuitJson).cad_component.getWhere({
         source_component_id: component.source_component_id,
       })
       const footprint = cadComponent?.footprinter_string
-      let header = component.name
+      let header = componentName
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${componentName} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${componentName} (${component.display_capacitance} ${footprint})`
       } else if (component.manufacturer_part_number) {
-        header = `${component.name} (${component.manufacturer_part_number})`
+        header = `${componentName} (${component.manufacturer_part_number})`
       }
       netlist.push(header)
       const ports = source_ports

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -1,5 +1,6 @@
 import { su } from "@tscircuit/circuit-json-util"
 import type { AnyCircuitElement, AnySourceComponent } from "circuit-json"
+import { getReadableComponentName } from "./getReadableComponentName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 import { scorePhrase } from "./scorePhrase"
 
@@ -77,5 +78,12 @@ export const generateNetName = ({
   const componentWithBestPort = all_source_components.find(
     (c) => c.source_component_id === bestPort?.source_component_id,
   )
-  return [componentWithBestPort?.name, bestPortName].filter(Boolean).join("_")
+  return [
+    componentWithBestPort
+      ? getReadableComponentName(componentWithBestPort)
+      : undefined,
+    bestPortName,
+  ]
+    .filter(Boolean)
+    .join("_")
 }

--- a/lib/getReadableComponentName.ts
+++ b/lib/getReadableComponentName.ts
@@ -1,0 +1,7 @@
+export const getReadableComponentName = (component: {
+  source_component_id: string
+  name?: string | null
+}): string => {
+  const trimmedName = component.name?.trim() ?? ""
+  return trimmedName || component.source_component_id
+}

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -5,6 +5,7 @@ import type {
   SourceNet,
   SourcePort,
 } from "circuit-json"
+import { getReadableComponentName } from "./getReadableComponentName"
 import { scorePhrase } from "./scorePhrase"
 
 export const getReadableNameForPin = ({
@@ -24,6 +25,7 @@ export const getReadableNameForPin = ({
     (c) => c.source_component_id === port.source_component_id,
   )
   if (!component) return ""
+  const componentName = getReadableComponentName(component)
 
   // Determine pin polarity from hints
   const isPositive = port.port_hints?.some((hint) =>
@@ -55,5 +57,5 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  return `${componentName} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/tests/test4-trim-component-names.test.ts
+++ b/tests/test4-trim-component-names.test.ts
@@ -1,0 +1,76 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("falls back to source component id for whitespace-only component names", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "   ",
+      ftype: "simple_chip",
+      manufacturer_part_number: "MCU",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "SDA",
+      pin_number: 1,
+      port_hints: ["SDA"],
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "R1",
+      ftype: "simple_resistor",
+      display_resistance: "1k",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos"],
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      source_component_id: "source_component_2",
+      footprinter_string: "0402",
+    } as any,
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+      "COMPONENTS:
+       - source_component_1: MCU
+       - R1: 1k 0402 resistor
+
+      NET: source_component_1_SDA
+        - source_component_1 SDA
+        - R1 pin1
+
+
+      COMPONENT_PINS:
+      source_component_1 (MCU)
+      - pin1(SDA): NETS(source_component_1_SDA)
+
+      R1 (1k 0402)
+      - pin1(anode, pos): NETS(source_component_1_SDA)
+      "
+    `)
+})


### PR DESCRIPTION
## Summary
- normalize source component display names with a shared helper
- fall back to `source_component_id` when a component name is whitespace-only
- use the normalized component name in component rows, generated net names, pin labels, and component-pin headers
- add a raw Circuit JSON regression for the whitespace-only component-name case

/claim #4

## Verification
- `npx --yes bun@latest test tests/test4-trim-component-names.test.ts`
- `npx --yes bun@latest test`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest x biome check .`
- `npx --yes bun@latest run build`
- `git diff --check`

Transparency note: this patch was prepared with AI-assisted coding and verified locally before submission.