### PR TITLE
Preserve SIM/UICC aliases in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const simCardSignalPattern =
+  /(^|[_-])(SIM|USIM|UICC|ISO7816)([_-]?(IO|CLK|RST|RESET|VCC|DET|PRES|PRESENT|DATA))?($|[_-])/i
+
 export const scorePhrase = (phrase: string) => {
+  if (simCardSignalPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/sim-uicc-pin-labels.test.tsx
+++ b/tests/sim-uicc-pin-labels.test.tsx
@@ -1,0 +1,26 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("includes SIM and UICC aliases for generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="CELLULAR_MODEM"
+        pinLabels={{
+          pin14: ["pin14", "SIM_IO"],
+        }}
+      />
+      <resistor resistance="22Ω" footprint="0402" name="R1" />
+
+      <trace from=".U1 .pin14" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_SIM_IO")
+  expect(netlist).toContain("  - U1 pin14 (SIM_IO)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- Add focused scoring for SIM/UICC/ISO7816 smart-card aliases such as `SIM_IO`, `SIM_CLK`, `SIM_RST`, and `UICC_*`.
- Add regression coverage for a generic modem pin that should render `NET: U1_SIM_IO` and `U1 pin14 (SIM_IO)` instead of hiding the smart-card signal behind `pin14`.

## Validation
- `/Users/chris/.npm/_npx/5c4f1b4a21be27f7/node_modules/.bin/bun test`
- `/Users/chris/.npm/_npx/5c4f1b4a21be27f7/node_modules/.bin/bun run build`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/sim-uicc-pin-labels.test.tsx`
- `git diff --check`
