### PR TITLE
Include aliases for generic chip pin labels

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -35,6 +35,11 @@ export const getReadableNameForPin = ({
 
   // Format pin description
   const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const isGenericPinName = /^pin\d+$/i.test(mainPinName)
+  const shouldIncludePinAliases =
+    isGenericPinName &&
+    component.ftype !== "simple_resistor" &&
+    component.ftype !== "simple_capacitor"
 
   const additionalPinLabels: string[] = []
 
@@ -46,8 +51,12 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (port.pin_number !== undefined) {
+      if (port_hint === String(port.pin_number)) continue
+      if (port_hint.toLowerCase() === `pin${port.pin_number}`) continue
+    }
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score > 1 || shouldIncludePinAliases) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/get-readable-name-for-pin.test.ts
+++ b/tests/get-readable-name-for-pin.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("includes chip pin aliases when the primary name is a generic pin number", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GP10", "SPI1_SCK", "pin14", "14"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (GP10,SPI1_SCK)")
+})


### PR DESCRIPTION
Fixes #4.
/claim #4

When a source port's primary name is a generic pin number, such as `pin14`, the readable netlist should still include useful chip aliases from `port_hints` like `GP10` and `SPI1_SCK`. This keeps numeric/pin-number duplicate hints out of the output and leaves passive resistor/capacitor pin output unchanged.

Verified locally:
- bun test
- bun run build
- bunx biome check lib/getReadableNameForPin.ts tests/get-readable-name-for-pin.test.ts