### PR TITLE
Preserve alphanumeric pin labels in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.toUpperCase()
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-full-pin-labels.test.ts
+++ b/tests/test4-full-pin-labels.test.ts
@@ -1,0 +1,31 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("keeps alphanumeric chip pin labels readable", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "GPIO14", "SCL"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(scorePhrase("GPIO14")).toBeGreaterThan(1)
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 pin14 (GPIO14,SCL)")
+})


### PR DESCRIPTION
Fixes #4

## Summary

`scorePhrase` currently returns a low score for any phrase containing a digit before checking useful electrical words. That means labels like `GPIO14`, `V3`, or `SCL1` can be dropped from readable pin names, leaving output like `pin14` without the full pin label.

This changes scoring to check known electrical terms case-insensitively before falling back to the numeric penalty, so alphanumeric pin labels remain readable while plain numeric hints still stay low priority.

## Verification

```bash
npm exec --yes bun test tests/test4-full-pin-labels.test.ts
npm exec tsc -- --noEmit
```

Full `bun test` still fails in existing tests on this checkout because `@tscircuit/circuit-json-util` is missing the `distanceBetweenCircleAndPolygon` export expected by existing dependencies; the new focused regression test passes.