### PR TITLE
Score QSPI flash pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const qspiFlashSignalPatterns = [
+  /^(?:Q?SPI_)?(?:IO|SIO)[0-3]$/,
+  /^QSPI_D[0-3]$/,
+  /^Q?SPI_(?:CS|CS_N|CSN|CLK|SCLK)$/,
+  /^(?:Q?SPI_)?(?:WP|HOLD|RESET)_N$/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.trim().toUpperCase()
+  if (
+    qspiFlashSignalPatterns.some((pattern) => pattern.test(normalizedPhrase))
+  ) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,7 +36,7 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 const qspiFlashSignalPatterns = [
-  /^(?:Q?SPI_)?(?:IO|SIO)[0-3]$/,
+  /^Q?SPI_(?:IO|SIO)[0-3]$/,
   /^QSPI_D[0-3]$/,
   /^Q?SPI_(?:CS|CS_N|CSN|CLK|SCLK)$/,
   /^(?:Q?SPI_)?(?:WP|HOLD|RESET)_N$/,

--- a/tests/test4-qspi-flash-pin-labels.test.ts
+++ b/tests/test4-qspi-flash-pin-labels.test.ts
@@ -1,0 +1,128 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("keeps QSPI flash aliases above generic pin labels", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      manufacturer_part_number: "MCU_WITH_QSPI",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u2",
+      name: "U2",
+      manufacturer_part_number: "SPI_FLASH",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_io0",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["QSPI_IO0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_io1",
+      source_component_id: "source_component_u1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["QSPI_IO1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_wp",
+      source_component_id: "source_component_u1",
+      name: "pin16",
+      pin_number: 16,
+      port_hints: ["QSPI_WP_N"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_hold",
+      source_component_id: "source_component_u1",
+      name: "pin17",
+      pin_number: 17,
+      port_hints: ["QSPI_HOLD_N"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u2_io0",
+      source_component_id: "source_component_u2",
+      name: "pin5",
+      pin_number: 5,
+      port_hints: ["IO0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u2_io1",
+      source_component_id: "source_component_u2",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["IO1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u2_wp",
+      source_component_id: "source_component_u2",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["WP_N"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u2_hold",
+      source_component_id: "source_component_u2",
+      name: "pin7",
+      pin_number: 7,
+      port_hints: ["HOLD_N"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_io0",
+      connected_source_port_ids: ["source_port_u1_io0", "source_port_u2_io0"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_io1",
+      connected_source_port_ids: ["source_port_u1_io1", "source_port_u2_io1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_wp",
+      connected_source_port_ids: ["source_port_u1_wp", "source_port_u2_wp"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_hold",
+      connected_source_port_ids: ["source_port_u1_hold", "source_port_u2_hold"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson as any)
+
+  expect(netlist).toContain("NET: U1_QSPI_IO0")
+  expect(netlist).toContain("  - U1 pin14 (QSPI_IO0)")
+  expect(netlist).toContain("  - U2 pin5 (IO0)")
+  expect(netlist).toContain("- pin14(QSPI_IO0): NETS(U1_QSPI_IO0)")
+
+  expect(netlist).toContain("NET: U1_QSPI_IO1")
+  expect(netlist).toContain("  - U1 pin15 (QSPI_IO1)")
+  expect(netlist).toContain("  - U2 pin2 (IO1)")
+
+  expect(netlist).toContain("NET: U1_QSPI_WP_N")
+  expect(netlist).toContain("  - U1 pin16 (QSPI_WP_N)")
+  expect(netlist).toContain("  - U2 pin3 (WP_N)")
+
+  expect(netlist).toContain("NET: U1_QSPI_HOLD_N")
+  expect(netlist).toContain("  - U1 pin17 (QSPI_HOLD_N)")
+  expect(netlist).toContain("  - U2 pin7 (HOLD_N)")
+})

--- a/tests/test4-qspi-flash-pin-labels.test.ts
+++ b/tests/test4-qspi-flash-pin-labels.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "bun:test"
 import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
 
 it("keeps QSPI flash aliases above generic pin labels", () => {
   const circuitJson = [
@@ -111,12 +112,12 @@ it("keeps QSPI flash aliases above generic pin labels", () => {
 
   expect(netlist).toContain("NET: U1_QSPI_IO0")
   expect(netlist).toContain("  - U1 pin14 (QSPI_IO0)")
-  expect(netlist).toContain("  - U2 pin5 (IO0)")
+  expect(netlist).toContain("  - U2 pin5")
   expect(netlist).toContain("- pin14(QSPI_IO0): NETS(U1_QSPI_IO0)")
 
   expect(netlist).toContain("NET: U1_QSPI_IO1")
   expect(netlist).toContain("  - U1 pin15 (QSPI_IO1)")
-  expect(netlist).toContain("  - U2 pin2 (IO1)")
+  expect(netlist).toContain("  - U2 pin2")
 
   expect(netlist).toContain("NET: U1_QSPI_WP_N")
   expect(netlist).toContain("  - U1 pin16 (QSPI_WP_N)")
@@ -125,4 +126,11 @@ it("keeps QSPI flash aliases above generic pin labels", () => {
   expect(netlist).toContain("NET: U1_QSPI_HOLD_N")
   expect(netlist).toContain("  - U1 pin17 (QSPI_HOLD_N)")
   expect(netlist).toContain("  - U2 pin7 (HOLD_N)")
+})
+
+it("does not score bare IO labels as QSPI flash aliases", () => {
+  expect(scorePhrase("IO0")).toBeLessThan(scorePhrase("BOOT"))
+  expect(scorePhrase("SIO0")).toBeLessThan(scorePhrase("BOOT"))
+  expect(scorePhrase("QSPI_IO0")).toBeGreaterThan(scorePhrase("BOOT"))
+  expect(scorePhrase("SPI_SIO0")).toBeGreaterThan(scorePhrase("BOOT"))
 })


### PR DESCRIPTION
## Summary
- add a focused QSPI/SPI-flash scorer guard for aliases such as `QSPI_IO0`, `QSPI_IO1`, `QSPI_WP_N`, and `QSPI_HOLD_N`
- keep those aliases above generic physical names like `pin14` when generating NET names and readable pin entries
- add raw Circuit JSON regression coverage for QSPI flash data/control pins

## Verification
- `bun test tests/test4-qspi-flash-pin-labels.test.ts`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/test4-qspi-flash-pin-labels.test.ts`
- `git diff --check`
- `bun test`
- `bun run build`

## Notes
AI-assisted with Codex; I reviewed the diff and verification locally before opening this PR. This is intentionally separate from my PCIe lane/control PR #124 and from the existing USB, MIPI, SD/MMC, CAN/LIN, JTAG, UART, reset/control, analog, and display-alias PR scopes.

/claim #4