### PR TITLE
Render pin header metadata in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,31 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const getPinHeaderDescription = ({
+  pinCount,
+  gender,
+  displayValue,
+  manufacturerPartNumber,
+  footprint,
+}: {
+  pinCount?: number
+  gender?: string
+  displayValue?: string
+  manufacturerPartNumber?: string
+  footprint?: string
+}) => {
+  const pinHeaderText = [
+    pinCount !== undefined ? `${pinCount}-pin` : undefined,
+    gender,
+    displayValue,
+    footprint,
+    "pin header",
+  ]
+    .filter(Boolean)
+    .join(" ")
+  return [manufacturerPartNumber, pinHeaderText].filter(Boolean).join(", ")
+}
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -48,6 +73,14 @@ export const convertCircuitJsonToReadableNetlist = (
       componentDescription = [manufacturerPartNumber, footprint]
         .filter(Boolean)
         .join(", ")
+    } else if (component.ftype === "simple_pin_header") {
+      componentDescription = getPinHeaderDescription({
+        pinCount: component.pin_count,
+        gender: component.gender,
+        displayValue: component.display_value,
+        manufacturerPartNumber: component.manufacturer_part_number,
+        footprint,
+      })
     } else {
       componentDescription = [component.name, component.type]
         .filter(Boolean)
@@ -148,6 +181,14 @@ export const convertCircuitJsonToReadableNetlist = (
         header = `${component.name} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
         header = `${component.name} (${component.display_capacitance} ${footprint})`
+      } else if (component.ftype === "simple_pin_header") {
+        header = `${component.name} (${getPinHeaderDescription({
+          pinCount: component.pin_count,
+          gender: component.gender,
+          displayValue: component.display_value,
+          manufacturerPartNumber: component.manufacturer_part_number,
+          footprint,
+        })})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-pin-header-description.test.ts
+++ b/tests/test4-pin-header-description.test.ts
@@ -1,0 +1,72 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("renders simple pin header metadata in readable netlists", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_pin_header",
+      source_component_id: "source_component_j1",
+      name: "J1",
+      manufacturer_part_number: "HDR-4F",
+      display_value: "shrouded",
+      pin_count: 4,
+      gender: "female",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_j1",
+      source_component_id: "source_component_j1",
+      footprinter_string: "pinrow4",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_1",
+      source_component_id: "source_component_j1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_2",
+      source_component_id: "source_component_j1",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["pin2", "2"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_3",
+      source_component_id: "source_component_j1",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["pin3", "3"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_4",
+      source_component_id: "source_component_j1",
+      name: "pin4",
+      pin_number: 4,
+      port_hints: ["pin4", "4"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - J1: HDR-4F, 4-pin female shrouded pinrow4 pin header
+
+
+    COMPONENT_PINS:
+    J1 (HDR-4F, 4-pin female shrouded pinrow4 pin header)
+    - pin1: NOT_CONNECTED
+    - pin2: NOT_CONNECTED
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- render `simple_pin_header` components with `pin_count`, `gender`, display value, manufacturer part number, and footprint metadata in `COMPONENTS`
- use the same readable pin-header metadata in `COMPONENT_PINS` headers, even when a pin header has a manufacturer part number
- add raw Circuit JSON regression coverage for the pin-header path

## Verification
- `bun test tests/test4-pin-header-description.test.ts`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-pin-header-description.test.ts`
- `bun run build`
- `git diff --check`

No public payment details are included; payout should stay inside the Algora bounty flow if this is rewarded.