### PR TITLE
Score touch sensor pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const touchAndProximityAliasPattern =
+  /^(?:(?:CAP|CAPACITIVE)[_-]?)?(?:TOUCH\d*|CAP[_-]?SENSE\d*|CAPSENSE\d*|CSD\d*|CSX\d*|CTSU\d*|PROX(?:IMITY)?(?:[_-]?(?:INT|IN|OUT|\d+))?)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (touchAndProximityAliasPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/touch-proximity-pin-labels.test.tsx
+++ b/tests/touch-proximity-pin-labels.test.tsx
@@ -1,0 +1,32 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves capacitive touch pin aliases in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="AT42QT2120"
+        pinLabels={{
+          pin1: ["pin14", "TOUCH0"],
+          pin2: ["pin15", "CAPSENSE0"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .TOUCH0" to=".R1 > .pin1" />
+      <trace from=".U1 .CAPSENSE0" to=".R1 > .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_TOUCH0")
+  expect(netlist).toContain("  - U1 pin14 (TOUCH0)")
+  expect(netlist).toContain("NET: U1_CAPSENSE0")
+  expect(netlist).toContain("  - U1 pin15 (CAPSENSE0)")
+  expect(netlist).toContain("- pin1(pin14, TOUCH0): NETS(U1_TOUCH0)")
+  expect(netlist).toContain("- pin2(pin15, CAPSENSE0): NETS(U1_CAPSENSE0)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for capacitive touch/proximity aliases such as `TOUCH0`, `CAPSENSE0`, `CSD0`, `CSX0`, `CTSU0`, and `PROX_INT`
- cover readable NET names, NET pin labels, and COMPONENT_PINS output for touch-sensing aliases

## Verification
- `npm exec --yes bun -- test tests/touch-proximity-pin-labels.test.tsx`
- `npm exec --yes bun -- test`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/touch-proximity-pin-labels.test.tsx`
- `npm exec --yes bun -- run build`
- `git diff --check`

/claim #4