### PR TITLE
Fix readable pin labels for generic chip pins

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -36,13 +36,21 @@ export const convertCircuitJsonToReadableNetlist = (
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
+      componentDescription = [
+        component.display_resistance,
+        footprint,
+        "resistor",
+      ]
+        .filter(Boolean)
+        .join(" ")
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
+      componentDescription = [
+        component.display_capacitance,
+        footprint,
+        "capacitor",
+      ]
+        .filter(Boolean)
+        .join(" ")
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -145,9 +153,19 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const description = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = description
+          ? `${component.name} (${description})`
+          : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const description = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = description
+          ? `${component.name} (${description})`
+          : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,17 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinName = (name: string | undefined): boolean =>
+  Boolean(name?.match(/^pin\d+$/i))
+
+const isPinNumberHint = (
+  hint: string,
+  pinNumber: number | string | undefined,
+): boolean => {
+  if (pinNumber === undefined) return false
+  return hint === String(pinNumber) || hint.toLowerCase() === `pin${pinNumber}`
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -25,6 +36,10 @@ export const getReadableNameForPin = ({
   )
   if (!component) return ""
 
+  const bestPinHint = port.port_hints?.find(
+    (hint) => !isPinNumberHint(hint, port.pin_number),
+  )
+
   // Determine pin polarity from hints
   const isPositive = port.port_hints?.some((hint) =>
     ["anode", "pos", "positive"].includes(hint.toLowerCase()),
@@ -34,9 +49,16 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName =
+    port.name && !isGenericPinName(port.name)
+      ? port.name
+      : (bestPinHint ?? port.name ?? `Pin${port.pin_number}`)
 
   const additionalPinLabels: string[] = []
+
+  if (port.name && port.name !== mainPinName) {
+    additionalPinLabels.push(port.name)
+  }
 
   if (isPositive && component.ftype !== "simple_resistor") {
     additionalPinLabels.push("+")
@@ -55,5 +77,6 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  const uniqueAdditionalLabels = Array.from(new Set(additionalPinLabels))
+  return `${component.name} ${mainPinName}${uniqueAdditionalLabels.length > 0 ? ` (${uniqueAdditionalLabels.join(",")})` : ""}${displayValue}`
 }

--- a/tests/test4-readable-pin-names.test.ts
+++ b/tests/test4-readable-pin-names.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("uses descriptive port hints instead of generic pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "PICO_W",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_13",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GP10_SPI1SCK_I2C1SDA", "pin14", "14"],
+      source_component_id: "source_component_0",
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_13",
+    }),
+  ).toBe("U1 GP10_SPI1SCK_I2C1SDA (pin14)")
+})


### PR DESCRIPTION
Fixes #4.

/claim #4

Summary:
- use descriptive port_hints when a source port name is only generic pinN
- keep the generic pin number as an alias, for example U1 GP10_SPI1SCK_I2C1SDA (pin14)
- avoid rendering undefined in simple resistor/capacitor descriptions when footprint data is missing

Verification:
- npm run build
- npm exec --yes bun@1.2.13 -- test tests/test4-readable-pin-names.test.ts
- verified the issue reference circuit renders U1 GP10_SPI1SCK_I2C1SDA (pin14) and contains no undefined

Note: the pre-existing TSX render tests currently fail locally in @tscircuit/core with TypeError: Attempting to define property on object that is not extensible; the new regression test is independent of that render harness.