### PR TITLE
Fix blank passive footprints in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,11 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const cleanOptionalText = (value?: string) => {
+  const cleaned = value?.trim()
+  return cleaned || undefined
+}
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -33,16 +38,24 @@ export const convertCircuitJsonToReadableNetlist = (
       source_component_id: component.source_component_id,
     })
 
-    const footprint = cadComponent?.footprinter_string
+    const footprint = cleanOptionalText(cadComponent?.footprinter_string)
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
+      componentDescription = [
+        component.display_resistance,
+        footprint,
+        "resistor",
+      ]
+        .filter(Boolean)
+        .join(" ")
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
+      componentDescription = [
+        component.display_capacitance,
+        footprint,
+        "capacitor",
+      ]
+        .filter(Boolean)
+        .join(" ")
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -142,12 +155,18 @@ export const convertCircuitJsonToReadableNetlist = (
       const cadComponent = su(circuitJson).cad_component.getWhere({
         source_component_id: component.source_component_id,
       })
-      const footprint = cadComponent?.footprinter_string
+      const footprint = cleanOptionalText(cadComponent?.footprinter_string)
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-passive-blank-footprint.test.ts
+++ b/tests/test4-passive-blank-footprint.test.ts
@@ -1,0 +1,73 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("omits blank passive footprints from readable labels", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "1k",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "   ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      ftype: "simple_capacitor",
+      name: "C1",
+      display_capacitance: "100nF",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_2",
+      source_component_id: "source_component_2",
+      footprinter_string: "\t",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - R1: 1k resistor
+     - C1: 100nF capacitor
+
+
+    COMPONENT_PINS:
+    R1 (1k)
+    - pin1(pos): NOT_CONNECTED
+
+    C1 (100nF)
+    - pin1(pos): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- trim optional passive footprint text before rendering readable netlist labels
- treat whitespace-only resistor/capacitor footprints as missing instead of emitting blank-looking spacing
- add a raw Circuit JSON regression test covering blank passive footprints for both resistor and capacitor output

## Repro
Current main can render whitespace-only passive footprints as noisy output, for example:

```text
COMPONENTS:
 - R1: 1k     resistor

COMPONENT_PINS:
R1 (1k    )
```

This PR normalizes those labels to:

```text
COMPONENTS:
 - R1: 1k resistor

COMPONENT_PINS:
R1 (1k)
```

## Verification
- `npx bun test tests/test4-passive-blank-footprint.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-passive-blank-footprint.test.ts`
- `npm run build`

Note: full `npx bun test` still fails in the existing JSX-renderer tests (`test1`-`test3`) before assertions with `TypeError: Attempting to define property on object that is not extensible` from `@tscircuit/core`; the new raw Circuit JSON regression test passes.
