### PR TITLE
Render frequency component descriptions

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -43,6 +43,12 @@ export const convertCircuitJsonToReadableNetlist = (
       componentDescription = `${component.display_capacitance}${
         footprint ? ` ${footprint}` : ""
       } capacitor`
+    } else if (component.ftype === "simple_crystal") {
+      const value = component.display_value ?? component.frequency
+      componentDescription = `${value}${footprint ? ` ${footprint}` : ""} crystal`
+    } else if (component.ftype === "simple_resonator") {
+      const value = component.display_value ?? component.frequency
+      componentDescription = `${value}${footprint ? ` ${footprint}` : ""} resonator`
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -148,6 +154,12 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
         header = `${component.name} (${component.display_capacitance} ${footprint})`
+      } else if (component.ftype === "simple_crystal") {
+        const value = component.display_value ?? component.frequency
+        header = `${component.name} (${value}${footprint ? ` ${footprint}` : ""})`
+      } else if (component.ftype === "simple_resonator") {
+        const value = component.display_value ?? component.frequency
+        header = `${component.name} (${value}${footprint ? ` ${footprint}` : ""})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-frequency-component-description.test.ts
+++ b/tests/test4-frequency-component-description.test.ts
@@ -1,0 +1,60 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("renders crystal and resonator values in component descriptions", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_crystal",
+      source_component_id: "source_component_0",
+      name: "Y1",
+      frequency: 16000000,
+      display_value: "16MHz",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      pcb_component_id: "pcb_component_0",
+      source_component_id: "source_component_0",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      footprinter_string: "3225",
+      layer: "top",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resonator",
+      source_component_id: "source_component_1",
+      name: "X1",
+      frequency: 8000000,
+      load_capacitance: 0.000000000012,
+      display_value: "8MHz",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      pcb_component_id: "pcb_component_1",
+      source_component_id: "source_component_1",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      footprinter_string: "CSTCE",
+      layer: "top",
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - Y1: 16MHz 3225 crystal
+     - X1: 8MHz CSTCE resonator
+
+
+    COMPONENT_PINS:
+    Y1 (16MHz 3225)
+
+    X1 (8MHz CSTCE)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- render `simple_crystal` and `simple_resonator` components with readable value/footprint text in `COMPONENTS`
- include the same frequency metadata in `COMPONENT_PINS` headers
- add raw Circuit JSON regression coverage for both frequency component paths

## Verification
- `npx -y bun test tests/test4-frequency-component-description.test.ts`
- `npx -y bun test`
- `npx -y tsc --noEmit`
- `npx -y biome check .`
- `npx -y bun run build`