### PR TITLE
Render simple ground descriptions

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -48,6 +48,8 @@ export const convertCircuitJsonToReadableNetlist = (
       componentDescription = [manufacturerPartNumber, footprint]
         .filter(Boolean)
         .join(", ")
+    } else if (component.ftype === "simple_ground") {
+      componentDescription = "ground"
     } else {
       componentDescription = [component.name, component.type]
         .filter(Boolean)
@@ -148,6 +150,8 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
         header = `${component.name} (${component.display_capacitance} ${footprint})`
+      } else if (component.ftype === "simple_ground") {
+        header = `${component.name} (ground)`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-ground-description.test.ts
+++ b/tests/test4-ground-description.test.ts
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("renders simple ground components with readable descriptions", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      ftype: "simple_ground",
+      source_component_id: "source_component_1",
+      name: "GND1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["gnd", "ground"],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - GND1: ground
+
+
+    COMPONENT_PINS:
+    GND1 (ground)
+    - pin1(gnd, ground): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- render `simple_ground` components as `ground` instead of generic `source_component` text
- use the same readable ground label in `COMPONENT_PINS` headers
- add raw Circuit JSON regression coverage for the ground component path

/claim #4

## Verification
- `npx --yes bun@1.2.17 test tests/test4-ground-description.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-ground-description.test.ts`
- `npm run build`
- `git diff --check`

Note: full `npx --yes bun@1.2.17 test` currently fails in the pre-existing TSX render tests before assertions with `Export named 'distanceBetweenCircleAndCircle' not found in module @tscircuit/circuit-json-util/dist/index.js`; the new raw Circuit JSON regression test passes independently.