### PR TITLE
Fix unnamed source net fallback

### DIFF
--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -61,11 +61,14 @@ export const generateNetName = ({
       ),
     )
     .concat(nets.map((n) => n.name))
+    .filter((name): name is string => Boolean(name))
 
   const phrases = possibleNames.map((name) => ({
     name,
     score: scorePhrase(name),
   }))
+
+  if (phrases.length === 0) return "unnamed_net"
 
   const bestPortName = phrases.sort((a, b) => b.score - a.score)[0].name
 

--- a/tests/test4-unnamed-source-net.test.tsx
+++ b/tests/test4-unnamed-source-net.test.tsx
@@ -1,0 +1,60 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses connected pin labels when a source net has no name", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="ATMEGA328P"
+        pinLabels={{
+          pin1: ["GND"],
+          pin2: ["AGND"],
+          pin3: ["GPIO1", "SCL"],
+        }}
+      />
+      <trace from=".U1 .GND" to="net.GND" />
+      <trace from=".U1 .AGND" to="net.GND" />
+      <trace from=".U1 .GPIO1" to="net.GND" />
+    </board>,
+  )
+
+  for (const element of circuitJson) {
+    if (element.type === "source_net" && element.name === "GND") {
+      element.name = undefined
+    }
+  }
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: ATMEGA328P, soic8
+
+    NET: U1_SCL
+      - U1 GPIO1 (SCL)
+      - U1 AGND
+      - U1 GND
+
+
+    COMPONENT_PINS:
+    U1 (ATMEGA328P)
+    - pin1(GND): NETS(U1_SCL)
+    - pin2(AGND): NETS(U1_SCL)
+    - pin3(GPIO1, SCL): NETS(U1_SCL)
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+    "
+  `)
+})

--- a/tests/test4-unnamed-source-net.test.tsx
+++ b/tests/test4-unnamed-source-net.test.tsx
@@ -27,14 +27,18 @@ it("uses connected pin labels when a source net has no name", () => {
     </board>,
   )
 
-  for (const element of circuitJson) {
+  const circuitJsonWithUnnamedSourceNet = circuitJson.map((element) => ({
+    ...element,
+  }))
+  for (const element of circuitJsonWithUnnamedSourceNet) {
     if (element.type === "source_net" && element.name === "GND") {
-      element.name = undefined
+      const unnamedSourceNet = element as Partial<typeof element>
+      unnamedSourceNet.name = undefined
     }
   }
 
   expect(
-    convertCircuitJsonToReadableNetlist(circuitJson),
+    convertCircuitJsonToReadableNetlist(circuitJsonWithUnnamedSourceNet),
   ).toMatchInlineSnapshot(`
     "COMPONENTS:
      - U1: ATMEGA328P, soic8


### PR DESCRIPTION
## Summary
- filter empty source-net names before scoring generated net-name candidates
- fall back to `unnamed_net` if a net has no usable names at all
- add a regression test for an unnamed `source_net` that should use connected pin labels instead of throwing

/claim #4

## Testing
- `bun test`
- `bun run build`
- `bun run format:check`
- `git diff --check`

Transparency: implementation was AI-assisted and locally verified.