### PR TITLE
Recognize USB-C power and configuration pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -8,6 +8,8 @@
  * These unique port names are usually the best indicator of what the net is for
  */
 const wordQualityScore = {
+  VBUS: 1.2,
+  VCONN: 1.2,
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
@@ -31,11 +33,22 @@ const wordQualityScore = {
   right: 0.3,
 }
 
+const exactPhraseScore = {
+  CC1: 1.2,
+  CC2: 1.2,
+  SBU1: 1.2,
+  SBU2: 1.2,
+}
+
 const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
 export const scorePhrase = (phrase: string) => {
+  const exactScore = exactPhraseScore[phrase as keyof typeof exactPhraseScore]
+  if (exactScore !== undefined) {
+    return exactScore
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-usbc-control-pin-labels.test.ts
+++ b/tests/test4-usbc-control-pin-labels.test.ts
@@ -1,0 +1,172 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("includes USB-C power and control labels on generic pin net entries", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_j1",
+      name: "J1",
+      manufacturer_part_number: "USB-C",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_vbus",
+      source_component_id: "source_component_u1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["VBUS"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_vbus",
+      source_component_id: "source_component_j1",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["VBUS"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_vconn",
+      source_component_id: "source_component_u1",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["VCONN"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_vconn",
+      source_component_id: "source_component_j1",
+      name: "pin4",
+      pin_number: 4,
+      port_hints: ["VCONN"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_cc1",
+      source_component_id: "source_component_u1",
+      name: "pin5",
+      pin_number: 5,
+      port_hints: ["CC1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_cc1",
+      source_component_id: "source_component_j1",
+      name: "pin6",
+      pin_number: 6,
+      port_hints: ["CC1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_cc2",
+      source_component_id: "source_component_u1",
+      name: "pin7",
+      pin_number: 7,
+      port_hints: ["CC2"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_cc2",
+      source_component_id: "source_component_j1",
+      name: "pin8",
+      pin_number: 8,
+      port_hints: ["CC2"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_sbu1",
+      source_component_id: "source_component_u1",
+      name: "pin9",
+      pin_number: 9,
+      port_hints: ["SBU1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_sbu1",
+      source_component_id: "source_component_j1",
+      name: "pin10",
+      pin_number: 10,
+      port_hints: ["SBU1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_sbu2",
+      source_component_id: "source_component_u1",
+      name: "pin11",
+      pin_number: 11,
+      port_hints: ["SBU2"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_sbu2",
+      source_component_id: "source_component_j1",
+      name: "pin12",
+      pin_number: 12,
+      port_hints: ["SBU2"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_vbus",
+      connected_source_port_ids: ["source_port_u1_vbus", "source_port_j1_vbus"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_vconn",
+      connected_source_port_ids: [
+        "source_port_u1_vconn",
+        "source_port_j1_vconn",
+      ],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_cc1",
+      connected_source_port_ids: ["source_port_u1_cc1", "source_port_j1_cc1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_cc2",
+      connected_source_port_ids: ["source_port_u1_cc2", "source_port_j1_cc2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_sbu1",
+      connected_source_port_ids: ["source_port_u1_sbu1", "source_port_j1_sbu1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_sbu2",
+      connected_source_port_ids: ["source_port_u1_sbu2", "source_port_j1_sbu2"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_VBUS")
+  expect(netlist).toContain("NET: U1_VCONN")
+  expect(netlist).toContain("NET: U1_CC1")
+  expect(netlist).toContain("NET: U1_CC2")
+  expect(netlist).toContain("NET: U1_SBU1")
+  expect(netlist).toContain("NET: U1_SBU2")
+  expect(netlist).toContain("  - U1 pin1 (VBUS)")
+  expect(netlist).toContain("  - U1 pin3 (VCONN)")
+  expect(netlist).toContain("  - U1 pin5 (CC1)")
+  expect(netlist).toContain("  - U1 pin7 (CC2)")
+  expect(netlist).toContain("  - U1 pin9 (SBU1)")
+  expect(netlist).toContain("  - U1 pin11 (SBU2)")
+})


### PR DESCRIPTION
## Summary
- recognize `VBUS` and `VCONN` as high-quality readable power pin hints
- keep `CC1`, `CC2`, `SBU1`, and `SBU2` above generic `pinN` labels despite their digits
- add a focused raw Circuit JSON regression test covering USB-C power/configuration nets

/claim #4

## Verification
- `bun test tests/test4-usbc-control-pin-labels.test.ts`
- `bun x biome check lib/scorePhrase.ts tests/test4-usbc-control-pin-labels.test.ts`
- `bun test`
- `bun run build`
- `git diff --check`