### PR TITLE
Score quadrature encoder pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const quadratureEncoderAliasPattern =
+  /^(?:QEA\d*|QEB\d*|QEI\d*|ENC(?:ODER)?[_-]?[ABZ]\d*|ENC(?:ODER)?[_-]?(?:INDEX|IDX)\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (quadratureEncoderAliasPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/quadrature-encoder-pin-labels.test.tsx
+++ b/tests/quadrature-encoder-pin-labels.test.tsx
@@ -1,0 +1,32 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves quadrature encoder pin aliases in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="STM32G0"
+        pinLabels={{
+          pin1: ["pin14", "QEA0"],
+          pin2: ["pin15", "QEB0"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .QEA0" to=".R1 > .pin1" />
+      <trace from=".U1 .QEB0" to=".R1 > .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_QEA0")
+  expect(netlist).toContain("  - U1 pin14 (QEA0)")
+  expect(netlist).toContain("NET: U1_QEB0")
+  expect(netlist).toContain("  - U1 pin15 (QEB0)")
+  expect(netlist).toContain("- pin1(pin14, QEA0): NETS(U1_QEA0)")
+  expect(netlist).toContain("- pin2(pin15, QEB0): NETS(U1_QEB0)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for quadrature encoder aliases such as `QEA0`, `QEB0`, `QEI0`, `ENC_A`, `ENC_B`, and `ENC_IDX`
- cover readable NET names, NET pin labels, and COMPONENT_PINS output for encoder channel aliases

## Verification
- `npm exec --yes bun -- test tests/quadrature-encoder-pin-labels.test.tsx`
- `npm exec --yes bun -- test`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/quadrature-encoder-pin-labels.test.tsx`
- `npm exec --yes bun -- run build`
- `git diff --check`

/claim #4