### PR TITLE
Fix readable netlist pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,14 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const joinDefined = (...values: Array<string | number | undefined | null>) =>
+  values
+    .map((value) =>
+      value === undefined || value === null ? "" : String(value),
+    )
+    .filter((value) => value.length > 0)
+    .join(" ")
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -36,13 +44,15 @@ export const convertCircuitJsonToReadableNetlist = (
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
+      componentDescription = `${joinDefined(
+        component.display_resistance,
+        footprint,
+      )} resistor`.trim()
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
+      componentDescription = `${joinDefined(
+        component.display_capacitance,
+        footprint,
+      )} capacitor`.trim()
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -145,9 +155,11 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = joinDefined(component.display_resistance, footprint)
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = joinDefined(component.display_capacitance, footprint)
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -1,11 +1,38 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
+
+const weakPinHints = new Set([
+  "anode",
+  "cathode",
+  "left",
+  "neg",
+  "negative",
+  "pos",
+  "positive",
+  "right",
+])
+
+const isGenericPinName = (name: string) => /^pin\d+$/i.test(name)
+
+const normalizeLabel = (label: unknown) =>
+  typeof label === "string" ? label.trim() : ""
+
+const addUniqueLabel = (labels: string[], label: string) => {
+  if (!label) return
+  const lowerLabel = label.toLowerCase()
+  if (labels.some((existing) => existing.toLowerCase() === lowerLabel)) return
+  labels.push(label)
+}
+
+const isDescriptivePinHint = (hint: string) => {
+  const normalizedHint = hint.trim()
+  if (!normalizedHint) return false
+  if (/^\d+$/.test(normalizedHint)) return false
+  if (isGenericPinName(normalizedHint)) return false
+  if (weakPinHints.has(normalizedHint.toLowerCase())) return false
+  return /[a-z]/i.test(normalizedHint)
+}
 
 export const getReadableNameForPin = ({
   circuitJson,
@@ -33,22 +60,45 @@ export const getReadableNameForPin = ({
     ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
   )
 
-  // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const rawPortName = normalizeLabel(port.name)
+  const fallbackPinName =
+    port.pin_number !== undefined ? `Pin${port.pin_number}` : ""
+  const descriptivePinHint = (port.port_hints ?? [])
+    .map(normalizeLabel)
+    .find(isDescriptivePinHint)
+
+  let mainPinName = rawPortName || fallbackPinName
+  if (
+    descriptivePinHint &&
+    (!mainPinName ||
+      (component.ftype === "simple_chip" && isGenericPinName(mainPinName)))
+  ) {
+    mainPinName = descriptivePinHint
+  }
+  if (!mainPinName) mainPinName = port.source_port_id
 
   const additionalPinLabels: string[] = []
+  if (rawPortName && rawPortName !== mainPinName) {
+    addUniqueLabel(additionalPinLabels, rawPortName)
+  }
 
   if (isPositive && component.ftype !== "simple_resistor") {
-    additionalPinLabels.push("+")
+    addUniqueLabel(additionalPinLabels, "+")
   } else if (isNegative && component.ftype !== "simple_resistor") {
-    additionalPinLabels.push("-")
+    addUniqueLabel(additionalPinLabels, "-")
   }
 
   for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
+    const normalizedHint = normalizeLabel(port_hint)
+    if (!normalizedHint) continue
+    if (normalizedHint === String(port.pin_number)) continue
+    if (normalizedHint.toLowerCase() === mainPinName.toLowerCase()) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
-      additionalPinLabels.push(port_hint)
+    if (
+      (component.ftype === "simple_chip" && isDescriptivePinHint(port_hint)) ||
+      score > 1
+    ) {
+      addUniqueLabel(additionalPinLabels, normalizedHint)
     }
   }
 

--- a/tests/test4-pin-labels-and-missing-footprint.test.ts
+++ b/tests/test4-pin-labels-and-missing-footprint.test.ts
@@ -1,0 +1,49 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("includes descriptive chip pin labels and omits missing footprints", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "PICO-W",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_2",
+      name: "R1",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GP10", "GPIO10", "SPI1_SCK"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["left", "anode", "pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson as any)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("U1 GP10 (pin14,GPIO10,SPI1_SCK)")
+  expect(netlist).toContain("R1 (10k)")
+})


### PR DESCRIPTION
Fixes #4
/claim #4

## Summary
- avoid rendering missing footprints as `undefined` in component descriptions and component pin headers
- use descriptive chip pin hints when the source port name is a generic pin name such as `pin14`
- keep the generic pin number and other chip labels as aliases so the readable netlist has both physical and functional context

## Testing
- `npm exec --yes bun test tests/test4-pin-labels-and-missing-footprint.test.ts`
- `npm exec --yes -- biome check lib/getReadableNameForPin.ts lib/convertCircuitJsonToReadableNetlist.ts tests/test4-pin-labels-and-missing-footprint.test.ts`
- `npm exec --yes bun run build`

Note: the existing render-based tests currently fail locally in `@tscircuit/core` before exercising this change with `TypeError: Attempting to define property on object that is not extensible`.