### PR TITLE
Fix readable numbered pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,9 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const formatValueWithFootprint = (value?: string, footprint?: string) =>
+  [value, footprint].filter(Boolean).join(" ")
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -145,9 +148,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${formatValueWithFootprint(
+          component.display_resistance,
+          footprint,
+        )})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${formatValueWithFootprint(
+          component.display_capacitance,
+          footprint,
+        )})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,17 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinLabel = (label: string, pinNumber?: number) => {
+  const normalizedLabel = label.trim().toLowerCase()
+  if (!normalizedLabel) return true
+  if (pinNumber === undefined) return false
+  return (
+    normalizedLabel === String(pinNumber) ||
+    normalizedLabel === `pin${pinNumber}` ||
+    normalizedLabel === `pin ${pinNumber}`
+  )
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -46,8 +57,9 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (isGenericPinLabel(port_hint, port.pin_number)) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score > 1 || (/\p{L}/u.test(port_hint) && /\d/.test(port_hint))) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/test4-readable-pin-labels.test.ts
+++ b/tests/test4-readable-pin-labels.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("keeps useful numbered pin labels in readable pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "pin14", "GP14", "SPI1_SCK"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 pin14 (GP14,SPI1_SCK)")
+})

--- a/tests/test5-no-footprint-passives.test.tsx
+++ b/tests/test5-no-footprint-passives.test.tsx
@@ -1,0 +1,24 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("passives without footprints don't output undefined in component pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <resistor resistance="1k" name="R1" />
+      <capacitor capacitance="1nF" name="C1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("R1 (1kΩ)")
+  expect(netlist).toContain("C1 (1nF)")
+})


### PR DESCRIPTION
Fixes #4.
/claim #4

## Summary
- keep useful numbered port hints like `GP14` and `SPI1_SCK` in readable pin labels
- continue filtering generic pin-number hints like `14`, `pin14`, and `pin 14`
- avoid rendering `undefined` in passive `COMPONENT_PINS` headers when footprint data is missing
- add focused regression tests for readable numbered pin labels and no-footprint passives

## Tests
- `npx bun test`
- `npx bun run format:check`
- `npx tsc --noEmit`
- `npx bun run build`