### PR TITLE
Render simple battery descriptions

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -43,6 +43,9 @@ export const convertCircuitJsonToReadableNetlist = (
       componentDescription = `${component.display_capacitance}${
         footprint ? ` ${footprint}` : ""
       } capacitor`
+    } else if (component.ftype === "simple_battery") {
+      const value = component.display_value ?? component.capacity
+      componentDescription = `${value}${footprint ? ` ${footprint}` : ""} battery`
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -148,6 +151,9 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
         header = `${component.name} (${component.display_capacitance} ${footprint})`
+      } else if (component.ftype === "simple_battery") {
+        const value = component.display_value ?? component.capacity
+        header = `${component.name} (${value}${footprint ? ` ${footprint}` : ""})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-battery-description.test.ts
+++ b/tests/test4-battery-description.test.ts
@@ -1,0 +1,56 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("renders simple_battery value and footprint in component descriptions", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_battery",
+      source_component_id: "source_component_0",
+      name: "B1",
+      capacity: 1000,
+      display_value: "1000mAh",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      pcb_component_id: "pcb_component_0",
+      source_component_id: "source_component_0",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      footprinter_string: "battery_holder",
+      layer: "top",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pos",
+      pin_number: 1,
+      port_hints: ["positive"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "neg",
+      pin_number: 2,
+      port_hints: ["negative"],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - B1: 1000mAh battery_holder battery
+
+
+    COMPONENT_PINS:
+    B1 (1000mAh battery_holder)
+    - pin1(pos, positive): NOT_CONNECTED
+    - pin2(neg, negative): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- render `simple_battery` components with readable value/footprint text in `COMPONENTS`
- include the same battery metadata in `COMPONENT_PINS` headers
- add raw Circuit JSON regression coverage for the battery path

## Verification
- `npx -y bun test tests/test4-battery-description.test.ts`
- `npx -y bun test`
- `npx -y tsc --noEmit`
- `npx -y biome check .`
- `npx -y bun run build`