### PR TITLE
Render simple diode descriptions

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -43,6 +43,9 @@ export const convertCircuitJsonToReadableNetlist = (
       componentDescription = `${component.display_capacitance}${
         footprint ? ` ${footprint}` : ""
       } capacitor`
+    } else if (component.ftype === "simple_diode") {
+      const value = component.display_value
+      componentDescription = `${value ? `${value} ` : ""}${footprint ? `${footprint} ` : ""}diode`
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -148,6 +151,10 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
         header = `${component.name} (${component.display_capacitance} ${footprint})`
+      } else if (component.ftype === "simple_diode") {
+        const value = component.display_value
+        const details = [value, footprint].filter(Boolean).join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-diode-description.test.ts
+++ b/tests/test4-diode-description.test.ts
@@ -1,0 +1,55 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("renders simple_diode value and footprint in component descriptions", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_diode",
+      source_component_id: "source_component_0",
+      name: "D1",
+      display_value: "1N4148",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      pcb_component_id: "pcb_component_0",
+      source_component_id: "source_component_0",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      footprinter_string: "SOD-123",
+      layer: "top",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "anode",
+      pin_number: 1,
+      port_hints: ["A"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "cathode",
+      pin_number: 2,
+      port_hints: ["K"],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - D1: 1N4148 SOD-123 diode
+
+
+    COMPONENT_PINS:
+    D1 (1N4148 SOD-123)
+    - pin1(anode, A): NOT_CONNECTED
+    - pin2(cathode, K): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- render `simple_diode` components with readable value/footprint text in `COMPONENTS`
- include the same diode metadata in `COMPONENT_PINS` headers
- add raw Circuit JSON regression coverage for the diode path

## Verification
- `npx -y bun test tests/test4-diode-description.test.ts`
- `npx -y bun test`
- `npx -y tsc --noEmit`
- `npx -y biome check .`
- `npx -y bun run build`