### PR TITLE
Fix readable labels for short chip pins

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,9 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${[component.display_resistance, footprint].filter(Boolean).join(" ")})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${[component.display_capacitance, footprint].filter(Boolean).join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -46,6 +46,15 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (port_hint === `pin${port.pin_number}`) continue
+    if (port_hint === String(port.pin_number)) continue
+    if (
+      component.ftype !== "simple_resistor" &&
+      component.ftype !== "simple_capacitor"
+    ) {
+      additionalPinLabels.push(port_hint)
+      continue
+    }
     const score = scorePhrase(port_hint)
     if (score > 1) {
       additionalPinLabels.push(port_hint)
@@ -55,5 +64,5 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${Array.from(new Set(additionalPinLabels)).join(",")})` : ""}${displayValue}`
 }

--- a/tests/test4-short-pin-labels.test.tsx
+++ b/tests/test4-short-pin-labels.test.tsx
@@ -1,0 +1,58 @@
+import { expect, it } from "bun:test"
+import type { SourcePort } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("keeps short chip pin labels and omits undefined footprints", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip name="U1" footprint="soic8" pinLabels={{ pin4: ["D0"] }} />
+      <resistor name="R1" resistance="1k" />
+      <trace from=".U1 .D0" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  const d0Port = circuitJson.find(
+    (element): element is SourcePort =>
+      element.type === "source_port" && element.name === "D0",
+  )
+  expect(d0Port).toBeDefined()
+
+  d0Port!.name = "pin4"
+  d0Port!.port_hints = ["D0", "pin4", "4"]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: soic8
+     - R1: 1kΩ resistor
+
+    NET: R1_pos
+      - U1 pin4 (D0)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1
+    - pin1: NOT_CONNECTED
+    - pin2: NOT_CONNECTED
+    - pin3: NOT_CONNECTED
+    - pin4(D0): NETS(R1_pos)
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ)
+    - pin1(anode, pos, left): NETS(R1_pos)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- keep short semantic chip pin hints like D0 in readable netlist entries when the source port name is only the physical pin
- omit undefined footprints from resistor/capacitor COMPONENT_PINS headers
- add regression coverage for short labels and missing footprints

## Test
- bun test
- bun run build

/claim #4
Fixes #4

AI assistance disclosure: I used Codex to help inspect the issue, implement the patch, and run validation. I reviewed the diff and tests before opening this PR.