### PR TITLE
Fix readable numbered pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -8,6 +8,25 @@ import type {
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { scorePhrase } from "./scorePhrase"
+
+const getPortPinNumberName = (port: SourcePort) =>
+  port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+
+const getReadablePortName = (port: SourcePort) => {
+  const pinNumberName = getPortPinNumberName(port)
+  const aliases = [port.name, ...(port.port_hints ?? [])].filter(
+    (label): label is string => Boolean(label),
+  )
+  const usefulAlias = aliases.find(
+    (label) => label !== pinNumberName && scorePhrase(label) > 1,
+  )
+
+  return usefulAlias ?? port.name ?? pinNumberName ?? ""
+}
+
+const getComponentPinsHeaderDetail = (...parts: Array<string | undefined>) =>
+  parts.filter(Boolean).join(" ")
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -145,9 +164,17 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const detail = getComponentPinsHeaderDetail(
+          component.display_resistance,
+          footprint,
+        )
+        header = detail ? `${component.name} (${detail})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const detail = getComponentPinsHeaderDetail(
+          component.display_capacitance,
+          footprint,
+        )
+        header = detail ? `${component.name} (${detail})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }
@@ -156,14 +183,17 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
-        const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
+        const mainPin = getReadablePortName(port)
+        const pinNumberName = getPortPinNumberName(port)
+        const aliases = [port.name].filter(
+          (alias): alias is string => Boolean(alias) && alias !== mainPin,
+        )
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
+          if (hint === pinNumberName) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)
         }
+        if (pinNumberName && pinNumberName !== mainPin) aliases.push(pinNumberName)
         const aliasPart =
           aliases.length > 0
             ? `(${Array.from(new Set(aliases)).join(", ")})`

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -11,11 +11,14 @@ const wordQualityScore = {
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
+  SCK: 1.2,
+  SPI: 1.2,
   SDA: 1.2,
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  GP: 1.1,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +39,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/component-pins.test.tsx
+++ b/tests/component-pins.test.tsx
@@ -1,0 +1,35 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("uses descriptive numbered chip labels in component pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        manufacturerPartNumber="RP2040"
+        pinLabels={{
+          pin14: ["GP10", "GPIO10", "SPI1_SCK"],
+        }}
+      />
+    </board>,
+  )
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain(
+    "- GP10(GPIO10, SPI1_SCK, pin14): NOT_CONNECTED",
+  )
+  expect(netlist).not.toContain("- pin14(GP10")
+})
+
+it("doesn't output undefined for passive component pin headers", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <resistor resistance="1k" name="R1" />
+      <capacitor capacitance="1nF" name="C1" />
+    </board>,
+  )
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+})

--- a/tests/score-phrase.test.ts
+++ b/tests/score-phrase.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from "bun:test"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("keeps useful numbered pin labels above generic pin names", () => {
+  expect(scorePhrase("GP10")).toBeGreaterThan(1)
+  expect(scorePhrase("GPIO10")).toBeGreaterThan(1)
+  expect(scorePhrase("SPI1_SCK")).toBeGreaterThan(1)
+  expect(scorePhrase("pin14")).toBeLessThan(1)
+  expect(scorePhrase("14")).toBeLessThan(1)
+})

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(SCL, pin3): NETS(GND)
+    - GPIO2(SDA, pin4): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(UART_TX, pin6): NOT_CONNECTED
+    - GPIO5(UART_RX, pin7): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)


### PR DESCRIPTION
## Summary

Fixes #4.

/claim #4

This updates readable netlist generation so numbered but meaningful chip pin labels like `GP10`, `GPIO10`, and `SPI1_SCK` are preferred over generic `pin14` labels in `COMPONENT_PINS`. It also keeps the generic pin number as an alias, so the physical pin mapping remains visible.

The root cause was that `scorePhrase` returned the generic digit penalty before checking whether a label contained useful words such as GPIO/SPI/SCK, and the component pin table always used `pinN` as the primary label when a pin number existed.

I also fixed passive component pin headers so missing footprints do not render as `undefined`.

## Validation

- `npx --yes bun test` in a D: verification copy: 6 pass, 0 fail
- `npx biome check --formatter-enabled=false lib/convertCircuitJsonToReadableNetlist.ts lib/scorePhrase.ts tests/component-pins.test.tsx tests/score-phrase.test.ts tests/test2-chip.test.tsx`
- `npx --yes bun run build`