### PR TITLE
Preserve chip pin aliases for generic pin names

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,8 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinName = (name: string) => /^pin\d+$/i.test(name)
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -46,8 +48,13 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    const isMeaningfulChipAlias =
+      component.ftype === "simple_chip" &&
+      isGenericPinName(mainPinName) &&
+      !isGenericPinName(port_hint) &&
+      port_hint !== String(port.pin_number)
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (isMeaningfulChipAlias || score > 1) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/get-readable-name-for-pin.test.ts
+++ b/tests/get-readable-name-for-pin.test.ts
@@ -1,0 +1,54 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("includes meaningful chip aliases for generic numbered pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "14", "P0.00", "AIN0", "XL1"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 pin14 (P0.00,AIN0,XL1)")
+})
+
+it("keeps low-value resistor pin hints out of readable pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "R1",
+      ftype: "simple_resistor",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "1", "anode", "pos", "left"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("R1 pin1")
+})


### PR DESCRIPTION
Fixes #4
/claim #4

## Summary
- Preserve meaningful chip aliases like P0.00, AIN0, and XL1 when the main pin name is generic, e.g. pin14.
- Keep low-value passive pin hints such as anode/pos/left out of readable resistor pin names.
- Add direct coverage for both behaviors.

## Tests
- npx bun test
- npx bun run build