### PR TITLE
Fix technical generic pin hints in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -11,19 +11,33 @@ const wordQualityScore = {
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
+  SCK: 1.2,
+  CLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  CS: 1.18,
+  RESET_N: 1.18,
+  RESET: 1.18,
+  RST: 1.18,
+  BOOT: 1.18,
   RX: 1.15,
   TX: 1.15,
+  EN: 1.12,
   GPIO: 1.1,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
   VDD: 1.1,
+  VCC: 1.1,
+  VBUS: 1.1,
   AGND: 1.1,
   V5: 1.1,
   V3: 1.1,
   V1: 1.1,
+  "D+": 1.1,
+  "D-": 1.1,
+  DP: 1.1,
+  DM: 1.1,
   neg: 0.9,
   pos: 0.9,
   pin: 0.5,
@@ -36,13 +50,15 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.trim().toUpperCase()
+  if (!normalizedPhrase) return 0
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
+  }
+  if (normalizedPhrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-technical-generic-pin-hints.test.ts
+++ b/tests/test4-technical-generic-pin-hints.test.ts
@@ -1,0 +1,76 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("keeps common technical hints for generic chip pin labels", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["RESET_N"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: MCU
+     - R1: 1kΩ 0402 resistor
+
+    NET: U1_RESET_N
+      - U1 pin14 (RESET_N)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (MCU)
+    - pin14(RESET_N): NETS(U1_RESET_N)
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_RESET_N)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- score technical pin labels case-insensitively before applying the generic digit penalty
- add common control, power, and USB differential labels such as `RESET_N`, `BOOT`, `EN`, `VCC`, `VBUS`, `D+`, and `D-`
- add a raw Circuit JSON regression test showing a generic `pin14` keeps the meaningful `RESET_N` alias in the NET output

## Verification
- `bun test`
- `bun x biome check .`
- `bun x tsc --noEmit`

/claim #4