### PR TITLE
Handle internally connected source ports

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,13 +9,60 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const getAugmentedNetMap = ({
+  netMap,
+  circuitJson,
+}: {
+  netMap: Record<string, string[]>
+  circuitJson: AnyCircuitElement[]
+}): Record<string, string[]> => {
+  const sourcePorts = su(circuitJson).source_port.list()
+  const sourcePortIds = new Set(sourcePorts.map((p) => p.source_port_id))
+  const netSets = Object.values(netMap).map((ids) => new Set(ids))
+  let internalNetIndex = 0
+
+  for (const component of su(circuitJson).source_component.list()) {
+    for (const internalGroup of component.internally_connected_source_port_ids ??
+      []) {
+      const internalPortIds = internalGroup.filter((id) =>
+        sourcePortIds.has(id),
+      )
+      if (internalPortIds.length <= 1) continue
+
+      const overlappingSets = netSets.filter((set) =>
+        internalPortIds.some((id) => set.has(id)),
+      )
+
+      if (overlappingSets.length === 0) {
+        netSets.push(new Set(internalPortIds))
+        continue
+      }
+
+      const mergedSet = overlappingSets[0]
+      for (const id of internalPortIds) mergedSet.add(id)
+
+      for (const set of overlappingSets.slice(1)) {
+        for (const id of set) mergedSet.add(id)
+        netSets.splice(netSets.indexOf(set), 1)
+      }
+    }
+  }
+
+  return Object.fromEntries(
+    netSets.map((set) => [`net${internalNetIndex++}`, Array.from(set)]),
+  )
+}
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
   const connectivityMap = getFullConnectivityMapFromCircuitJson(
     circuitJson.filter((e) => e.type.startsWith("source_")),
   )
-  const netMap = connectivityMap.netMap
+  const netMap = getAugmentedNetMap({
+    netMap: connectivityMap.netMap,
+    circuitJson,
+  })
   const source_ports = su(circuitJson).source_port.list()
   const source_components = su(circuitJson).source_component.list()
   const source_nets = su(circuitJson).source_net.list()

--- a/tests/test4-internally-connected-pins.test.ts
+++ b/tests/test4-internally-connected-pins.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("renders internally connected source ports as connected nets", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "TEST_CHIP",
+      internally_connected_source_port_ids: [
+        ["source_port_1", "source_port_2"],
+      ],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "A",
+      pin_number: 1,
+      port_hints: ["A"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "B",
+      pin_number: 2,
+      port_hints: ["B"],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: TEST_CHIP
+
+    NET: U1_A
+      - U1 A
+      - U1 B
+
+
+    COMPONENT_PINS:
+    U1 (TEST_CHIP)
+    - pin1(A): NETS(U1_A)
+    - pin2(B): NETS(U1_A)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- include `internally_connected_source_port_ids` groups when building the readable net map
- merge those internal groups with existing trace/source-net connectivity when they overlap
- add a raw Circuit JSON regression test for internally connected chip pins

## Verification
- `npx bun test`
- `npx tsc --noEmit`
- `npx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-internally-connected-pins.test.ts`

/claim #4