### PR TITLE
Fix schematic display pin labels in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -8,6 +8,7 @@ import type {
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { getSchematicDisplayPinLabel } from "./getSourcePortLabelCandidates"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -160,6 +161,17 @@ export const convertCircuitJsonToReadableNetlist = (
           port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
+        const schematicDisplayPinLabel = getSchematicDisplayPinLabel({
+          circuitJson,
+          source_port_id: port.source_port_id,
+        })
+        if (
+          schematicDisplayPinLabel &&
+          schematicDisplayPinLabel !== mainPin &&
+          schematicDisplayPinLabel !== port.name
+        ) {
+          aliases.push(schematicDisplayPinLabel)
+        }
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -1,6 +1,6 @@
 import { su } from "@tscircuit/circuit-json-util"
 import type { AnyCircuitElement, AnySourceComponent } from "circuit-json"
-import { getReadableNameForPin } from "./getReadableNameForPin"
+import { getSourcePortLabelCandidates } from "./getSourcePortLabelCandidates"
 import { scorePhrase } from "./scorePhrase"
 
 // Order components by how much better they are as a reference (chips are
@@ -55,11 +55,7 @@ export const generateNetName = ({
   )
 
   const possibleNames = ports
-    .flatMap((p) =>
-      Array.from(
-        new Set([...(p.name ? [p.name] : []), ...(p.port_hints ?? [])]),
-      ),
-    )
+    .flatMap((p) => getSourcePortLabelCandidates({ circuitJson, port: p }))
     .concat(nets.map((n) => n.name))
 
   const phrases = possibleNames.map((name) => ({
@@ -70,8 +66,10 @@ export const generateNetName = ({
   const bestPortName = phrases.sort((a, b) => b.score - a.score)[0].name
 
   // Find the component that has the best port name
-  const bestPort = ports.find(
-    (p) => p.name === bestPortName || p.port_hints?.includes(bestPortName),
+  const bestPort = ports.find((p) =>
+    getSourcePortLabelCandidates({ circuitJson, port: p }).includes(
+      bestPortName,
+    ),
   )
 
   const componentWithBestPort = all_source_components.find(

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -1,10 +1,6 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
+import { getSchematicDisplayPinLabel } from "./getSourcePortLabelCandidates"
 import { scorePhrase } from "./scorePhrase"
 
 export const getReadableNameForPin = ({
@@ -37,18 +33,31 @@ export const getReadableNameForPin = ({
   const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
 
   const additionalPinLabels: string[] = []
+  const addAdditionalPinLabel = (label: string) => {
+    if (label !== mainPinName && !additionalPinLabels.includes(label)) {
+      additionalPinLabels.push(label)
+    }
+  }
 
   if (isPositive && component.ftype !== "simple_resistor") {
-    additionalPinLabels.push("+")
+    addAdditionalPinLabel("+")
   } else if (isNegative && component.ftype !== "simple_resistor") {
-    additionalPinLabels.push("-")
+    addAdditionalPinLabel("-")
+  }
+
+  const schematicDisplayPinLabel = getSchematicDisplayPinLabel({
+    circuitJson,
+    source_port_id,
+  })
+  if (schematicDisplayPinLabel) {
+    addAdditionalPinLabel(schematicDisplayPinLabel)
   }
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
     if (score > 1) {
-      additionalPinLabels.push(port_hint)
+      addAdditionalPinLabel(port_hint)
     }
   }
 

--- a/lib/getSourcePortLabelCandidates.ts
+++ b/lib/getSourcePortLabelCandidates.ts
@@ -1,0 +1,59 @@
+import type { AnyCircuitElement, SourcePort } from "circuit-json"
+import { scorePhrase } from "./scorePhrase"
+
+export const getSchematicDisplayPinLabel = ({
+  circuitJson,
+  source_port_id,
+}: {
+  circuitJson: AnyCircuitElement[]
+  source_port_id: string
+}): string | undefined => {
+  const schematicPort = circuitJson.find(
+    (element) =>
+      element.type === "schematic_port" &&
+      "source_port_id" in element &&
+      element.source_port_id === source_port_id,
+  )
+
+  if (
+    schematicPort &&
+    "display_pin_label" in schematicPort &&
+    typeof schematicPort.display_pin_label === "string"
+  ) {
+    const label = schematicPort.display_pin_label.trim()
+    if (label && scorePhrase(label) >= 1) {
+      return label
+    }
+  }
+}
+
+export const getSourcePortLabelCandidates = ({
+  circuitJson,
+  port,
+}: {
+  circuitJson: AnyCircuitElement[]
+  port: SourcePort
+}): string[] => {
+  const labels: string[] = []
+
+  const addLabel = (label: unknown) => {
+    if (typeof label !== "string") return
+    const trimmedLabel = label.trim()
+    if (trimmedLabel && !labels.includes(trimmedLabel)) {
+      labels.push(trimmedLabel)
+    }
+  }
+
+  addLabel(port.name)
+  addLabel(
+    getSchematicDisplayPinLabel({
+      circuitJson,
+      source_port_id: port.source_port_id,
+    }),
+  )
+  for (const hint of port.port_hints ?? []) {
+    addLabel(hint)
+  }
+
+  return labels
+}

--- a/tests/test4-schematic-display-pin-labels.test.ts
+++ b/tests/test4-schematic-display-pin-labels.test.ts
@@ -1,0 +1,57 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses schematic display pin labels when source port names are generic", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "sc_u1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "sc_r1",
+      name: "R1",
+      ftype: "simple_resistor",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_14",
+      source_component_id: "sc_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: [],
+    },
+    {
+      type: "schematic_port",
+      schematic_port_id: "schematic_port_u1_14",
+      source_port_id: "source_port_u1_14",
+      display_pin_label: "RESET",
+      center: { x: 0, y: 0 },
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "sc_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_u1_14", "source_port_r1_1"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_RESET")
+  expect(netlist).toContain("  - U1 pin14 (RESET)")
+  expect(netlist).toContain("- pin14(RESET): NETS(U1_RESET)")
+  expect(netlist).not.toContain("NET: R1_pos")
+})


### PR DESCRIPTION
## Summary
- use `schematic_port.display_pin_label` as an additional readable label source for source ports with generic names like `pin14`
- include useful schematic display labels when generating net names and COMPONENT_PINS aliases
- avoid low-information schematic labels such as `pos`/`anode` so existing passive output stays unchanged
- add a raw Circuit JSON regression test for a `RESET` schematic pin label

/claim #4

## Verification
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `bun x biome check lib/getSourcePortLabelCandidates.ts lib/generateNetName.ts lib/getReadableNameForPin.ts lib/convertCircuitJsonToReadableNetlist.ts tests/test4-schematic-display-pin-labels.test.ts`
- `git diff --check HEAD~1..HEAD`

Transparency note: this patch was prepared with AI-assisted coding and locally verified.
