### PR TITLE
Use chip display value in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -44,10 +44,9 @@ export const convertCircuitJsonToReadableNetlist = (
         footprint ? ` ${footprint}` : ""
       } capacitor`
     } else if (component.ftype === "simple_chip") {
-      const manufacturerPartNumber = component.manufacturer_part_number
-      componentDescription = [manufacturerPartNumber, footprint]
-        .filter(Boolean)
-        .join(", ")
+      const chipLabel =
+        component.manufacturer_part_number ?? component.display_value
+      componentDescription = [chipLabel, footprint].filter(Boolean).join(", ")
     } else {
       componentDescription = [component.name, component.type]
         .filter(Boolean)
@@ -150,6 +149,8 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_capacitance} ${footprint})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
+      } else if (component.ftype === "simple_chip" && component.display_value) {
+        header = `${component.name} (${component.display_value})`
       }
       netlist.push(header)
       const ports = source_ports

--- a/tests/test4-chip-display-value.test.ts
+++ b/tests/test4-chip-display-value.test.ts
@@ -1,0 +1,41 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses chip display value when manufacturer part number is absent", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      display_value: "RP2040",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      pcb_component_id: "pcb_component_0",
+      source_component_id: "source_component_0",
+      position: { x: 0, y: 0, z: 0 },
+      footprinter_string: "qfn56",
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: RP2040, qfn56
+
+
+    COMPONENT_PINS:
+    U1 (RP2040)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- Use `simple_chip.display_value` as a readable chip label when `manufacturer_part_number` is absent.
- Keep manufacturer part numbers as the preferred chip label and keep footprint output unchanged.
- Add a raw Circuit JSON regression test covering a display-value-only chip with a CAD footprint.

## Why
A `simple_chip` can carry a useful `display_value`, but current readable output drops it if there is no `manufacturer_part_number`. For example, a chip with `display_value: "RP2040"` and footprint `qfn56` currently renders as only `U1: qfn56` in `COMPONENTS` and a bare `U1` header in `COMPONENT_PINS`. This change renders `U1: RP2040, qfn56` and `U1 (RP2040)`.

## Verification
- `bun test tests/test4-chip-display-value.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run build`
- `bunx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-chip-display-value.test.ts`
- `git diff --check`

/claim #4