### PR TITLE
[codex] Render semiconductor and power source descriptions

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -1,3 +1,4 @@
+
 import { su } from "@tscircuit/circuit-json-util"
 import type {
   AnyCircuitElement,
@@ -8,6 +9,28 @@ import type {
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+
+const formatVoltage = (voltage?: number) =>
+  voltage !== undefined ? `${voltage}V` : undefined
+
+const getMosfetDescription = (component: {
+  channel_type?: string
+  mosfet_mode?: string
+}) =>
+  [
+    component.channel_type
+      ? `${component.channel_type.toUpperCase()}-channel`
+      : undefined,
+    component.mosfet_mode,
+    "MOSFET",
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+const getTransistorDescription = (component: { transistor_type?: string }) =>
+  [component.transistor_type?.toUpperCase(), "transistor"]
+    .filter(Boolean)
+    .join(" ")
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -46,6 +69,22 @@ export const convertCircuitJsonToReadableNetlist = (
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
+        .filter(Boolean)
+        .join(", ")
+    } else if (component.ftype === "simple_power_source") {
+      componentDescription = [
+        component.display_value ?? formatVoltage(component.voltage),
+        footprint,
+        "power source",
+      ]
+        .filter(Boolean)
+        .join(" ")
+    } else if (component.ftype === "simple_mosfet") {
+      componentDescription = [getMosfetDescription(component), footprint]
+        .filter(Boolean)
+        .join(", ")
+    } else if (component.ftype === "simple_transistor") {
+      componentDescription = [getTransistorDescription(component), footprint]
         .filter(Boolean)
         .join(", ")
     } else {
@@ -150,6 +189,18 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_capacitance} ${footprint})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
+      } else if (component.ftype === "simple_power_source") {
+        const powerSourceDescription = [
+          component.display_value ?? formatVoltage(component.voltage),
+          footprint,
+        ]
+          .filter(Boolean)
+          .join(" ")
+        header = `${component.name} (${powerSourceDescription})`
+      } else if (component.ftype === "simple_mosfet") {
+        header = `${component.name} (${getMosfetDescription(component)})`
+      } else if (component.ftype === "simple_transistor") {
+        header = `${component.name} (${getTransistorDescription(component)})`
       }
       netlist.push(header)
       const ports = source_ports

--- a/tests/test4-semiconductor-and-power-source-descriptions.test.ts
+++ b/tests/test4-semiconductor-and-power-source-descriptions.test.ts
@@ -1,0 +1,55 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("renders readable semiconductor and power source descriptions", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_mosfet",
+      source_component_id: "source_component_0",
+      name: "Q1",
+      channel_type: "n",
+      mosfet_mode: "enhancement",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_transistor",
+      source_component_id: "source_component_1",
+      name: "Q2",
+      transistor_type: "pnp",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_power_source",
+      source_component_id: "source_component_2",
+      name: "V1",
+      voltage: 3.3,
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - Q1: N-channel enhancement MOSFET
+     - Q2: PNP transistor
+     - V1: 3.3V power source
+
+
+    COMPONENT_PINS:
+    Q1 (N-channel enhancement MOSFET)
+
+    Q2 (PNP transistor)
+
+    V1 (3.3V)
+    "
+  `)
+})
+


### PR DESCRIPTION
Fixes #4

/claim #4

## Summary
- Render readable COMPONENTS descriptions for `simple_mosfet`, `simple_transistor`, and `simple_power_source`.
- Use matching readable labels in COMPONENT_PINS headers.
- Add raw Circuit JSON regression coverage for MOSFET, transistor, and power source output.

## Verification
- `~/.bun/bin/bun test`
- `~/.bun/bin/bun run format:check`
- `~/.bun/bin/bun node_modules/tsup/dist/cli-default.js ./lib/index.ts --format esm --dts`