### PR TITLE
Fix custom pin hints in readable labels

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -45,10 +45,11 @@ export const getReadableNameForPin = ({
   }
 
   for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
-      additionalPinLabels.push(port_hint)
+    const readableHint = port_hint.trim()
+    if (!readableHint || readableHint === mainPinName) continue
+    const score = scorePhrase(readableHint)
+    if (score >= 1 && !additionalPinLabels.includes(readableHint)) {
+      additionalPinLabels.push(readableHint)
     }
   }
 

--- a/tests/test4-custom-pin-hints.test.ts
+++ b/tests/test4-custom-pin-hints.test.ts
@@ -1,0 +1,61 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("includes custom descriptive hints for generic source port names", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["RESET", "pos", "left", "pin14", "14"],
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 10000,
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      source_component_id: "source_component_1",
+      footprinter_string: "0402",
+      pcb_component_id: "pcb_component_0",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "pin1", "1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_RESET")
+  expect(netlist).toContain("  - U1 pin14 (+,RESET)")
+  expect(netlist).not.toContain("U1 pin14 (pos")
+  expect(netlist).not.toContain("U1 pin14 (left")
+})


### PR DESCRIPTION
/claim #4

## Summary
- include default-quality custom pin hints such as RESET in readable net pin labels when the source port name is only a generic physical label like pin14
- trim hints before scoring so blank hints are still ignored
- keep low-information hints such as pos, left, and bare pin numbers out of the readable label text
- add a raw Circuit JSON regression test for the generic-pin/custom-hint case

## Verification
- `bun test tests/test4-custom-pin-hints.test.ts`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/getReadableNameForPin.ts tests/test4-custom-pin-hints.test.ts`
- `bun run build`
- `git diff --check`

Transparency note: this patch was prepared with AI-assisted coding and verified locally before submission.