### PR TITLE
Fix USB differential pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -8,6 +8,8 @@
  * These unique port names are usually the best indicator of what the net is for
  */
 const wordQualityScore = {
+  "D+": 1.2,
+  "D-": 1.2,
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,

--- a/tests/test4-usb-differential-labels.test.ts
+++ b/tests/test4-usb-differential-labels.test.ts
@@ -1,0 +1,73 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("includes USB differential labels on generic pin net entries", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_j1",
+      name: "J1",
+      manufacturer_part_number: "USB-C",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_dp",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["D+"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_dp",
+      source_component_id: "source_component_j1",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["D+"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_dm",
+      source_component_id: "source_component_u1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["D-"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_dm",
+      source_component_id: "source_component_j1",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["D-"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_dp",
+      connected_source_port_ids: ["source_port_u1_dp", "source_port_j1_dp"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_dm",
+      connected_source_port_ids: ["source_port_u1_dm", "source_port_j1_dm"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("  - U1 pin14 (D+)")
+  expect(netlist).toContain("  - J1 pin2 (D+)")
+  expect(netlist).toContain("  - U1 pin15 (D-)")
+  expect(netlist).toContain("  - J1 pin3 (D-)")
+})


### PR DESCRIPTION
## Summary
- recognize USB differential `D+` and `D-` labels as high-quality readable pin hints
- keep generic physical pin names like `pin14` while including the full USB label in NET entries
- add a raw Circuit JSON regression test covering both USB data lines

/claim #4

## Verification
- `bun test tests/test4-usb-differential-labels.test.ts`
- `bun test`
- `bun run build`
- `bun x tsc --noEmit`
- `bun x biome check lib\scorePhrase.ts tests\test4-usb-differential-labels.test.ts`
- `git diff --check`

Transparency note: this patch was prepared with AI assistance and verified locally.