### PR TITLE
Handle missing readable netlist labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,9 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${[component.display_resistance, footprint].filter(Boolean).join(" ")})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${[component.display_capacitance, footprint].filter(Boolean).join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -67,7 +67,24 @@ export const generateNetName = ({
     score: scorePhrase(name),
   }))
 
-  const bestPortName = phrases.sort((a, b) => b.score - a.score)[0].name
+  const bestPortName = phrases.sort((a, b) => b.score - a.score)[0]?.name
+
+  if (!bestPortName) {
+    const componentNames = ports
+      .map(
+        (port) =>
+          all_source_components.find(
+            (c) => c.source_component_id === port.source_component_id,
+          )?.name,
+      )
+      .filter(Boolean)
+
+    if (componentNames.length > 0) {
+      return Array.from(new Set(componentNames)).join("_")
+    }
+
+    return "unnamed_net"
+  }
 
   // Find the component that has the best port name
   const bestPort = ports.find(

--- a/tests/test3-no-footprint-chip.test.tsx
+++ b/tests/test3-no-footprint-chip.test.tsx
@@ -1,5 +1,7 @@
 import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { generateNetName } from "lib/generateNetName"
 import { renderCircuit } from "tests/fixtures/render-circuit"
 
 declare module "bun:test" {
@@ -25,4 +27,53 @@ it("chip without footprint doesn't output undefined", () => {
     LED1 (WS2812B_2020)
     "
   `)
+})
+
+it("passives without footprint don't output undefined in pin headers", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <resistor resistance="1k" name="R1" />
+      <capacitor capacitance="1nF" name="C1" />
+      <trace from=".R1 > .pin1" to=".C1 > .pin1" />
+    </board>,
+  )
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("R1 (1kΩ)")
+  expect(netlist).toContain("C1 (1nF)")
+})
+
+it("generates a fallback net name for unnamed connected ports", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "U2",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    generateNetName({
+      circuitJson,
+      connectedIds: ["source_port_1", "source_port_2"],
+    }),
+  ).toBe("U1_U2")
 })


### PR DESCRIPTION
## Summary
- avoid `undefined` in simple resistor/capacitor COMPONENT_PINS headers when no footprint is present
- add a safe generated-net fallback for connected ports with no names or hints
- cover both cases with regression tests

/claim #4

## Verification
- `bun test`
- `node_modules/@biomejs/cli-darwin-arm64/biome format . --write`

Note: `bun run format` itself hits a local Homebrew Node dylib issue in this environment, so I invoked the installed Biome native binary directly.