### PR TITLE
Score analog peripheral pin hints

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -15,6 +15,9 @@ const wordQualityScore = {
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
+  ADC: 1.15,
+  DAC: 1.15,
+  PWM: 1.15,
   GPIO: 1.1,
   cathode: 0.5,
   anode: 0.5,
@@ -36,13 +39,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-analog-peripheral-pin-hints.test.ts
+++ b/tests/test4-analog-peripheral-pin-hints.test.ts
@@ -1,0 +1,54 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("keeps analog peripheral aliases for generic numbered chip pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["ADC0", "pos"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      display_resistance: "10k",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ADC0")
+  expect(netlist).toContain("  - U1 pin14 (+,ADC0)")
+  expect(netlist).not.toContain("NET: U1_pos")
+})


### PR DESCRIPTION
## Summary
- score common analog/peripheral aliases such as `ADC0`, `DAC0`, and `PWM0` before the generic numeric fallback
- keep ordinary numbered labels such as `pin14` filtered as low-information aliases
- add raw Circuit JSON regression coverage for a generic chip pin carrying `ADC0`

/claim #4

## Verification
- `npx --yes bun@1.2.17 test tests/test4-analog-peripheral-pin-hints.test.ts`
- `npx --yes bun@1.2.17 x biome check lib/scorePhrase.ts tests/test4-analog-peripheral-pin-hints.test.ts`
- `npx --yes bun@1.2.17 test`
- `npx --yes bun@1.2.17 run build`
- `npx --yes bun@1.2.17 x tsc --noEmit`
- `git diff --check`