### PR TITLE
Fix generic pin label display

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,49 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const lowInformationPinHints = new Set([
+  "anode",
+  "cathode",
+  "left",
+  "neg",
+  "negative",
+  "pos",
+  "positive",
+  "right",
+])
+
+const isGenericPinReference = (name: string, pinNumber?: number) => {
+  const normalizedName = name.trim().toLowerCase()
+  return (
+    normalizedName === "pin" ||
+    normalizedName === `pin${pinNumber}` ||
+    normalizedName === String(pinNumber)
+  )
+}
+
+const shouldIncludePinHint = ({
+  hint,
+  mainPinName,
+  pinNumber,
+}: {
+  hint: string
+  mainPinName: string
+  pinNumber?: number
+}) => {
+  const normalizedHint = hint.trim().toLowerCase()
+  if (!normalizedHint) return false
+  if (hint === mainPinName) return false
+  if (isGenericPinReference(hint, pinNumber)) return false
+
+  if (scorePhrase(hint) > 1) return true
+
+  return (
+    isGenericPinReference(mainPinName, pinNumber) &&
+    !lowInformationPinHints.has(normalizedHint) &&
+    /[a-z]/i.test(hint)
+  )
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -45,9 +88,14 @@ export const getReadableNameForPin = ({
   }
 
   for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (
+      shouldIncludePinHint({
+        hint: port_hint,
+        mainPinName,
+        pinNumber: port.pin_number,
+      }) &&
+      !additionalPinLabels.includes(port_hint)
+    ) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/test4-generic-pin-labels.test.ts
+++ b/tests/test4-generic-pin-labels.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("includes useful labels for generic pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "14", "GPIO10", "SPI1_SCK"],
+    },
+  ]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (GPIO10,SPI1_SCK)")
+})

--- a/tests/test4-generic-pin-labels.test.ts
+++ b/tests/test4-generic-pin-labels.test.ts
@@ -1,8 +1,9 @@
 import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
 import { getReadableNameForPin } from "lib/getReadableNameForPin"
 
 it("includes useful labels for generic pin names", () => {
-  const circuitJson = [
+  const circuitJson: AnyCircuitElement[] = [
     {
       type: "source_component",
       source_component_id: "source_component_0",


### PR DESCRIPTION
## Summary
- Include useful non-generic `port_hints` when a port's primary name is a generic `pinN` label, so readable netlists can show labels like `GPIO10` and `SPI1_SCK` instead of only `pin14`.
- Filter duplicate/generic numeric hints and low-information passive hints.
- Add a regression test for generic pin labels.

Fixes tscircuit/circuit-json-to-readable-netlist#4
/claim tscircuit/circuit-json-to-readable-netlist#4

## Review & Testing Checklist for Human
- [ ] Verify the generic `pin14` regression case now emits the useful labels in the readable pin output.
- [ ] Confirm passive/resistor/capacitor pin labels still remain concise and existing snapshots are unchanged.
- [ ] Run `bun test` and `bun run build` locally or via CI.

### Notes
Tested locally:
- `bun test`
- `bun run build`
- `bun run format:check`