### PR TITLE
Score thermal pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,9 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  if (phrase.match(/^(TS\d*|TEMP\d*|THERM\d*|NTC\d*|PTC\d*)$/i)) {
+    return 1.15
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-thermal-pin-labels.test.ts
+++ b/tests/test4-thermal-pin-labels.test.ts
@@ -1,0 +1,55 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("keeps thermal sensor aliases for generic numbered chip pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "BQ76952",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["TS1", "THERM"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      display_resistance: "10k",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_TS1")
+  expect(netlist).toContain("  - U1 pin14 (TS1,THERM)")
+  expect(netlist).not.toContain("NET: U1_pin14")
+})


### PR DESCRIPTION
## Summary
- add a focused score for thermal sensor aliases (`TS*`, `TEMP*`, `THERM*`, `NTC*`, `PTC*`) before the numeric fallback
- add regression coverage for a generic numbered chip pin carrying `TS1`/`THERM` hints

## Verification
- `npx bun test ./tests/test4-thermal-pin-labels.test.ts`
- `npx bun test`
- `npx bun x tsc --noEmit`
- `npx bun run build`

Transparency: AI-assisted with Codex, reviewed before submission.

/claim #4