### PR TITLE
Score power-management pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -7,6 +7,10 @@
  *
  * These unique port names are usually the best indicator of what the net is for
  */
+const exactWordQualityScore = {
+  EN: 1.1,
+}
+
 const wordQualityScore = {
   MISO: 1.2,
   MOSI: 1.2,
@@ -16,6 +20,12 @@ const wordQualityScore = {
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  PGOOD: 1.15,
+  PWR_OK: 1.15,
+  POWER_GOOD: 1.15,
+  ENABLE: 1.1,
+  SHDN: 1.1,
+  WAKE: 1.1,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -35,7 +45,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const exactWordQualityScoreEntries = Object.entries(exactWordQualityScore).sort(
+  (a, b) => b[1] - a[1],
+)
+
 export const scorePhrase = (phrase: string) => {
+  const exactWords = phrase.split(/[^A-Za-z0-9]+/).filter(Boolean)
+  for (const [word, score] of exactWordQualityScoreEntries) {
+    if (exactWords.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-power-management-pin-aliases.test.ts
+++ b/tests/test4-power-management-pin-aliases.test.ts
@@ -1,0 +1,68 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("shows power-management aliases on generic numbered pins", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_pmic",
+      name: "U1",
+      manufacturer_part_number: "TPS62840",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_mcu",
+      name: "U2",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_pmic_pgood",
+      source_component_id: "source_component_pmic",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "PGOOD", "PWR_OK"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_mcu_enable",
+      source_component_id: "source_component_mcu",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["pin2", "EN", "WAKE"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_pgood",
+      connected_source_port_ids: [
+        "source_port_pmic_pgood",
+        "source_port_mcu_enable",
+      ],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: TPS62840
+     - U2: RP2040
+
+    NET: U1_PGOOD
+      - U1 pin14 (PGOOD,PWR_OK)
+      - U2 pin2 (EN,WAKE)
+
+
+    COMPONENT_PINS:
+    U1 (TPS62840)
+    - pin14(PGOOD, PWR_OK): NETS(U1_PGOOD)
+
+    U2 (RP2040)
+    - pin2(EN, WAKE): NETS(U1_PGOOD)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- Recognize common power-management control/status aliases (`PGOOD`, `PWR_OK`, `POWER_GOOD`, `ENABLE`, `EN`, `SHDN`, `WAKE`) as readable pin labels.
- Keep short `EN` matching limited to a standalone token so unrelated words are not over-scored.
- Add raw Circuit JSON regression coverage showing generic numbered pins render the PMIC aliases in NET and COMPONENT_PINS output.

## Verification
- `bun test tests/test4-power-management-pin-aliases.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check lib/scorePhrase.ts tests/test4-power-management-pin-aliases.test.ts`
- `bun run build`
- `git diff --check`

/claim #4