### PR TITLE
Fix scoring for numbered chip pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -11,11 +11,14 @@ const wordQualityScore = {
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
+  SCK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
+  SPI: 1.15,
   GPIO: 1.1,
+  GP: 1.1,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +39,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/score-phrase.test.ts
+++ b/tests/score-phrase.test.ts
@@ -1,0 +1,37 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores useful pin labels that contain numbers", () => {
+  expect(scorePhrase("GPIO10")).toBeGreaterThan(1)
+  expect(scorePhrase("GP10")).toBeGreaterThan(1)
+  expect(scorePhrase("SPI1_SCK")).toBeGreaterThan(1)
+  expect(scorePhrase("pin14")).toBeLessThan(1)
+  expect(scorePhrase("14")).toBeLessThan(1)
+})
+
+it("includes useful aliases for generic chip pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GP10", "GPIO10", "SPI1_SCK", "pin14", "14"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (GP10,GPIO10,SPI1_SCK)")
+})


### PR DESCRIPTION
Fixes #4.
/claim #4

This fixes the phrase scoring helper so meaningful pin aliases that contain numbers are not discarded as low-quality numeric labels. The existing comment says GPIO-style labels should score well, but the digit check ran before word scoring, so labels such as `GPIO10`, `GP10`, and `SPI1_SCK` were treated like plain numbers and omitted from readable pin names.

Changes:
- score known signal words before applying the generic numeric penalty
- add common numbered chip-pin alias tokens (`GP`, `SPI`, `SCK`)
- add regression coverage for numbered aliases and generic `pin14`/`14` filtering

Verified:
- `npx bun test`
- `npx bun run build`
- `npx bun x biome check lib\scorePhrase.ts tests\score-phrase.test.ts`