### PR TITLE
Render simple inductor descriptions

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -43,6 +43,9 @@ export const convertCircuitJsonToReadableNetlist = (
       componentDescription = `${component.display_capacitance}${
         footprint ? ` ${footprint}` : ""
       } capacitor`
+    } else if (component.ftype === "simple_inductor") {
+      const value = component.display_value ?? component.inductance
+      componentDescription = `${value}${footprint ? ` ${footprint}` : ""} inductor`
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -148,6 +151,9 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
         header = `${component.name} (${component.display_capacitance} ${footprint})`
+      } else if (component.ftype === "simple_inductor") {
+        const value = component.display_value ?? component.inductance
+        header = `${component.name} (${value}${footprint ? ` ${footprint}` : ""})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-inductor-description.test.ts
+++ b/tests/test4-inductor-description.test.ts
@@ -1,0 +1,56 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("renders simple_inductor value and footprint in component descriptions", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_inductor",
+      source_component_id: "source_component_0",
+      name: "L1",
+      inductance: 0.00001,
+      display_value: "10uH",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      pcb_component_id: "pcb_component_0",
+      source_component_id: "source_component_0",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      footprinter_string: "0402",
+      layer: "top",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["2"],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - L1: 10uH 0402 inductor
+
+
+    COMPONENT_PINS:
+    L1 (10uH 0402)
+    - pin1: NOT_CONNECTED
+    - pin2: NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- render `simple_inductor` components with readable value/footprint text in `COMPONENTS`
- include the same inductor metadata in `COMPONENT_PINS` headers
- add raw Circuit JSON regression coverage for the inductor path

## Verification
- `npx -y bun test`
- `npx -y tsc --noEmit`
- `npx -y biome check .`
- `npx -y bun run build`