### PR TITLE
Use source net flags for blank net names

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,14 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const getSourceNetNameFromMetadata = (net: SourceNet | undefined) => {
+  const name = net?.name?.trim()
+  if (name) return name
+  if (net?.is_ground) return "GND"
+  if (net?.is_power) return "POWER"
+  return undefined
+}
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -63,7 +71,7 @@ export const convertCircuitJsonToReadableNetlist = (
     // Get net name
     const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
 
-    let netName = net?.name
+    let netName = getSourceNetNameFromMetadata(net)
 
     if (!netName) {
       // Generate a net name from the connected port names
@@ -125,7 +133,7 @@ export const convertCircuitJsonToReadableNetlist = (
     const portIds = connectedIds.filter((id) => id.startsWith("source_port"))
     if (portIds.length === 0) continue
     const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
-    let netName = net?.name
+    let netName = getSourceNetNameFromMetadata(net)
     if (!netName) {
       netName = generateNetName({ circuitJson, connectedIds })
     }

--- a/tests/test4-source-net-flags.test.ts
+++ b/tests/test4-source-net-flags.test.ts
@@ -1,0 +1,94 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses source net flags when explicit net names are blank", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_capacitor",
+      source_component_id: "source_component_2",
+      name: "C1",
+      display_capacitance: "100nF",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_0",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["2"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["1"],
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_0",
+      name: "",
+      member_source_group_ids: [],
+      is_ground: true,
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_1",
+      name: "   ",
+      member_source_group_ids: [],
+      is_power: true,
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: ["source_net_0"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_2", "source_port_3"],
+      connected_source_net_ids: ["source_net_1"],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: GND")
+  expect(netlist).toContain("NET: POWER")
+  expect(netlist).toContain("- pin1: NETS(GND)")
+  expect(netlist).toContain("- pin2: NETS(POWER)")
+})


### PR DESCRIPTION
## Summary
- use `source_net.is_ground` and `source_net.is_power` when explicit source net names are blank or whitespace-only
- apply the metadata-derived name consistently to `NET:` headers and `COMPONENT_PINS` `NETS(...)` entries
- add raw Circuit JSON regression coverage for blank ground and power source nets

## Repro
Current `main` renders blank-looking net labels for flagged source nets with empty names, for example:

```text
NET: 
  - U1 pin1
  - R1 pin1

COMPONENT_PINS:
U1 (MCU)
- pin1: NETS()
```

After this change, the same source net metadata renders as `GND` or `POWER` instead of an empty label.

## Verification
- `npx --yes bun test ./tests/test4-source-net-flags.test.ts` passes
- `npx tsc --noEmit` passes
- `npm run build` passes
- `npx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-source-net-flags.test.ts` passes
- `git diff --check` passes

Note: full `npx --yes bun test` still fails in the three pre-existing JSX render tests before assertions with `Export named 'distanceBetweenCircleAndPolygon' not found in module @tscircuit/circuit-json-util/dist/index.js`; the new raw JSON regression test passes.

/claim #4