### PR TITLE
Fix generic chip pin hints in readable netlists

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,22 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const lowInformationPinHints = new Set([
+  "anode",
+  "cathode",
+  "neg",
+  "negative",
+  "pos",
+  "positive",
+  "left",
+  "right",
+])
+
+const isGenericPinLabel = (label: string) =>
+  /^pin\d+$/i.test(label) || /^\d+$/.test(label)
+
+const hasTechnicalPinName = (label: string) => /[A-Z]/.test(label)
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -35,6 +51,7 @@ export const getReadableNameForPin = ({
 
   // Format pin description
   const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinIsGeneric = isGenericPinLabel(mainPinName)
 
   const additionalPinLabels: string[] = []
 
@@ -45,10 +62,15 @@ export const getReadableNameForPin = ({
   }
 
   for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
-      additionalPinLabels.push(port_hint)
+    const pinLabel = port_hint.trim()
+    if (!pinLabel) continue
+    if (pinLabel === mainPinName) continue
+    if (isGenericPinLabel(pinLabel)) continue
+    if (lowInformationPinHints.has(pinLabel.toLowerCase())) continue
+
+    const score = scorePhrase(pinLabel)
+    if (score > 1 || (mainPinIsGeneric && hasTechnicalPinName(pinLabel))) {
+      additionalPinLabels.push(pinLabel)
     }
   }
 

--- a/tests/test4-generic-chip-pin-hints.test.ts
+++ b/tests/test4-generic-chip-pin-hints.test.ts
@@ -1,0 +1,71 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("includes descriptive technical hints for generic chip pin labels", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "PICO_W",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GP10_SPI1SCK_I2C1SDA", "pin14", "14"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_chip",
+      name: "LED1",
+      manufacturer_part_number: "WS2812B_2020",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["DI", "pin3", "3"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: PICO_W
+     - LED1: WS2812B_2020
+
+    NET: LED1_DI
+      - U1 pin14 (GP10_SPI1SCK_I2C1SDA)
+      - LED1 pin3 (DI)
+
+
+    COMPONENT_PINS:
+    U1 (PICO_W)
+    - pin14(GP10_SPI1SCK_I2C1SDA): NETS(LED1_DI)
+
+    LED1 (WS2812B_2020)
+    - pin3(DI): NETS(LED1_DI)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- include meaningful technical source-port hints when a generic chip pin label like `pin14` is rendered in NET entries
- filter low-information aliases such as numeric hints, `pinN`, `pos`, `neg`, `left`, and `right`
- add a raw Circuit JSON regression test for the Pico W-style `GP10_SPI1SCK_I2C1SDA` case

## Validation
- `bun test`
- `bun run build`
- `bun run format:check`
- verified the original Pico W Circuit JSON now renders `U1 pin14 (GP10_SPI1SCK_I2C1SDA)`

/claim #4