### PR TITLE
Fix component pin labels in readable netlistFix component pin labels in readable netlist

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -157,7 +157,8 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.name ||
+          (port.pin_number !== undefined ? `pin${port.pin_number}` : "")
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(SCL, pin3): NETS(GND)
+    - GPIO2(SDA, pin4): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(UART_TX, pin6): NOT_CONNECTED
+    - GPIO5(UART_RX, pin7): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)

--- a/tests/test4-component-pin-labels.test.ts
+++ b/tests/test4-component-pin-labels.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses source port names instead of generic pin numbers in component pins", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "GPIO14",
+      pin_number: 14,
+      port_hints: ["pin14", "14", "GPIO14", "SCL"],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("- GPIO14(pin14, SCL): NOT_CONNECTED")
+  expect(netlist).not.toContain("- pin14")
+})


### PR DESCRIPTION
/claim #4

## Summary
- Prefer source port names over generic `pinN` labels in the `COMPONENT_PINS` section.
- Keep `pinN` as an alias when present in `port_hints`.
- Add a focused regression test for descriptive chip pin labels.

## Tests
- `npx bun test tests/test4-component-pin-labels.test.ts`
- `npm run build`
- `npx biome check .`

Note: full `npx bun test` currently fails in existing TSX tests due to an unrelated dependency export error: `distanceBetweenCircleAndPolygon` is not exported by `@tscircuit/circuit-json-util`.
