### PR TITLE
fix: preserve readable chip pin labels

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -34,6 +34,12 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
+  const componentName =
+    component.name ??
+    ("manufacturer_part_number" in component
+      ? component.manufacturer_part_number
+      : undefined) ??
+    component.source_component_id
   const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
 
   const additionalPinLabels: string[] = []
@@ -47,7 +53,7 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score >= 1) {
       additionalPinLabels.push(port_hint)
     }
   }
@@ -55,5 +61,5 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  return `${componentName} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (/^(pin)?\d+$/i.test(phrase)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/get-readable-name-for-pin.test.ts
+++ b/tests/get-readable-name-for-pin.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("uses full chip pin labels instead of short pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "GP14", "SPI_RX"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("RP2040 pin14 (GP14,SPI_RX)")
+})


### PR DESCRIPTION
Fixes #4

Preserves readable chip pin labels such as `GP14` and `SPI_RX` instead of dropping them when the primary pin name is only `pin14`.

Changes:
- score known signal labels before penalizing bare numeric pin names
- include neutral readable port hints in pin output
- fall back to `manufacturer_part_number` when a chip has no component name
- add a focused regression test for full chip pin labels

Tested:
- `tsc --noEmit`
- `biome check lib/getReadableNameForPin.ts lib/scorePhrase.ts tests/get-readable-name-for-pin.test.ts`
- `bun test`
