### PR TITLE
Render simple pin header descriptions

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,23 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const formatPinHeaderDescription = ({
+  pinCount,
+  gender,
+  displayValue,
+  footprint,
+}: {
+  pinCount: number
+  gender?: string
+  displayValue?: string
+  footprint?: string
+}) => {
+  const headerType = [`${pinCount}-pin`, gender, "header"]
+    .filter(Boolean)
+    .join(" ")
+  return [displayValue, headerType, footprint].filter(Boolean).join(", ")
+}
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -48,6 +65,13 @@ export const convertCircuitJsonToReadableNetlist = (
       componentDescription = [manufacturerPartNumber, footprint]
         .filter(Boolean)
         .join(", ")
+    } else if (component.ftype === "simple_pin_header") {
+      componentDescription = formatPinHeaderDescription({
+        pinCount: component.pin_count,
+        gender: component.gender,
+        displayValue: component.display_value,
+        footprint,
+      })
     } else {
       componentDescription = [component.name, component.type]
         .filter(Boolean)
@@ -150,6 +174,14 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_capacitance} ${footprint})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
+      } else if (component.ftype === "simple_pin_header") {
+        const pinHeaderDescription = formatPinHeaderDescription({
+          pinCount: component.pin_count,
+          gender: component.gender,
+          displayValue: component.display_value,
+          footprint,
+        })
+        header = `${component.name} (${pinHeaderDescription})`
       }
       netlist.push(header)
       const ports = source_ports

--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -172,8 +172,6 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
         header = `${component.name} (${component.display_capacitance} ${footprint})`
-      } else if (component.manufacturer_part_number) {
-        header = `${component.name} (${component.manufacturer_part_number})`
       } else if (component.ftype === "simple_pin_header") {
         const pinHeaderDescription = formatPinHeaderDescription({
           pinCount: component.pin_count,
@@ -182,6 +180,8 @@ export const convertCircuitJsonToReadableNetlist = (
           footprint,
         })
         header = `${component.name} (${pinHeaderDescription})`
+      } else if (component.manufacturer_part_number) {
+        header = `${component.name} (${component.manufacturer_part_number})`
       }
       netlist.push(header)
       const ports = source_ports

--- a/tests/test4-pin-header-description.test.ts
+++ b/tests/test4-pin-header-description.test.ts
@@ -15,6 +15,7 @@ it("renders simple pin header descriptions", () => {
       source_component_id: "source_component_j1",
       ftype: "simple_pin_header",
       name: "J1",
+      manufacturer_part_number: "HDR-4",
       pin_count: 4,
       gender: "female",
       display_value: "I2C expansion",

--- a/tests/test4-pin-header-description.test.ts
+++ b/tests/test4-pin-header-description.test.ts
@@ -1,0 +1,79 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("renders simple pin header descriptions", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_j1",
+      ftype: "simple_pin_header",
+      name: "J1",
+      pin_count: 4,
+      gender: "female",
+      display_value: "I2C expansion",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_j1",
+      pcb_component_id: "pcb_component_j1",
+      source_component_id: "source_component_j1",
+      position: { x: 0, y: 0, z: 0 },
+      footprinter_string: "pinrow4_p2.54",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_1",
+      source_component_id: "source_component_j1",
+      pin_number: 1,
+      name: "pin1",
+      port_hints: ["SDA"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_2",
+      source_component_id: "source_component_j1",
+      pin_number: 2,
+      name: "pin2",
+      port_hints: ["SCL"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_3",
+      source_component_id: "source_component_j1",
+      pin_number: 3,
+      name: "pin3",
+      port_hints: ["VCC"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_4",
+      source_component_id: "source_component_j1",
+      pin_number: 4,
+      name: "pin4",
+      port_hints: ["GND"],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - J1: I2C expansion, 4-pin female header, pinrow4_p2.54
+
+
+    COMPONENT_PINS:
+    J1 (I2C expansion, 4-pin female header, pinrow4_p2.54)
+    - pin1(SDA): NOT_CONNECTED
+    - pin2(SCL): NOT_CONNECTED
+    - pin3(VCC): NOT_CONNECTED
+    - pin4(GND): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- render `simple_pin_header` components with pin count, gender, display value, and footprint metadata in `COMPONENTS`
- use the same readable metadata in `COMPONENT_PINS` headers
- add raw Circuit JSON regression coverage for the pin-header path

## Verification
- `npm exec --yes bun@1.2.17 -- test tests/test4-pin-header-description.test.ts`
- `./node_modules/.bin/biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-pin-header-description.test.ts`
- `npm exec --yes bun@1.2.17 -- test`
- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
- `git diff --check`