### PR TITLE
Fix fallback component descriptions in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -49,9 +49,7 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter(Boolean)
         .join(", ")
     } else {
-      componentDescription = [component.name, component.type]
-        .filter(Boolean)
-        .join(", ")
+      componentDescription = getReadableComponentType(component.ftype)
     }
 
     netlist.push(` - ${component.name}: ${componentDescription}`)
@@ -178,4 +176,9 @@ export const convertCircuitJsonToReadableNetlist = (
   }
 
   return netlist.join("\n")
+}
+
+const getReadableComponentType = (ftype?: string): string => {
+  if (!ftype) return "component"
+  return ftype.replace(/^simple_/, "").replaceAll("_", " ")
 }

--- a/tests/test4-custom-component-description.test.ts
+++ b/tests/test4-custom-component-description.test.ts
@@ -1,0 +1,42 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("non-chip component descriptions do not repeat the component name", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_power_source",
+      source_component_id: "source_component_1",
+      name: "PWR1",
+      voltage: 5,
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "VCC",
+      pin_number: 1,
+      port_hints: ["VCC"],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - PWR1: power source
+
+
+    COMPONENT_PINS:
+    PWR1
+    - pin1(VCC): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- Fix fallback component descriptions for non-chip/non-passive source components so they no longer repeat the component name or expose the internal `source_component` type.
- Add a raw Circuit JSON regression test for a `simple_power_source` component.

/claim #4

## Verification
- `npx biome format lib/convertCircuitJsonToReadableNetlist.ts tests/test4-custom-component-description.test.ts --write`
- `npx bun test tests/test4-custom-component-description.test.ts` passes
- `npx tsc --noEmit` passes
- `npm run build` passes

## Note
- `npx bun test` still has the existing JSX-renderer failures in test1-test3 in this local environment: `TypeError: Attempting to define property on object that is not extensible` from `@tscircuit/core` render. The new raw Circuit JSON regression test passes and does not rely on that renderer path.