### PR TITLE
Handle lowercase technical pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -39,8 +39,9 @@ export const scorePhrase = (phrase: string) => {
   if (phrase.match(/\d+/)) {
     return 0.5
   }
+  const normalizedPhrase = phrase.toLowerCase()
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toLowerCase())) {
       return score
     }
   }

--- a/tests/lowercase-technical-pin-labels.test.ts
+++ b/tests/lowercase-technical-pin-labels.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("includes lowercase technical pin hints in readable net entries", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["sda"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "J1",
+      manufacturer_part_number: "HEADER",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_sda")
+  expect(netlist).toContain("  - U1 pin14 (sda)")
+  expect(netlist).toContain("  - J1 pin1")
+  expect(netlist).not.toContain("  - J1 pin1 (pos)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- make known technical label scoring case-insensitive in `scorePhrase`
- keep numeric fallback and low-information labels such as `pos`, `neg`, `left`, and `right` unchanged
- add a raw Circuit JSON regression test for a generic physical pin carrying lowercase `sda`

## Why
Current main can generate `NET: U1_sda` from a lowercase technical hint, but the readable NET entry still prints only `U1 pin14` because `getReadableNameForPin` only includes hints with `scorePhrase(hint) > 1`. Uppercase `SDA` scores as meaningful, while lowercase `sda` falls back to the default score.

## Verification
- `bunx biome check lib\\scorePhrase.ts tests\\lowercase-technical-pin-labels.test.ts`
- `bun test`
- `bun run build`
- `bunx tsc --noEmit`
- `git diff --check`