### PR TITLE
Use source group names when naming unnamed nets

### DIFF
--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -43,6 +43,10 @@ export const generateNetName = ({
 
   const all_source_nets = su(circuitJson).source_net.list()
   const all_source_traces = su(circuitJson).source_trace.list()
+  const all_source_groups = su(circuitJson).source_group.list()
+  const sourceGroupNameById = new Map(
+    all_source_groups.map((group) => [group.source_group_id, group.name]),
+  )
 
   const ports = all_source_ports.filter((p) =>
     connectedIds.includes(p.source_port_id),
@@ -53,6 +57,14 @@ export const generateNetName = ({
   const traces = all_source_traces.filter((t) =>
     connectedIds.includes(t.source_trace_id),
   )
+  const netNameCandidates = nets.flatMap((n): string[] =>
+    [
+      n.name,
+      ...(n.member_source_group_ids ?? []).map((sourceGroupId) =>
+        sourceGroupNameById.get(sourceGroupId),
+      ),
+    ].filter((name): name is string => Boolean(name?.trim())),
+  )
 
   const possibleNames = ports
     .flatMap((p) =>
@@ -60,7 +72,11 @@ export const generateNetName = ({
         new Set([...(p.name ? [p.name] : []), ...(p.port_hints ?? [])]),
       ),
     )
-    .concat(nets.map((n) => n.name))
+    .concat(netNameCandidates)
+    .filter((name): name is string => Boolean(name?.trim()))
+    .map((name) => name.trim())
+
+  if (possibleNames.length === 0) return ""
 
   const phrases = possibleNames.map((name) => ({
     name,

--- a/tests/test4-source-group-net-name.test.ts
+++ b/tests/test4-source-group-net-name.test.ts
@@ -1,0 +1,74 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses named source groups for unnamed source net fallback names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "J1",
+      manufacturer_part_number: "CONN",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1"],
+    },
+    {
+      type: "source_group",
+      source_group_id: "source_group_usb",
+      name: "USB",
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_1",
+      name: "",
+      member_source_group_ids: ["source_group_usb"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: ["source_net_1"],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toBe(`COMPONENTS:
+ - U1: MCU
+ - J1: CONN
+
+NET: USB
+  - U1 pin14
+  - J1 pin1
+
+
+COMPONENT_PINS:
+U1 (MCU)
+- pin14: NETS(USB)
+
+J1 (CONN)
+- pin1: NETS(USB)
+`)
+})


### PR DESCRIPTION
## Summary
- Include `source_group.name` values from `source_net.member_source_group_ids` as net-name candidates.
- Ignore blank name candidates so named groups can win over generic pin labels.
- Add a raw Circuit JSON regression test for an unnamed source net in a named `USB` source group.

/claim #4

## Testing
- `bun run format:check`
- `bunx tsc --noEmit`
- `bun test tests/test4-source-group-net-name.test.ts`
- `bun run build`