### PR TITLE
Show source net aliases in component pin lists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -124,14 +124,16 @@ export const convertCircuitJsonToReadableNetlist = (
   for (const [netId, connectedIds] of Object.entries(netMap)) {
     const portIds = connectedIds.filter((id) => id.startsWith("source_port"))
     if (portIds.length === 0) continue
-    const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
-    let netName = net?.name
-    if (!netName) {
-      netName = generateNetName({ circuitJson, connectedIds })
-    }
+    const netNames = source_nets
+      .filter((n) => connectedIds.includes(n.source_net_id) && n.name)
+      .map((n) => n.name)
+    const uniqueNetNames =
+      netNames.length > 0
+        ? Array.from(new Set(netNames))
+        : [generateNetName({ circuitJson, connectedIds })]
     for (const portId of portIds) {
       if (!portIdToNetNames[portId]) portIdToNetNames[portId] = []
-      portIdToNetNames[portId].push(netName)
+      portIdToNetNames[portId].push(...uniqueNetNames)
     }
   }
 

--- a/tests/test5-source-net-aliases.test.ts
+++ b/tests/test5-source-net-aliases.test.ts
@@ -1,0 +1,77 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("includes all explicit source net names in component pin net lists", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "U2",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 1,
+      name: "VDD",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "VIN",
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_vcc",
+      name: "VCC",
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_5v",
+      name: "5V",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: ["source_net_vcc", "source_net_5v"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+      "COMPONENTS:
+       - U1: 
+       - U2: 
+
+      NET: VCC
+        - U1 VDD
+        - U2 VIN
+
+
+      COMPONENT_PINS:
+      U1
+      - pin1(VDD): NETS(VCC, 5V)
+
+      U2
+      - pin1(VIN): NETS(VCC, 5V)
+      "
+    `)
+})


### PR DESCRIPTION
When a connectivity group includes multiple explicit `source_net` names, the readable netlist currently keeps only the first one in `COMPONENT_PINS`. That makes valid aliases such as `VCC` and `5V` look like only `VCC` is connected.

This keeps the existing primary `NET:` header behavior, but stores every explicit source-net name in the per-pin `NETS(...)` list and deduplicates aliases. If no explicit source-net name is present, it still falls back to `generateNetName` as before.

/claim #4

Verification:
- `bun test tests/test5-source-net-aliases.test.ts`
- `bun test`
- `bun run format:check`