### PR TITLE
Fix whitespace source net names in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -8,6 +8,7 @@ import type {
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { normalizeReadableLabel } from "./readable-labels"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -63,7 +64,7 @@ export const convertCircuitJsonToReadableNetlist = (
     // Get net name
     const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
 
-    let netName = net?.name
+    let netName = normalizeReadableLabel(net?.name)
 
     if (!netName) {
       // Generate a net name from the connected port names
@@ -125,7 +126,7 @@ export const convertCircuitJsonToReadableNetlist = (
     const portIds = connectedIds.filter((id) => id.startsWith("source_port"))
     if (portIds.length === 0) continue
     const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
-    let netName = net?.name
+    let netName = normalizeReadableLabel(net?.name)
     if (!netName) {
       netName = generateNetName({ circuitJson, connectedIds })
     }

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -1,6 +1,7 @@
 import { su } from "@tscircuit/circuit-json-util"
 import type { AnyCircuitElement, AnySourceComponent } from "circuit-json"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { normalizeReadableLabel } from "./readable-labels"
 import { scorePhrase } from "./scorePhrase"
 
 // Order components by how much better they are as a reference (chips are
@@ -57,10 +58,18 @@ export const generateNetName = ({
   const possibleNames = ports
     .flatMap((p) =>
       Array.from(
-        new Set([...(p.name ? [p.name] : []), ...(p.port_hints ?? [])]),
+        new Set(
+          [p.name, ...(p.port_hints ?? [])]
+            .map(normalizeReadableLabel)
+            .filter((name): name is string => Boolean(name)),
+        ),
       ),
     )
-    .concat(nets.map((n) => n.name))
+    .concat(
+      nets
+        .map((n) => normalizeReadableLabel(n.name))
+        .filter((name): name is string => Boolean(name)),
+    )
 
   const phrases = possibleNames.map((name) => ({
     name,

--- a/lib/readable-labels.ts
+++ b/lib/readable-labels.ts
@@ -1,0 +1,6 @@
+export const normalizeReadableLabel = (
+  value: string | null | undefined,
+): string | undefined => {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}

--- a/tests/test4-trim-source-net-names.test.tsx
+++ b/tests/test4-trim-source-net-names.test.tsx
@@ -1,0 +1,67 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+const renderNamedNetCircuit = () =>
+  renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+      <trace from=".R1 > .pin1" to="net.VBUS" />
+      <trace from=".C1 > .pin1" to="net.VBUS" />
+    </board>,
+  )
+
+it("trims source net names before rendering readable netlists", () => {
+  const circuitJson = renderNamedNetCircuit()
+  const sourceNet = circuitJson.find((element) => element.type === "source_net")
+  if (!sourceNet || sourceNet.type !== "source_net") {
+    throw new Error("expected source_net fixture element")
+  }
+  sourceNet.name = "  VBUS  "
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - R1: 1kΩ 0402 resistor
+     - C1: 1nF 0402 capacitor
+
+    NET: VBUS
+      - C1 pin1 (+)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(VBUS)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    C1 (1nF 0402)
+    - pin1(pos, anode, left): NETS(VBUS)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})
+
+it("ignores blank source net names when generating fallback names", () => {
+  const circuitJson = renderNamedNetCircuit()
+  const sourceNet = circuitJson.find((element) => element.type === "source_net")
+  if (!sourceNet || sourceNet.type !== "source_net") {
+    throw new Error("expected source_net fixture element")
+  }
+  sourceNet.name = "   "
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: C1_pos")
+  expect(netlist).toContain("NETS(C1_pos)")
+  expect(netlist).not.toContain("NET:    ")
+  expect(netlist).not.toContain("NETS(   )")
+})


### PR DESCRIPTION
## Summary

- trims `source_net.name` before rendering readable net names
- ignores blank-only source net names when generating fallback net names
- adds regression coverage for padded and blank source net labels

## Issue

/claim #4

## Verification

```text
bun test
5 pass, 0 fail

bunx tsc --noEmit
passed

bun run build
Build success

git diff --check
passed
```

## Payment note

No public payment details are included. If this PR is accepted, payout should go through the Algora bounty flow for issue #4.