### PR TITLE
Recognize symbolic polarity pin hints

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -27,10 +27,10 @@ export const getReadableNameForPin = ({
 
   // Determine pin polarity from hints
   const isPositive = port.port_hints?.some((hint) =>
-    ["anode", "pos", "positive"].includes(hint.toLowerCase()),
+    ["+", "anode", "plus", "pos", "positive"].includes(hint.toLowerCase()),
   )
   const isNegative = port.port_hints?.some((hint) =>
-    ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
+    ["-", "cathode", "minus", "neg", "negative"].includes(hint.toLowerCase()),
   )
 
   // Format pin description

--- a/tests/test4-symbolic-polarity-hints.test.ts
+++ b/tests/test4-symbolic-polarity-hints.test.ts
@@ -1,0 +1,72 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("renders symbolic plus and minus polarity hints in net entries", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_capacitor",
+      source_component_id: "source_component_0",
+      name: "C1",
+      capacitance: 0.000001,
+      display_capacitance: "1uF",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["+"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["-"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "VDD",
+      pin_number: 1,
+      port_hints: ["VDD"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      name: "GND",
+      pin_number: 2,
+      port_hints: ["GND"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("  - C1 pin1 (+)")
+  expect(netlist).toContain("  - C1 pin2 (-)")
+})


### PR DESCRIPTION
## Summary
- Recognizes symbolic polarity hints `+`, `plus`, `-`, and `minus` when rendering readable NET pin labels.
- Adds raw Circuit JSON regression coverage for polarized capacitor pins connected to VDD/GND.
- Keeps the change scoped to readable pin labeling.

## Root cause
`getReadableNameForPin` only treated word hints like `pos`/`positive` and `neg`/`negative` as polarity. Symbolic hints were already used in component pin aliases, but were not surfaced in NET entries, so readable labels stayed short.

## Verification
- `npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check lib/getReadableNameForPin.ts tests/test4-symbolic-polarity-hints.test.ts`
- `npx --yes bun run build`
- `git diff --check`

/claim #4

Transparency note: this patch was prepared with AI-assisted coding and verified locally before submission.