### PR TITLE
Preserve string pin number labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -6,6 +6,7 @@ import type {
   SourcePort,
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
+import { formatPinLabelFromNumber } from "./formatPinLabelFromNumber"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
@@ -157,7 +158,10 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          formatPinLabelFromNumber({
+            pinNumber: port.pin_number,
+            numericPrefix: "pin",
+          }) ?? port.name
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/lib/formatPinLabelFromNumber.ts
+++ b/lib/formatPinLabelFromNumber.ts
@@ -1,0 +1,11 @@
+export const formatPinLabelFromNumber = ({
+  pinNumber,
+  numericPrefix,
+}: {
+  pinNumber: unknown
+  numericPrefix: string
+}) => {
+  if (pinNumber === undefined || pinNumber === null) return undefined
+  if (typeof pinNumber === "number") return `${numericPrefix}${pinNumber}`
+  return String(pinNumber)
+}

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -5,6 +5,7 @@ import type {
   SourceNet,
   SourcePort,
 } from "circuit-json"
+import { formatPinLabelFromNumber } from "./formatPinLabelFromNumber"
 import { scorePhrase } from "./scorePhrase"
 
 export const getReadableNameForPin = ({
@@ -34,7 +35,12 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName =
+    port.name ||
+    formatPinLabelFromNumber({
+      pinNumber: port.pin_number,
+      numericPrefix: "Pin",
+    })
 
   const additionalPinLabels: string[] = []
 

--- a/tests/test4-string-pin-number-labels.test.ts
+++ b/tests/test4-string-pin-number-labels.test.ts
@@ -1,0 +1,68 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves string pin numbers as readable pin labels", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_led1",
+      name: "LED1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "LED-RED",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_led1_a",
+      source_component_id: "source_component_led1",
+      pin_number: "A",
+      port_hints: ["anode"],
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_j1",
+      name: "J1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "TEST-JIG",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_1",
+      source_component_id: "source_component_j1",
+      name: "TP1",
+      pin_number: 1,
+      port_hints: ["1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_led1_a", "source_port_j1_1"],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson as any),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - LED1: LED-RED
+     - J1: TEST-JIG
+
+    NET: LED1_anode
+      - LED1 A (+)
+      - J1 TP1
+
+
+    COMPONENT_PINS:
+    LED1 (LED-RED)
+    - A(anode): NETS(LED1_anode)
+
+    J1 (TEST-JIG)
+    - pin1(TP1): NETS(LED1_anode)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- Preserve string-valued source_port.pin_number labels without adding synthetic pin/Pin prefixes.
- Share the formatter between NET entries and COMPONENT_PINS so labels such as A remain A in both sections.
- Add raw Circuit JSON regression coverage for the string pin-number case.

/claim #4

## Verification
- bun test
- bunx tsc --noEmit
- bun run build
- bunx biome check lib/convertCircuitJsonToReadableNetlist.ts lib/getReadableNameForPin.ts lib/formatPinLabelFromNumber.ts tests/test4-string-pin-number-labels.test.ts
- git diff --check