### PR TITLE
Fix voltage rail labels in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -21,6 +21,11 @@ const wordQualityScore = {
   GND: 1.1,
   VDD: 1.1,
   AGND: 1.1,
+  VCC: 1.1,
+  VBAT: 1.1,
+  VBUS: 1.1,
+  "3V3": 1.1,
+  "5V": 1.1,
   V5: 1.1,
   V3: 1.1,
   V1: 1.1,
@@ -36,13 +41,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-voltage-rail-labels.test.tsx
+++ b/tests/test4-voltage-rail-labels.test.tsx
@@ -1,0 +1,25 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("uses common voltage rail labels instead of passive polarity hints", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="TEST_CHIP"
+        pinLabels={{
+          pin1: ["3V3"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <trace from=".U1 .3V3" to=".R1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_3V3")
+  expect(netlist).not.toContain("NET: R1_pos")
+})


### PR DESCRIPTION
## Summary
- recognize common voltage rail labels such as `3V3`, `5V`, `VCC`, `VBAT`, and `VBUS` as useful net-name hints
- check known technical labels before applying the generic digit fallback
- add a regression test showing `U1_3V3` wins over a low-information passive `pos` hint

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `bun test`
- `bun run build`
- `bunx tsc --noEmit`
- `bunx biome check lib/scorePhrase.ts tests/test4-voltage-rail-labels.test.tsx`

Note: initial `bun install --frozen-lockfile` failed because sharp timed out downloading libvips from GitHub; the test/build/typecheck path passed after installing with scripts ignored.

/claim #4