### PR TITLE
Render power source voltage in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,20 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const formatPowerSourceDescription = (component: {
+  ftype?: string
+  voltage?: unknown
+}) => {
+  if (component.ftype !== "simple_power_source") return ""
+  if (typeof component.voltage === "number") {
+    return `${component.voltage}V power source`
+  }
+  if (typeof component.voltage === "string" && component.voltage.trim()) {
+    return `${component.voltage.trim()} power source`
+  }
+  return "power source"
+}
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -48,6 +62,8 @@ export const convertCircuitJsonToReadableNetlist = (
       componentDescription = [manufacturerPartNumber, footprint]
         .filter(Boolean)
         .join(", ")
+    } else if (component.ftype === "simple_power_source") {
+      componentDescription = formatPowerSourceDescription(component)
     } else {
       componentDescription = [component.name, component.type]
         .filter(Boolean)
@@ -150,6 +166,8 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_capacitance} ${footprint})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
+      } else if (component.ftype === "simple_power_source") {
+        header = `${component.name} (${formatPowerSourceDescription(component)})`
       }
       netlist.push(header)
       const ports = source_ports

--- a/tests/test4-power-source-description.test.ts
+++ b/tests/test4-power-source-description.test.ts
@@ -1,0 +1,33 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("renders power source voltage in component descriptions", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_power_source",
+      source_component_id: "source_component_0",
+      name: "VCC",
+      voltage: 3.3,
+    } as AnyCircuitElement,
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - VCC: 3.3V power source
+
+
+    COMPONENT_PINS:
+    VCC (3.3V power source)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- render simple_power_source components as voltage-aware power source descriptions instead of generic source_component text
- use the same description in COMPONENT_PINS headers
- add raw Circuit JSON regression coverage for the voltage case

/claim #4

## Verification
- bun test tests/test4-power-source-description.test.ts
- bun test
- bunx tsc --noEmit
- bunx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-power-source-description.test.ts
- bun run build
- git diff --check