### PR TITLE
Use trace display names for generated net names

### DIFF
--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -54,13 +54,19 @@ export const generateNetName = ({
     connectedIds.includes(t.source_trace_id),
   )
 
-  const possibleNames = ports
-    .flatMap((p) =>
-      Array.from(
-        new Set([...(p.name ? [p.name] : []), ...(p.port_hints ?? [])]),
+  const traceDisplayNames = traces
+    .map((t) => t.display_name)
+    .filter((name): name is string => Boolean(name))
+
+  const possibleNames = traceDisplayNames
+    .concat(nets.map((n) => n.name))
+    .concat(
+      ports.flatMap((p) =>
+        Array.from(
+          new Set([...(p.name ? [p.name] : []), ...(p.port_hints ?? [])]),
+        ),
       ),
     )
-    .concat(nets.map((n) => n.name))
 
   const phrases = possibleNames.map((name) => ({
     name,
@@ -77,5 +83,7 @@ export const generateNetName = ({
   const componentWithBestPort = all_source_components.find(
     (c) => c.source_component_id === bestPort?.source_component_id,
   )
+  if (!componentWithBestPort) return bestPortName
+
   return [componentWithBestPort?.name, bestPortName].filter(Boolean).join("_")
 }

--- a/tests/test4-trace-display-net-names.test.ts
+++ b/tests/test4-trace-display-net-names.test.ts
@@ -1,0 +1,72 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses source trace display names when generating readable net names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1kΩ",
+      are_pins_interchangeable: true,
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["cathode", "neg", "right", "pin2", "2"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_capacitor",
+      name: "C1",
+      capacitance: 1e-9,
+      display_capacitance: "1nF",
+      are_pins_interchangeable: true,
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode", "left", "pin1", "1"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["neg", "cathode", "right", "pin2", "2"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+      display_name: "VBUS",
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: VBUS")
+  expect(netlist).toContain("- pin1(anode, pos, left): NETS(VBUS)")
+  expect(netlist).toContain("- pin1(pos, anode, left): NETS(VBUS)")
+  expect(netlist).not.toContain("NET: C1_pos")
+})


### PR DESCRIPTION
## Summary
- use connected `source_trace.display_name` values as candidates when generating readable net names
- prefer explicit trace labels like `VBUS` over lower-information generated names such as `C1_pos`
- add raw Circuit JSON regression coverage for trace display-name based net naming

## Root cause
`generateNetName` already collected connected `source_trace` elements, but never used them when building `possibleNames`. As a result, explicit trace labels were ignored during generated net-name selection.

## Validation
- `npx --yes bun test tests/test4-trace-display-net-names.test.ts`
- `npx --yes bun test`
- `npx --yes bun run build`
- `npx --yes biome check .`
- `npx --yes tsc --noEmit`
- `git diff --check`

/claim #4