### PR TITLE
Render switch and push button descriptions

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -48,6 +48,14 @@ export const convertCircuitJsonToReadableNetlist = (
       componentDescription = [manufacturerPartNumber, footprint]
         .filter(Boolean)
         .join(", ")
+    } else if (component.ftype === "simple_switch") {
+      componentDescription = [component.display_value, footprint, "switch"]
+        .filter(Boolean)
+        .join(" ")
+    } else if (component.ftype === "simple_push_button") {
+      componentDescription = [component.display_value, footprint, "push button"]
+        .filter(Boolean)
+        .join(" ")
     } else {
       componentDescription = [component.name, component.type]
         .filter(Boolean)
@@ -148,6 +156,22 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
         header = `${component.name} (${component.display_capacitance} ${footprint})`
+      } else if (component.ftype === "simple_switch") {
+        header = `${component.name} (${[
+          component.display_value,
+          footprint,
+          "switch",
+        ]
+          .filter(Boolean)
+          .join(" ")})`
+      } else if (component.ftype === "simple_push_button") {
+        header = `${component.name} (${[
+          component.display_value,
+          footprint,
+          "push button",
+        ]
+          .filter(Boolean)
+          .join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-control-component-description.test.ts
+++ b/tests/test4-control-component-description.test.ts
@@ -1,0 +1,97 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("renders switch and push button descriptions", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_switch",
+      source_component_id: "source_component_sw1",
+      name: "SW1",
+      display_value: "SPDT",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_sw1_1",
+      source_component_id: "source_component_sw1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["common"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_sw1_2",
+      source_component_id: "source_component_sw1",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["throw"],
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_sw1",
+      source_component_id: "source_component_sw1",
+      pcb_component_id: "pcb_component_sw1",
+      footprinter_string: "slide",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+    },
+    {
+      type: "source_component",
+      ftype: "simple_push_button",
+      source_component_id: "source_component_btn1",
+      name: "BTN1",
+      display_value: "momentary",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_btn1_1",
+      source_component_id: "source_component_btn1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_btn1_2",
+      source_component_id: "source_component_btn1",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["right"],
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_btn1",
+      source_component_id: "source_component_btn1",
+      pcb_component_id: "pcb_component_btn1",
+      footprinter_string: "tactile",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+  expect(netlist).not.toContain("source_component")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - SW1: SPDT slide switch
+     - BTN1: momentary tactile push button
+
+
+    COMPONENT_PINS:
+    SW1 (SPDT slide switch)
+    - pin1(common): NOT_CONNECTED
+    - pin2(throw): NOT_CONNECTED
+
+    BTN1 (momentary tactile push button)
+    - pin1(left): NOT_CONNECTED
+    - pin2(right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- render `simple_switch` components with display value and footprint metadata in readable netlists
- render `simple_push_button` components with display value and footprint metadata
- add raw Circuit JSON regression coverage for both control component types

## Verification
- `bun test tests/test4-control-component-description.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-control-component-description.test.ts`
- `bun run build`
- `git diff --check`