### PR TITLE
Fix readable nets for internally connected pins

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -12,12 +12,19 @@ import { getReadableNameForPin } from "./getReadableNameForPin"
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
+  const source_components = su(circuitJson).source_component.list()
   const connectivityMap = getFullConnectivityMapFromCircuitJson(
     circuitJson.filter((e) => e.type.startsWith("source_")),
   )
+  for (const component of source_components) {
+    if ("internally_connected_source_port_ids" in component) {
+      connectivityMap.addConnections(
+        component.internally_connected_source_port_ids ?? [],
+      )
+    }
+  }
   const netMap = connectivityMap.netMap
   const source_ports = su(circuitJson).source_port.list()
-  const source_components = su(circuitJson).source_component.list()
   const source_nets = su(circuitJson).source_net.list()
   const source_traces = su(circuitJson).source_trace.list()
   // Build readable netlist

--- a/tests/test4-internal-connections.test.ts
+++ b/tests/test4-internal-connections.test.ts
@@ -1,0 +1,44 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("includes internally connected source component pins in readable nets", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "POWER_TIE",
+      internally_connected_source_port_ids: [
+        ["source_port_1", "source_port_2"],
+      ],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["VDD"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["VDD"],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_VDD")
+  expect(netlist).toContain("  - U1 pin1 (VDD)")
+  expect(netlist).toContain("  - U1 pin2 (VDD)")
+  expect(netlist).toContain("- pin1(VDD): NETS(U1_VDD)")
+  expect(netlist).toContain("- pin2(VDD): NETS(U1_VDD)")
+  expect(netlist).not.toContain("- pin1(VDD): NOT_CONNECTED")
+  expect(netlist).not.toContain("- pin2(VDD): NOT_CONNECTED")
+})


### PR DESCRIPTION
/claim #4

## Summary
- include `source_component.internally_connected_source_port_ids` in the readable-netlist connectivity map
- add a raw Circuit JSON regression test showing internally tied pins render under a generated `NET:` and no longer appear as `NOT_CONNECTED`

## Verification
- `npx bun test`
- `npx tsc --noEmit`
- `npx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-internal-connections.test.ts`
