### PR TITLE
Use supplier part number as chip metadata fallback

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,26 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+type ComponentWithSupplierPartNumbers = {
+  supplier_part_numbers?: Partial<Record<string, string[]>>
+}
+
+const getFirstSupplierPartNumber = (
+  component: ComponentWithSupplierPartNumbers,
+) => {
+  const supplierPartNumbers = component.supplier_part_numbers
+  if (!supplierPartNumbers) return undefined
+
+  for (const [supplierName, partNumbers] of Object.entries(
+    supplierPartNumbers,
+  )) {
+    const partNumber = partNumbers?.find((value) => value.trim())
+    if (partNumber) return `${supplierName}: ${partNumber.trim()}`
+  }
+
+  return undefined
+}
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -45,7 +65,11 @@ export const convertCircuitJsonToReadableNetlist = (
       } capacitor`
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
-      componentDescription = [manufacturerPartNumber, footprint]
+      const supplierPartNumber = getFirstSupplierPartNumber(component)
+      componentDescription = [
+        manufacturerPartNumber ?? supplierPartNumber,
+        footprint,
+      ]
         .filter(Boolean)
         .join(", ")
     } else {
@@ -150,6 +174,11 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_capacitance} ${footprint})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
+      } else if (component.ftype === "simple_chip") {
+        const supplierPartNumber = getFirstSupplierPartNumber(component)
+        if (supplierPartNumber) {
+          header = `${component.name} (${supplierPartNumber})`
+        }
       }
       netlist.push(header)
       const ports = source_ports

--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -13,6 +13,11 @@ type ComponentWithSupplierPartNumbers = {
   supplier_part_numbers?: Partial<Record<string, string[]>>
 }
 
+const getNonEmptyString = (value: string | undefined) => {
+  const trimmedValue = value?.trim()
+  return trimmedValue ? trimmedValue : undefined
+}
+
 const getFirstSupplierPartNumber = (
   component: ComponentWithSupplierPartNumbers,
 ) => {
@@ -64,7 +69,9 @@ export const convertCircuitJsonToReadableNetlist = (
         footprint ? ` ${footprint}` : ""
       } capacitor`
     } else if (component.ftype === "simple_chip") {
-      const manufacturerPartNumber = component.manufacturer_part_number
+      const manufacturerPartNumber = getNonEmptyString(
+        component.manufacturer_part_number,
+      )
       const supplierPartNumber = getFirstSupplierPartNumber(component)
       componentDescription = [
         manufacturerPartNumber ?? supplierPartNumber,
@@ -167,13 +174,16 @@ export const convertCircuitJsonToReadableNetlist = (
         source_component_id: component.source_component_id,
       })
       const footprint = cadComponent?.footprinter_string
+      const manufacturerPartNumber = getNonEmptyString(
+        component.manufacturer_part_number,
+      )
       let header = component.name
       if (component.ftype === "simple_resistor") {
         header = `${component.name} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
         header = `${component.name} (${component.display_capacitance} ${footprint})`
-      } else if (component.manufacturer_part_number) {
-        header = `${component.name} (${component.manufacturer_part_number})`
+      } else if (manufacturerPartNumber) {
+        header = `${component.name} (${manufacturerPartNumber})`
       } else if (component.ftype === "simple_chip") {
         const supplierPartNumber = getFirstSupplierPartNumber(component)
         if (supplierPartNumber) {

--- a/tests/test4-chip-supplier-part-number.test.ts
+++ b/tests/test4-chip-supplier-part-number.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses supplier part number when chip manufacturer part number is missing", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      supplier_part_numbers: {
+        jlcpcb: ["C12345"],
+      },
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      source_component_id: "source_component_0",
+      footprinter_string: "soic8",
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain(" - U1: jlcpcb: C12345, soic8")
+  expect(netlist).toContain("U1 (jlcpcb: C12345)")
+  expect(netlist).not.toContain("undefined")
+})

--- a/tests/test4-chip-supplier-part-number.test.ts
+++ b/tests/test4-chip-supplier-part-number.test.ts
@@ -26,3 +26,29 @@ it("uses supplier part number when chip manufacturer part number is missing", ()
   expect(netlist).toContain("U1 (jlcpcb: C12345)")
   expect(netlist).not.toContain("undefined")
 })
+
+it("uses supplier part number when chip manufacturer part number is empty", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "",
+      supplier_part_numbers: {
+        jlcpcb: ["C12345"],
+      },
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      source_component_id: "source_component_0",
+      footprinter_string: "soic8",
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain(" - U1: jlcpcb: C12345, soic8")
+  expect(netlist).toContain("U1 (jlcpcb: C12345)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- use the first non-empty supplier part number as the simple_chip metadata fallback when manufacturer_part_number is absent
- include that fallback in both COMPONENTS output and COMPONENT_PINS headers
- add raw Circuit JSON regression coverage for supplier-only chip metadata

## Verification
- `npx -y bun test`
- `npx -y tsc --noEmit`
- `npx -y biome check .`
- `npx -y bun run build`