### PR TITLE
Score fieldbus pin aliases in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const fieldbusPinAliasPatterns = [/RS[-_]?485/i, /DMX/i, /DALI/i, /MODBUS/i]
+
 export const scorePhrase = (phrase: string) => {
+  // These protocol labels often contain digits, so score them before the
+  // generic digit fallback.
+  if (fieldbusPinAliasPatterns.some((pattern) => pattern.test(phrase))) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/fieldbus-pin-labels.test.tsx
+++ b/tests/fieldbus-pin-labels.test.tsx
@@ -1,0 +1,114 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves industrial fieldbus pin aliases in readable netlists", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_u1",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "MAX3485",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_r1",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1k",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_r2",
+      ftype: "simple_resistor",
+      name: "R2",
+      resistance: 1000,
+      display_resistance: "1k",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_r3",
+      ftype: "simple_resistor",
+      name: "R3",
+      resistance: 1000,
+      display_resistance: "1k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_13",
+      source_component_id: "source_component_u1",
+      name: "pin13",
+      pin_number: 13,
+      port_hints: ["pin13", "DMX_D+"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_14",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "RS485_A"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_15",
+      source_component_id: "source_component_u1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["pin15", "DALI1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r2_1",
+      source_component_id: "source_component_r2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r3_1",
+      source_component_id: "source_component_r3",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_dmx",
+      connected_source_port_ids: ["source_port_u1_13", "source_port_r1_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_rs485",
+      connected_source_port_ids: ["source_port_u1_14", "source_port_r2_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_dali",
+      connected_source_port_ids: ["source_port_u1_15", "source_port_r3_1"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_DMX_D+")
+  expect(readableNetlist).toContain("  - U1 pin13 (DMX_D+)")
+  expect(readableNetlist).toContain("NET: U1_RS485_A")
+  expect(readableNetlist).toContain("  - U1 pin14 (RS485_A)")
+  expect(readableNetlist).toContain("NET: U1_DALI1")
+  expect(readableNetlist).toContain("  - U1 pin15 (DALI1)")
+})


### PR DESCRIPTION
/claim #4

## Summary

- Score RS-485, DMX, DALI, and MODBUS pin aliases before the generic digit fallback.
- Preserve labels such as `RS485_A`, `DMX_D+`, and `DALI1` in generated NET names and readable pin entries.
- Add raw Circuit JSON regression coverage for industrial and lighting fieldbus aliases.

## Verification

- `npm exec --yes bun -- test tests/fieldbus-pin-labels.test.tsx`
- `npm exec --yes bun -- x biome check lib/scorePhrase.ts tests/fieldbus-pin-labels.test.tsx`
- `npm exec --yes bun -- x tsc --noEmit`
- `npm exec --yes bun -- run build`
- `git diff --check`

Note: a local full-suite run with `npm exec --yes bun -- test` still hits the existing JSX fixture failure in `tests/fixtures/render-circuit.ts` (`TypeError: Attempting to define property on object that is not extensible`) before the converter path in the pre-existing JSX tests. The new raw Circuit JSON regression test passes.
