### PR TITLE
Fix blank port hints in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -8,6 +8,7 @@ import type {
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { getReadablePortHints } from "./getReadablePortHints"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -160,7 +161,7 @@ export const convertCircuitJsonToReadableNetlist = (
           port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
-        for (const hint of port.port_hints ?? []) {
+        for (const hint of getReadablePortHints(port.port_hints)) {
           if (hint === String(port.pin_number)) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)
         }

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -1,6 +1,7 @@
 import { su } from "@tscircuit/circuit-json-util"
 import type { AnyCircuitElement, AnySourceComponent } from "circuit-json"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { getReadablePortHints } from "./getReadablePortHints"
 import { scorePhrase } from "./scorePhrase"
 
 // Order components by how much better they are as a reference (chips are
@@ -57,7 +58,10 @@ export const generateNetName = ({
   const possibleNames = ports
     .flatMap((p) =>
       Array.from(
-        new Set([...(p.name ? [p.name] : []), ...(p.port_hints ?? [])]),
+        new Set([
+          ...(p.name ? [p.name] : []),
+          ...getReadablePortHints(p.port_hints),
+        ]),
       ),
     )
     .concat(nets.map((n) => n.name))

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -5,6 +5,7 @@ import type {
   SourceNet,
   SourcePort,
 } from "circuit-json"
+import { getReadablePortHints } from "./getReadablePortHints"
 import { scorePhrase } from "./scorePhrase"
 
 export const getReadableNameForPin = ({
@@ -25,11 +26,13 @@ export const getReadableNameForPin = ({
   )
   if (!component) return ""
 
+  const readablePortHints = getReadablePortHints(port.port_hints)
+
   // Determine pin polarity from hints
-  const isPositive = port.port_hints?.some((hint) =>
+  const isPositive = readablePortHints.some((hint) =>
     ["anode", "pos", "positive"].includes(hint.toLowerCase()),
   )
-  const isNegative = port.port_hints?.some((hint) =>
+  const isNegative = readablePortHints.some((hint) =>
     ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
   )
 
@@ -44,7 +47,7 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
-  for (const port_hint of port.port_hints ?? []) {
+  for (const port_hint of readablePortHints) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
     if (score > 1) {

--- a/lib/getReadablePortHints.ts
+++ b/lib/getReadablePortHints.ts
@@ -1,0 +1,2 @@
+export const getReadablePortHints = (portHints?: string[]) =>
+  (portHints ?? []).map((hint) => hint.trim()).filter((hint) => hint.length > 0)

--- a/tests/test5-blank-port-hints.test.ts
+++ b/tests/test5-blank-port-hints.test.ts
@@ -1,0 +1,53 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("ignores blank port hints when naming nets and aliases", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "U2",
+      manufacturer_part_number: "SENSOR",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["   ", "pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["\t", "positive"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_pos")
+  expect(netlist).toContain("- pin1(pos): NETS(U1_pos)")
+  expect(netlist).toContain("- pin1(positive): NETS(U1_pos)")
+  expect(netlist).not.toContain("NET: U1_   ")
+  expect(netlist).not.toContain("pin1(   ")
+  expect(netlist).not.toContain("pin1(\t")
+})


### PR DESCRIPTION
## Summary
- normalize `source_port.port_hints` by trimming values and ignoring blank-only hints
- use normalized hints for generated net names, polarity/readable pin labels, and `COMPONENT_PINS` aliases
- add a raw Circuit JSON regression test showing blank hints no longer produce blank-looking net names or aliases

## Verification
- `npx --yes bun test`
- `npm exec tsc -- --noEmit`
- `npm exec biome -- check . --write`
- `npm run build`

/claim #4