### PR TITLE
Fix unnamed port labels in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -157,7 +157,9 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.pin_number !== undefined
+            ? `pin${port.pin_number}`
+            : (port.name ?? port.source_port_id)
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -34,7 +34,11 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName =
+    port.name ??
+    (port.pin_number !== undefined
+      ? `Pin${port.pin_number}`
+      : port.source_port_id)
 
   const additionalPinLabels: string[] = []
 

--- a/tests/test4-unnamed-port.test.ts
+++ b/tests/test4-unnamed-port.test.ts
@@ -1,0 +1,39 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("does not render undefined for unnamed disconnected ports", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: 
+
+
+    COMPONENT_PINS:
+    U1
+    - source_port_1: NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- add a source_port_id fallback when a source port has neither name nor pin_number
- use the same fallback in COMPONENT_PINS so disconnected unnamed ports do not render `undefined`
- add a raw Circuit JSON regression test for the disconnected unnamed-port case

/claim #4

## Validation
- `bun test`
- `bun run build`
- `git diff --check`