### PR TITLE
Improve readable component descriptions

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -1,13 +1,13 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+
+const formatSourceComponentType = (ftype?: string) => {
+  if (!ftype) return undefined
+  return ftype.replace(/^simple_/, "").replaceAll("_", " ")
+}
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -23,36 +23,48 @@ export const convertCircuitJsonToReadableNetlist = (
   // Build readable netlist
   const netlist: string[] = []
 
+  const getComponentDescription = (
+    component: (typeof source_components)[number],
+    footprint?: string,
+  ) => {
+    if (component.ftype === "simple_resistor") {
+      return `${component.display_resistance}${
+        footprint ? ` ${footprint}` : ""
+      } resistor`
+    }
+    if (component.ftype === "simple_capacitor") {
+      return `${component.display_capacitance}${
+        footprint ? ` ${footprint}` : ""
+      } capacitor`
+    }
+    if (component.ftype === "simple_chip") {
+      const manufacturerPartNumber = component.manufacturer_part_number
+      return [manufacturerPartNumber, footprint].filter(Boolean).join(", ")
+    }
+
+    const readableComponentType = formatSourceComponentType(component.ftype)
+    const componentDescription = [
+      component.manufacturer_part_number,
+      component.display_value,
+      footprint,
+      readableComponentType,
+    ]
+      .filter(Boolean)
+      .join(" ")
+
+    return componentDescription || component.name
+  }
+
   // Add COMPONENTS section
   netlist.push("COMPONENTS:")
   for (const component of source_components) {
-    let componentDescription = ""
-
     // Get the cad_component associated with the source_component
     const cadComponent = su(circuitJson).cad_component.getWhere({
       source_component_id: component.source_component_id,
     })
 
     const footprint = cadComponent?.footprinter_string
-
-    if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
-    } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
-    } else if (component.ftype === "simple_chip") {
-      const manufacturerPartNumber = component.manufacturer_part_number
-      componentDescription = [manufacturerPartNumber, footprint]
-        .filter(Boolean)
-        .join(", ")
-    } else {
-      componentDescription = [component.name, component.type]
-        .filter(Boolean)
-        .join(", ")
-    }
+    const componentDescription = getComponentDescription(component, footprint)
 
     netlist.push(` - ${component.name}: ${componentDescription}`)
   }

--- a/tests/test4-readable-component-descriptions.test.ts
+++ b/tests/test4-readable-component-descriptions.test.ts
@@ -1,0 +1,53 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses readable descriptions for non resistor/capacitor components", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_diode",
+      source_component_id: "source_component_0",
+      name: "D1",
+    },
+    {
+      type: "source_component",
+      ftype: "led",
+      source_component_id: "source_component_1",
+      name: "LED1",
+      display_value: "red",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_inductor",
+      source_component_id: "source_component_2",
+      name: "L1",
+      inductance: 0.000001,
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("source_component")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - D1: diode
+     - LED1: red led
+     - L1: inductor
+
+
+    COMPONENT_PINS:
+    D1
+
+    LED1
+
+    L1
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- render generic source component ftypes like `simple_diode`, `led`, and `simple_inductor` as readable component descriptions instead of `source_component`
- keep the existing resistor, capacitor, and chip descriptions unchanged
- add raw Circuit JSON regression coverage for non resistor/capacitor component descriptions

/claim #4

## Verification
- `npx --yes bun@latest test tests/test4-readable-component-descriptions.test.ts`
- `npx --yes bun@latest test`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest x biome lint lib/convertCircuitJsonToReadableNetlist.ts tests/test4-readable-component-descriptions.test.ts`
- `npx --yes bun@latest run build`
- `git diff --check`

Transparency note: this patch was prepared with AI-assisted coding and verified locally before submission.
