### PR TITLE
Fix spacing for multiple readable pin labels

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -55,5 +55,5 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(", ")})` : ""}${displayValue}`
 }

--- a/tests/test4-multiple-pin-labels.test.tsx
+++ b/tests/test4-multiple-pin-labels.test.tsx
@@ -1,0 +1,55 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("formats multiple readable pin labels with spaces", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="ATMEGA328P"
+        pinLabels={{
+          pin1: ["GPIO1", "SCL", "SDA"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <trace from=".U1 .GPIO1" to=".R1 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: ATMEGA328P, soic8
+     - R1: 1kΩ 0402 resistor
+
+    NET: U1_SCL
+      - U1 GPIO1 (SCL, SDA)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (ATMEGA328P)
+    - pin1(GPIO1, SCL, SDA): NETS(U1_SCL)
+    - pin2: NOT_CONNECTED
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_SCL)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- Format multiple readable pin labels in NET entries with `, ` instead of a bare comma.
- Add a regression test covering a chip pin with multiple useful labels (`SCL`, `SDA`).

/claim #4

## Verification
- `bun test`
- `bun run build`
- `bun run format:check`
- `git diff --check`