### PR TITLE
Fix semantic numbered pin label scoring

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-scored-pin-labels.test.tsx
+++ b/tests/test4-scored-pin-labels.test.tsx
@@ -1,0 +1,8 @@
+import { expect, it } from "bun:test"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores semantic pin labels with digits before generic numbered pins", () => {
+  expect(scorePhrase("GPIO1")).toBe(1.1)
+  expect(scorePhrase("GPIO1_RX")).toBe(1.15)
+  expect(scorePhrase("pin14")).toBe(0.5)
+})


### PR DESCRIPTION
## Summary
- score known semantic pin tokens before falling back to the generic numbered-pin score
- keep low-information labels like `pin14` low-scored
- add regression coverage for `GPIO1`, `GPIO1_RX`, and `pin14`

## Why
`scorePhrase` documented that `GPIO1` should score as a useful GPIO label, but the digit fallback ran before semantic token matching. That made labels containing digits, such as `GPIO1` / `GPIO1_RX`, score like generic numbered pins.

## Verification
- `bun test`
- `bun run build`
- `bunx biome check lib/scorePhrase.ts tests/test4-scored-pin-labels.test.tsx`

/claim #4