### PR TITLE
Preserve analog audio pin aliases in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const analogAudioAliasPattern =
+  /(^|[_-])(?:HP\d*_[LR]|HPOUT\d*_[LR]|SPK\d*_[PNLR]|MICBIAS\d*|MIC\d*_(?:P|N|BIAS)|LINE(?:IN|OUT)\d*_[LR]|AUDIO_JD|JACK_DETECT)($|[_-])/
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (analogAudioAliasPattern.test(normalizedPhrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/analog-audio-pin-labels.test.tsx
+++ b/tests/analog-audio-pin-labels.test.tsx
@@ -1,0 +1,31 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves analog audio aliases on generic numbered pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn28"
+        manufacturerPartNumber="WM8960"
+        pinLabels={{
+          pin14: ["GPIO14", "SPK1_P"],
+          pin15: ["GPIO15", "MICBIAS"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .GPIO14" to=".R1 > .pin1" />
+      <trace from=".U1 .GPIO15" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_SPK1_P")
+  expect(netlist).toContain("NET: U1_MICBIAS")
+  expect(netlist).toContain("U1 GPIO14 (SPK1_P)")
+  expect(netlist).toContain("U1 GPIO15 (MICBIAS)")
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Problem
Generic physical chip pins carrying analog audio labels like `SPK1_P` or `MICBIAS` were scored too low. `SPK1_P` hit the digit fallback and could lose to resistor polarity, while default-scored audio hints did not appear in NET pin entries.

## Solution
Add a focused analog-audio alias guard in `scorePhrase` for speaker/headphone/mic-bias/line/jack-detect labels, and add regression coverage.

## Tests
- `npm exec --yes bun -- test tests/analog-audio-pin-labels.test.tsx`
- `npm exec --yes bun -- test`
- `npm exec --yes bun -- x tsc --noEmit`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/analog-audio-pin-labels.test.tsx`
- `npm exec --yes bun -- run build`
- `git diff --check`

## Notes
I checked the issue thread for overlapping analog-audio alias attempts. This is scoped to analog audio codec aliases, not I2S/PDM/DMIC/debug bus labels.