### PR TITLE
Fix scoring for digit-bearing and custom pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -8,6 +8,7 @@ import type {
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { getUsefulSchematicLabelsForPort } from "./getUsefulSchematicLabelsForPort"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -164,6 +165,7 @@ export const convertCircuitJsonToReadableNetlist = (
           if (hint === String(port.pin_number)) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)
         }
+        aliases.push(...getUsefulSchematicLabelsForPort({ circuitJson, port }))
         const aliasPart =
           aliases.length > 0
             ? `(${Array.from(new Set(aliases)).join(", ")})`

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -1,6 +1,7 @@
 import { su } from "@tscircuit/circuit-json-util"
 import type { AnyCircuitElement, AnySourceComponent } from "circuit-json"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { getUsefulSchematicLabelsForPort } from "./getUsefulSchematicLabelsForPort"
 import { scorePhrase } from "./scorePhrase"
 
 // Order components by how much better they are as a reference (chips are
@@ -57,7 +58,11 @@ export const generateNetName = ({
   const possibleNames = ports
     .flatMap((p) =>
       Array.from(
-        new Set([...(p.name ? [p.name] : []), ...(p.port_hints ?? [])]),
+        new Set([
+          ...(p.name ? [p.name] : []),
+          ...(p.port_hints ?? []),
+          ...getUsefulSchematicLabelsForPort({ circuitJson, port: p }),
+        ]),
       ),
     )
     .concat(nets.map((n) => n.name))
@@ -71,7 +76,12 @@ export const generateNetName = ({
 
   // Find the component that has the best port name
   const bestPort = ports.find(
-    (p) => p.name === bestPortName || p.port_hints?.includes(bestPortName),
+    (p) =>
+      p.name === bestPortName ||
+      p.port_hints?.includes(bestPortName) ||
+      getUsefulSchematicLabelsForPort({ circuitJson, port: p }).includes(
+        bestPortName,
+      ),
   )
 
   const componentWithBestPort = all_source_components.find(

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -5,6 +5,7 @@ import type {
   SourceNet,
   SourcePort,
 } from "circuit-json"
+import { getUsefulSchematicLabelsForPort } from "./getUsefulSchematicLabelsForPort"
 import { scorePhrase } from "./scorePhrase"
 
 export const getReadableNameForPin = ({
@@ -51,9 +52,13 @@ export const getReadableNameForPin = ({
       additionalPinLabels.push(port_hint)
     }
   }
+  additionalPinLabels.push(
+    ...getUsefulSchematicLabelsForPort({ circuitJson, port }),
+  )
 
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  const dedupedAdditionalPinLabels = Array.from(new Set(additionalPinLabels))
+  return `${component.name} ${mainPinName}${dedupedAdditionalPinLabels.length > 0 ? ` (${dedupedAdditionalPinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -47,7 +47,7 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score >= 1) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/lib/getUsefulSchematicLabelsForPort.ts
+++ b/lib/getUsefulSchematicLabelsForPort.ts
@@ -1,0 +1,27 @@
+import type { AnyCircuitElement, SourcePort } from "circuit-json"
+import { scorePhrase } from "./scorePhrase"
+
+export const getUsefulSchematicLabelsForPort = ({
+  circuitJson,
+  port,
+}: {
+  circuitJson: AnyCircuitElement[]
+  port: SourcePort
+}): string[] => {
+  return circuitJson
+    .filter(
+      (element) =>
+        element.type === "schematic_port" &&
+        "source_port_id" in element &&
+        element.source_port_id === port.source_port_id &&
+        "display_pin_label" in element &&
+        typeof element.display_pin_label === "string",
+    )
+    .map((element) => element.display_pin_label)
+    .filter((label) => {
+      if (!label) return false
+      if (label === port.name) return false
+      if (label === String(port.pin_number)) return false
+      return scorePhrase(label) >= 1
+    })
+}

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-pin-labels-with-digits.test.ts
+++ b/tests/test4-pin-labels-with-digits.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("keeps meaningful pin labels that contain digits", () => {
+  const readablePinName = getReadableNameForPin({
+    source_port_id: "source_port_1",
+    circuitJson: [
+      {
+        type: "source_component",
+        source_component_id: "source_component_1",
+        name: "U1",
+        ftype: "simple_chip",
+      },
+      {
+        type: "source_port",
+        source_port_id: "source_port_1",
+        source_component_id: "source_component_1",
+        name: "pin14",
+        pin_number: 14,
+        port_hints: ["pin14", "GPIO2", "SDA"],
+      },
+    ],
+  })
+
+  expect(readablePinName).toBe("U1 pin14 (GPIO2,SDA)")
+})

--- a/tests/test4-pin-labels-with-digits.test.ts
+++ b/tests/test4-pin-labels-with-digits.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
 import { getReadableNameForPin } from "lib/getReadableNameForPin"
 
 declare module "bun:test" {
@@ -93,4 +94,62 @@ it("keeps USB differential pin hints on generic physical pins", () => {
       source_port_id: "source_port_2",
     }),
   ).toBe("U1 pin15 (D-)")
+})
+
+it("uses useful schematic display labels for generic physical pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "J1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14"],
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "schematic_port_1",
+      source_port_id: "source_port_1",
+      center: { x: 0, y: 0 },
+      display_pin_label: "USB_DP",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+    },
+  ]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 pin14 (USB_DP)")
+  expect(convertCircuitJsonToReadableNetlist(circuitJson)).toContain(
+    "NET: U1_USB_DP",
+  )
+  expect(convertCircuitJsonToReadableNetlist(circuitJson)).toContain(
+    "- pin14(USB_DP): NETS(U1_USB_DP)",
+  )
 })

--- a/tests/test4-pin-labels-with-digits.test.ts
+++ b/tests/test4-pin-labels-with-digits.test.ts
@@ -30,3 +30,27 @@ it("keeps meaningful pin labels that contain digits", () => {
 
   expect(readablePinName).toBe("U1 pin14 (GPIO2,SDA)")
 })
+
+it("keeps custom descriptive pin hints while filtering low quality labels", () => {
+  const readablePinName = getReadableNameForPin({
+    source_port_id: "source_port_1",
+    circuitJson: [
+      {
+        type: "source_component",
+        source_component_id: "source_component_1",
+        name: "U1",
+        ftype: "simple_chip",
+      },
+      {
+        type: "source_port",
+        source_port_id: "source_port_1",
+        source_component_id: "source_component_1",
+        name: "pin14",
+        pin_number: 14,
+        port_hints: ["pin14", "RESET", "BOOT", "left"],
+      },
+    ],
+  })
+
+  expect(readablePinName).toBe("U1 pin14 (RESET,BOOT)")
+})

--- a/tests/test4-pin-labels-with-digits.test.ts
+++ b/tests/test4-pin-labels-with-digits.test.ts
@@ -54,3 +54,43 @@ it("keeps custom descriptive pin hints while filtering low quality labels", () =
 
   expect(readablePinName).toBe("U1 pin14 (RESET,BOOT)")
 })
+
+it("keeps USB differential pin hints on generic physical pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "D+"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["pin15", "D-"],
+    },
+  ]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 pin14 (D+)")
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_2",
+    }),
+  ).toBe("U1 pin15 (D-)")
+})


### PR DESCRIPTION
## Summary

- Keep meaningful pin labels like `GPIO2` and `SDA` when a pin name also contains digits, e.g. `pin14`.
- Keep custom descriptive pin hints like `RESET`, `BOOT`, `D+`, and `D-` while still filtering low-information hints such as bare pin numbers and placement hints.
- Use useful `schematic_port.display_pin_label` values in generated net names, readable NET entries, and COMPONENT_PINS aliases.
- Add regression tests covering readable pin output for digit-bearing, custom descriptive, USB differential, and schematic display labels.

## Testing

- `npx bun test`
- `npx bun run build`
- `npx @biomejs/biome check lib/scorePhrase.ts lib/getUsefulSchematicLabelsForPort.ts lib/getReadableNameForPin.ts lib/generateNetName.ts lib/convertCircuitJsonToReadableNetlist.ts tests/test4-pin-labels-with-digits.test.ts`

/claim #4
Fixes #4