### PR TITLE
Add 1-Wire pin label scoring

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,29 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const oneWirePinAliases = new Set([
+  "1W",
+  "1WDQ",
+  "1WIO",
+  "1WIRE",
+  "1WIREDQ",
+  "1WIREIO",
+  "ONEWIRE",
+  "ONEWIREDQ",
+  "ONEWIREIO",
+  "OW",
+  "OWDQ",
+  "OWIO",
+  "DQ",
+])
+
+const getNormalizedPinAlias = (phrase: string) =>
+  phrase.replace(/[^a-zA-Z0-9]/g, "").toUpperCase()
+
 export const scorePhrase = (phrase: string) => {
+  if (oneWirePinAliases.has(getNormalizedPinAlias(phrase))) {
+    return 1.15
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-one-wire-pin-labels.test.ts
+++ b/tests/test4-one-wire-pin-labels.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+
+test("1-Wire aliases score above generic numbered pins", () => {
+  for (const alias of ["1WIRE_DQ", "ONEWIRE", "1W_DQ", "OW_IO", "DQ"]) {
+    expect(scorePhrase(alias)).toBeGreaterThan(1)
+  }
+  expect(scorePhrase("pin14")).toBe(0.5)
+})
+
+test("keeps 1-Wire data aliases for generic numbered chip pins", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_sensor",
+      name: "U1",
+      manufacturer_part_number: "DS18B20",
+    } as any,
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_controller",
+      name: "U2",
+      manufacturer_part_number: "MCU",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "source_port_sensor_dq",
+      source_component_id: "source_component_sensor",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["1WIRE_DQ"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_controller_dq",
+      source_component_id: "source_component_controller",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["OW_IO"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_one_wire",
+      connected_source_port_ids: [
+        "source_port_sensor_dq",
+        "source_port_controller_dq",
+      ],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: DS18B20
+     - U2: MCU
+
+    NET: U1_1WIRE_DQ
+      - U1 pin2 (1WIRE_DQ)
+      - U2 pin14 (OW_IO)
+
+
+    COMPONENT_PINS:
+    U1 (DS18B20)
+    - pin2(1WIRE_DQ): NETS(U1_1WIRE_DQ)
+
+    U2 (MCU)
+    - pin14(OW_IO): NETS(U1_1WIRE_DQ)
+    "
+  `)
+})


### PR DESCRIPTION
Fixes #4
/claim #4

## Summary
- Add focused 1-Wire / Dallas sensor alias scoring for `1W`, `1WIRE`, `1WIRE_DQ`, `ONEWIRE`, `OW_IO`, and `DQ`.
- Preserve useful 1-Wire data labels in generated NET names and readable NET entries instead of falling back to generic numbered pins or the other endpoint.
- Add raw Circuit JSON regression coverage for generic chip pins carrying `1WIRE_DQ` and `OW_IO` hints.

## Verification
- `bun test tests/test4-one-wire-pin-labels.test.ts`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/test4-one-wire-pin-labels.test.ts`
- `bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and verification locally before submission.
