### PR TITLE
Handle numbered-only source port net names

### DIFF
--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -55,12 +55,21 @@ export const generateNetName = ({
   )
 
   const possibleNames = ports
-    .flatMap((p) =>
-      Array.from(
-        new Set([...(p.name ? [p.name] : []), ...(p.port_hints ?? [])]),
-      ),
-    )
-    .concat(nets.map((n) => n.name))
+    .flatMap((p) => {
+      const names = new Set([
+        ...(p.name ? [p.name] : []),
+        ...(p.port_hints ?? []),
+      ])
+      if (names.size === 0 && p.pin_number !== undefined) {
+        names.add(`pin${p.pin_number}`)
+      }
+      return Array.from(names)
+    })
+    .concat(nets.map((n) => n.name).filter(Boolean))
+
+  if (possibleNames.length === 0) {
+    return "unnamed_net"
+  }
 
   const phrases = possibleNames.map((name) => ({
     name,
@@ -71,7 +80,10 @@ export const generateNetName = ({
 
   // Find the component that has the best port name
   const bestPort = ports.find(
-    (p) => p.name === bestPortName || p.port_hints?.includes(bestPortName),
+    (p) =>
+      p.name === bestPortName ||
+      p.port_hints?.includes(bestPortName) ||
+      (p.pin_number !== undefined && `pin${p.pin_number}` === bestPortName),
   )
 
   const componentWithBestPort = all_source_components.find(

--- a/tests/test4-numbered-pin-net-fallback.test.tsx
+++ b/tests/test4-numbered-pin-net-fallback.test.tsx
@@ -1,0 +1,46 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("generates a net name for source ports that only have pin numbers", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip name="U1" footprint="soic2" />
+      <chip name="U2" footprint="soic2" />
+      <trace from=".U1 > .pin1" to=".U2 > .pin1" />
+    </board>,
+  ).map((element) => {
+    if (element.type !== "source_port") return element
+    const { name, port_hints, ...portWithOnlyPinNumber } = element
+    return portWithOnlyPinNumber
+  })
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson as any),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: soic2
+     - U2: soic2
+
+    NET: U1_pin1
+      - U1 Pin1
+      - U2 Pin1
+
+
+    COMPONENT_PINS:
+    U1
+    - pin1: NETS(U1_pin1)
+    - pin2: NOT_CONNECTED
+
+    U2
+    - pin1: NETS(U1_pin1)
+    - pin2: NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
Fixes a crashy/ambiguous edge case for #4 where connected source ports have only pin_number values and no name, port_hints, or explicit source_net name.

Before this change, generateNetName could build an empty candidate list and then read phrases[0].name. The fallback now uses pin<number> when a port has no names/hints, still prefixes the selected component when possible, and falls back to unnamed_net only when there is truly no usable label.

Verification:
- PATH=/private/tmp/bun-runtime/bun-darwin-aarch64:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/phil/.codex/tmp/arg0/codex-arg0SMEyBJ:/Users/phil/google-cloud-sdk/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/Applications/Codex.app/Contents/Resources /private/tmp/bun-runtime/bun-darwin-aarch64/bun test
- PATH=/private/tmp/bun-runtime/bun-darwin-aarch64:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/phil/.codex/tmp/arg0/codex-arg0SMEyBJ:/Users/phil/google-cloud-sdk/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/Applications/Codex.app/Contents/Resources /private/tmp/bun-runtime/bun-darwin-aarch64/bun x biome check lib/generateNetName.ts tests/test4-numbered-pin-net-fallback.test.tsx
- PATH=/private/tmp/bun-runtime/bun-darwin-aarch64:/Library/Frameworks/Python.framework/Versions/3.13/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/phil/.codex/tmp/arg0/codex-arg0SMEyBJ:/Users/phil/google-cloud-sdk/bin:/Library/Frameworks/Python.framework/Versions/3.13/bin:/Applications/Codex.app/Contents/Resources /private/tmp/bun-runtime/bun-darwin-aarch64/bun x tsc --noEmit

/claim #4