### PR TITLE
Prefer descriptive chip pin labels over generic pin names

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,8 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinName = (label: string) => /^pin\d+$/i.test(label)
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -33,8 +35,21 @@ export const getReadableNameForPin = ({
     ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
   )
 
-  // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const informativeHints = Array.from(new Set(port.port_hints ?? []))
+    .filter((hint) => hint !== String(port.pin_number))
+    .filter((hint) => !isGenericPinName(hint))
+    .sort((a, b) => scorePhrase(b) - scorePhrase(a) || b.length - a.length)
+
+  const bestInformativeHint =
+    informativeHints[0] && scorePhrase(informativeHints[0]) > 1
+      ? informativeHints[0]
+      : undefined
+
+  // Prefer a more descriptive port hint when the generated name is just "pinN".
+  const mainPinName =
+    port.name && !isGenericPinName(port.name)
+      ? port.name
+      : bestInformativeHint ?? (port.name ? port.name : `Pin${port.pin_number}`)
 
   const additionalPinLabels: string[] = []
 
@@ -44,10 +59,13 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
-  for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
+  for (const port_hint of Array.from(new Set(port.port_hints ?? []))) {
+    if (port_hint === mainPinName || port_hint === String(port.pin_number)) {
+      continue
+    }
+    if (isGenericPinName(port_hint)) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score >= 1) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,19 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/^\d+$/)) {
+    return 0
+  }
+  if (phrase.match(/^pin\d+$/i)) {
+    return 0.5
+  }
+  if (phrase.match(/\d+/)) {
+    return 1.05
   }
   return 1
 }

--- a/tests/test4-generic-chip-pin-name.test.tsx
+++ b/tests/test4-generic-chip-pin-name.test.tsx
@@ -1,0 +1,68 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("prefers descriptive port hints over generic pin names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="ATMEGA328P"
+        pinLabels={{
+          pin1: ["GND"],
+          pin2: ["GPIO14"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <trace from=".U1 .GPIO14" to=".R1 .pin1" />
+    </board>,
+  )
+
+  const gpio14Port = circuitJson.find(
+    (element) => element.type === "source_port" && element.name === "GPIO14",
+  )
+
+  if (!gpio14Port || gpio14Port.type !== "source_port") {
+    throw new Error("expected GPIO14 source port")
+  }
+
+  gpio14Port.name = "pin14"
+  gpio14Port.pin_number = 14
+  gpio14Port.port_hints = ["GPIO14", "pin14", "14"]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: ATMEGA328P, soic8
+     - R1: 1kΩ 0402 resistor
+
+    NET: U1_GPIO14
+      - U1 GPIO14
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (ATMEGA328P)
+    - pin1(GND): NOT_CONNECTED
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+    - pin14(GPIO14): NETS(U1_GPIO14)
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_GPIO14)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- prefer descriptive port hints like GPIO14 when the generated port name is only a generic pin name such as pin14
- keep generic polarity hints like pos/neg from replacing passive pin names
- add a regression test covering the pin14 -> GPIO14 case

## Testing
- bun test

Fixes #4

/claim #4