### PR TITLE
Score SPI chip select pin hints

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,9 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  if (/^(CS|NSS)\d*$/i.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-spi-chip-select-pin-hints.test.ts
+++ b/tests/test4-spi-chip-select-pin-hints.test.ts
@@ -1,0 +1,92 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses SPI chip select hints for generic numbered chip pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "soic8",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 1,
+      port_hints: ["CS0"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_2",
+      name: "R1",
+      resistance: 10000,
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_2",
+      source_component_id: "source_component_2",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["cathode", "neg", "right"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: MCU, soic8
+     - R1: 10kΩ 0402 resistor
+
+    NET: U1_CS0
+      - U1 pin14 (CS0)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (MCU)
+    - pin1(pin14, CS0): NETS(U1_CS0)
+
+    R1 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_CS0)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- Recognize numeric SPI chip-select aliases like `CS0` and `NSS0` before the generic numeric-name fallback.
- Add a raw circuit-json regression test showing a generic chip pin with `CS0` should produce `U1_CS0` instead of a passive `R1_pos` net name.

## Verification
- `npm_config_cache=/private/tmp/npm-cache npm exec --yes bun -- test ./tests/test4-spi-chip-select-pin-hints.test.ts`
- `npm_config_cache=/private/tmp/npm-cache ./node_modules/.bin/biome check lib/scorePhrase.ts tests/test4-spi-chip-select-pin-hints.test.ts`
- `npm_config_cache=/private/tmp/npm-cache ./node_modules/.bin/tsc --noEmit`
- `npm_config_cache=/private/tmp/npm-cache npm run build`

Full `bun test` still fails in the existing TSX fixture tests because `@tscircuit/circuit-json-util` does not export `distanceBetweenCircleAndPolygon`; the new raw circuit-json regression test passes independently.

/claim #4
