### PR TITLE
Render simple potentiometer descriptions

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,15 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const getPotentiometerValue = (component: {
+  display_value?: string
+  max_resistance?: number
+}) =>
+  component.display_value ??
+  (component.max_resistance !== undefined
+    ? `${component.max_resistance}Ω`
+    : undefined)
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -43,6 +52,14 @@ export const convertCircuitJsonToReadableNetlist = (
       componentDescription = `${component.display_capacitance}${
         footprint ? ` ${footprint}` : ""
       } capacitor`
+    } else if (component.ftype === "simple_potentiometer") {
+      componentDescription = [
+        getPotentiometerValue(component),
+        footprint,
+        "potentiometer",
+      ]
+        .filter(Boolean)
+        .join(" ")
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -148,6 +165,14 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
         header = `${component.name} (${component.display_capacitance} ${footprint})`
+      } else if (component.ftype === "simple_potentiometer") {
+        header = `${component.name} (${[
+          getPotentiometerValue(component),
+          footprint,
+          "potentiometer",
+        ]
+          .filter(Boolean)
+          .join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-potentiometer-description.test.ts
+++ b/tests/test4-potentiometer-description.test.ts
@@ -1,0 +1,65 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("renders simple potentiometers with readable descriptions", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_potentiometer",
+      source_component_id: "source_component_1",
+      name: "RV1",
+      max_resistance: 10000,
+      display_value: "10kΩ",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      pcb_component_id: "pcb_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "potentiometer_tht_3pin",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      layer: "top",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "CCW",
+      pin_number: 1,
+      port_hints: ["ccw", "pin1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "WIPER",
+      pin_number: 2,
+      port_hints: ["wiper", "pin2"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      name: "CW",
+      pin_number: 3,
+      port_hints: ["cw", "pin3"],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - RV1: 10kΩ potentiometer_tht_3pin potentiometer
+
+
+    COMPONENT_PINS:
+    RV1 (10kΩ potentiometer_tht_3pin potentiometer)
+    - pin1(CCW, ccw): NOT_CONNECTED
+    - pin2(WIPER, wiper): NOT_CONNECTED
+    - pin3(CW, cw): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- render `simple_potentiometer` components with value/footprint metadata instead of generic `source_component` text
- use the same readable potentiometer metadata in `COMPONENT_PINS` headers
- add raw Circuit JSON regression coverage for the potentiometer path

## Verification
- `npx --yes bun@1.2.17 test tests/test4-potentiometer-description.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-potentiometer-description.test.ts`
- `npm run build`
- `git diff --check`

Note: I did not rely on the existing TSX render fixture tests for this regression because the prior local runbook documented a pre-existing `@tscircuit/circuit-json-util` export mismatch in those fixtures; this test uses raw Circuit JSON to keep the new coverage isolated.