### PR TITLE
Render semiconductor component descriptions

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,25 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const getSemiconductorDescription = (component: {
+  ftype?: string
+  transistor_type?: string
+  channel_type?: string
+  mosfet_mode?: string
+}) => {
+  if (component.ftype === "simple_transistor" && component.transistor_type) {
+    return `${component.transistor_type.toUpperCase()} transistor`
+  }
+
+  if (component.ftype === "simple_mosfet" && component.channel_type) {
+    const channel = component.channel_type === "n" ? "n-channel" : "p-channel"
+    const mode = component.mosfet_mode ? ` ${component.mosfet_mode}` : ""
+    return `${channel}${mode} MOSFET`
+  }
+
+  return ""
+}
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -34,6 +53,7 @@ export const convertCircuitJsonToReadableNetlist = (
     })
 
     const footprint = cadComponent?.footprinter_string
+    const semiconductorDescription = getSemiconductorDescription(component)
 
     if (component.ftype === "simple_resistor") {
       componentDescription = `${component.display_resistance}${
@@ -46,6 +66,13 @@ export const convertCircuitJsonToReadableNetlist = (
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
+        .filter(Boolean)
+        .join(", ")
+    } else if (semiconductorDescription) {
+      componentDescription = [
+        component.manufacturer_part_number,
+        semiconductorDescription,
+      ]
         .filter(Boolean)
         .join(", ")
     } else {
@@ -150,6 +177,10 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_capacitance} ${footprint})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
+      }
+      const semiconductorDescription = getSemiconductorDescription(component)
+      if (semiconductorDescription && !component.manufacturer_part_number) {
+        header = `${component.name} (${semiconductorDescription})`
       }
       netlist.push(header)
       const ports = source_ports

--- a/tests/test4-semiconductor-component-descriptions.test.ts
+++ b/tests/test4-semiconductor-component-descriptions.test.ts
@@ -1,0 +1,48 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("renders semiconductor component metadata in readable sections", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_q1",
+      name: "Q1",
+      ftype: "simple_transistor",
+      transistor_type: "npn",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_q1_collector",
+      source_component_id: "source_component_q1",
+      name: "collector",
+      pin_number: 1,
+      port_hints: ["collector"],
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_q2",
+      name: "Q2",
+      ftype: "simple_mosfet",
+      channel_type: "n",
+      mosfet_mode: "enhancement",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_q2_gate",
+      source_component_id: "source_component_q2",
+      name: "gate",
+      pin_number: 1,
+      port_hints: ["gate"],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("- Q1: NPN transistor")
+  expect(netlist).toContain("- Q2: n-channel enhancement MOSFET")
+  expect(netlist).toContain("Q1 (NPN transistor)")
+  expect(netlist).toContain("Q2 (n-channel enhancement MOSFET)")
+  expect(netlist).not.toContain("Q1, source_component")
+  expect(netlist).not.toContain("Q2, source_component")
+})


### PR DESCRIPTION
## Summary
- render `simple_transistor` metadata as readable labels such as `NPN transistor` instead of `Q1, source_component`
- render `simple_mosfet` metadata such as `n-channel enhancement MOSFET` in `COMPONENTS` and `COMPONENT_PINS`
- add raw Circuit JSON regression coverage for semiconductor component descriptions

## Repro
Current main drops semiconductor metadata and renders internal fallback text like:

```text
COMPONENTS:
 - Q1: Q1, source_component

COMPONENT_PINS:
Q1
```

After this patch, transistor and MOSFET entries preserve the schema metadata in readable output.

## Verification
- `bun test tests/test4-semiconductor-component-descriptions.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run build`
- `bunx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-semiconductor-component-descriptions.test.ts`

/claim #4

Transparency note: this patch was prepared with AI-assisted coding and locally verified.