### PR TITLE
Improve generic component pin headers

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -1,13 +1,32 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+
+const formatSourceComponentType = (ftype?: string) =>
+  ftype?.replace(/^simple_/, "").replaceAll("_", " ")
+
+type ComponentPinHeaderSource = {
+  display_value?: string
+  ftype?: string
+  name: string
+}
+
+const getGenericComponentPinHeader = (
+  component: ComponentPinHeaderSource,
+  footprint?: string,
+) => {
+  const description = [
+    component.display_value,
+    footprint,
+    formatSourceComponentType(component.ftype),
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  return description ? `${component.name} (${description})` : component.name
+}
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -150,6 +169,8 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_capacitance} ${footprint})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
+      } else if (component.ftype !== "simple_chip") {
+        header = getGenericComponentPinHeader(component, footprint)
       }
       netlist.push(header)
       const ports = source_ports

--- a/tests/test4-generic-component-pin-headers.test.ts
+++ b/tests/test4-generic-component-pin-headers.test.ts
@@ -1,0 +1,37 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses generic component metadata in COMPONENT_PINS headers", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "led",
+      source_component_id: "source_component_led",
+      name: "LED1",
+      display_value: "red",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_inductor",
+      source_component_id: "source_component_l1",
+      name: "L1",
+      inductance: 0.00001,
+      display_value: "10uH",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+  const componentPins = netlist.split("COMPONENT_PINS:\n")[1]
+
+  expect(componentPins).toContain("LED1 (red led)")
+  expect(componentPins).toContain("L1 (10uH inductor)")
+  expect(componentPins).toContain("U1\n")
+  expect(componentPins).not.toContain("U1 (chip)")
+})


### PR DESCRIPTION
## Summary
- Add a focused formatter for non-chip/non-passive `COMPONENT_PINS` headers so useful generic component metadata is not dropped.
- Preserve existing resistor, capacitor, manufacturer part number, and no-MPN chip header behavior.
- Add a raw Circuit JSON regression test covering LED/inductor metadata and unchanged no-MPN chip output.

## Why
Generic source components can carry readable metadata such as `display_value` and `ftype`, but the pin table currently renders only the bare component name. For example, an LED with `display_value: "red"` becomes just `LED1` in `COMPONENT_PINS`; after this change it renders as `LED1 (red led)`.

## Verification
- `bun test tests/test4-generic-component-pin-headers.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run build`
- `bunx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-generic-component-pin-headers.test.ts`
- `git diff --check`

/claim #4