### PR TITLE
Improve readable netlist pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-readable-label-regression.test.ts
+++ b/tests/test4-readable-label-regression.test.ts
@@ -1,0 +1,77 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses meaningful chip pin hints and omits undefined passive footprint details", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_u1",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_pin14",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GP10_SPI1SCK_I2C1SDA", "pin14", "14"],
+      source_component_id: "source_component_u1",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_r1",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_pin1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+      source_component_id: "source_component_r1",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: [
+        "source_port_u1_pin14",
+        "source_port_r1_pin1",
+      ],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("U1 pin14 (GP10_SPI1SCK_I2C1SDA)")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: RP2040
+     - R1: 1kΩ resistor
+
+    NET: U1_GP10_SPI1SCK_I2C1SDA
+      - U1 pin14 (GP10_SPI1SCK_I2C1SDA)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (RP2040)
+    - pin14(GP10_SPI1SCK_I2C1SDA): NETS(U1_GP10_SPI1SCK_I2C1SDA)
+
+    R1 (1kΩ)
+    - pin1(anode, pos, left): NETS(U1_GP10_SPI1SCK_I2C1SDA)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary

This improves readable netlist output for the issue #4 cases by keeping descriptive pin labels such as `GP10_SPI1SCK_I2C1SDA` from being downgraded to generic `pin14` output, while also avoiding `undefined` in resistor/capacitor component descriptions when footprint information is missing.

## Changes

- Score known signal words before applying the generic digit penalty, so useful compound pin labels remain visible.
- Omit missing passive footprint detail instead of rendering `undefined`.
- Add a regression test that covers both the long pin-label behavior and the missing-footprint `undefined` case.

## Verification

- `npx --yes bun test tests/test4-readable-label-regression.test.ts`
- `npx --yes bun test`
- `npx --yes bun x biome check .`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun run build`
- `git diff --check`
