### PR TITLE
Score NFC and RFID reader pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,21 +35,22 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
-const i2sAudioBusAliases = [
-  "I2S_BCLK",
-  "I2S_LRCLK",
-  "I2S_MCLK",
-  "I2S_SDIN",
-  "I2S_SDOUT",
-  "BCLK",
-  "LRCLK",
-  "MCLK",
-  "SDIN",
-  "SDOUT",
+const contactlessReaderAliases = [
+  "NFC_IRQ",
+  "NFC_FIELD",
+  "NFC_CLK",
+  "NFC_TX",
+  "NFC_RX",
+  "RFID_IRQ",
+  "RFID_FIELD",
+  "RFID_CLK",
+  "RFID_TX",
+  "RFID_RX",
+  "ISO14443",
 ]
 
 export const scorePhrase = (phrase: string) => {
-  if (i2sAudioBusAliases.some((alias) => phrase.includes(alias))) {
+  if (contactlessReaderAliases.some((alias) => phrase.includes(alias))) {
     return 1.2
   }
   if (phrase.match(/\d+/)) {

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,23 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const i2sAudioBusAliases = [
+  "I2S_BCLK",
+  "I2S_LRCLK",
+  "I2S_MCLK",
+  "I2S_SDIN",
+  "I2S_SDOUT",
+  "BCLK",
+  "LRCLK",
+  "MCLK",
+  "SDIN",
+  "SDOUT",
+]
+
 export const scorePhrase = (phrase: string) => {
+  if (i2sAudioBusAliases.some((alias) => phrase.includes(alias))) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/contactless-reader-pin-labels.test.tsx
+++ b/tests/contactless-reader-pin-labels.test.tsx
@@ -8,17 +8,17 @@ declare module "bun:test" {
   }
 }
 
-it("preserves I2S audio bus pin labels in readable netlists", () => {
+it("preserves NFC and RFID contactless-reader pin labels", () => {
   const circuitJson = renderCircuit(
     <board width="10mm" height="10mm" routingDisabled>
       <chip
         name="U1"
         footprint="soic8"
-        manufacturerPartNumber="PCM5102A"
+        manufacturerPartNumber="PN532"
         pinLabels={{
-          pin1: ["GPIO1", "I2S_BCLK"],
-          pin2: ["GPIO2", "I2S_LRCLK"],
-          pin3: ["GPIO3", "SDOUT"],
+          pin1: ["GPIO1", "NFC_IRQ"],
+          pin2: ["GPIO2", "RFID_FIELD"],
+          pin3: ["GPIO3", "ISO14443_TX"],
         }}
       />
       <resistor resistance="33Ω" name="R1" />
@@ -35,29 +35,29 @@ it("preserves I2S audio bus pin labels in readable netlists", () => {
     convertCircuitJsonToReadableNetlist(circuitJson),
   ).toMatchInlineSnapshot(`
     "COMPONENTS:
-     - U1: PCM5102A, soic8
+     - U1: PN532, soic8
      - R1: 33Ω resistor
      - R2: 33Ω resistor
      - R3: 33Ω resistor
 
-    NET: U1_I2S_BCLK
-      - U1 GPIO1 (I2S_BCLK)
+    NET: U1_NFC_IRQ
+      - U1 GPIO1 (NFC_IRQ)
       - R1 pin1
 
-    NET: U1_I2S_LRCLK
-      - U1 GPIO2 (I2S_LRCLK)
+    NET: U1_RFID_FIELD
+      - U1 GPIO2 (RFID_FIELD)
       - R2 pin1
 
-    NET: U1_SDOUT
-      - U1 GPIO3 (SDOUT)
+    NET: U1_ISO14443_TX
+      - U1 GPIO3 (ISO14443_TX)
       - R3 pin1
 
 
     COMPONENT_PINS:
-    U1 (PCM5102A)
-    - pin1(GPIO1, I2S_BCLK): NETS(U1_I2S_BCLK)
-    - pin2(GPIO2, I2S_LRCLK): NETS(U1_I2S_LRCLK)
-    - pin3(GPIO3, SDOUT): NETS(U1_SDOUT)
+    U1 (PN532)
+    - pin1(GPIO1, NFC_IRQ): NETS(U1_NFC_IRQ)
+    - pin2(GPIO2, RFID_FIELD): NETS(U1_RFID_FIELD)
+    - pin3(GPIO3, ISO14443_TX): NETS(U1_ISO14443_TX)
     - pin4: NOT_CONNECTED
     - pin5: NOT_CONNECTED
     - pin6: NOT_CONNECTED
@@ -65,15 +65,15 @@ it("preserves I2S audio bus pin labels in readable netlists", () => {
     - pin8: NOT_CONNECTED
 
     R1 (33Ω undefined)
-    - pin1(anode, pos, left): NETS(U1_I2S_BCLK)
+    - pin1(anode, pos, left): NETS(U1_NFC_IRQ)
     - pin2(cathode, neg, right): NOT_CONNECTED
 
     R2 (33Ω undefined)
-    - pin1(anode, pos, left): NETS(U1_I2S_LRCLK)
+    - pin1(anode, pos, left): NETS(U1_RFID_FIELD)
     - pin2(cathode, neg, right): NOT_CONNECTED
 
     R3 (33Ω undefined)
-    - pin1(anode, pos, left): NETS(U1_SDOUT)
+    - pin1(anode, pos, left): NETS(U1_ISO14443_TX)
     - pin2(cathode, neg, right): NOT_CONNECTED
     "
   `)

--- a/tests/i2s-audio-pin-labels.test.tsx
+++ b/tests/i2s-audio-pin-labels.test.tsx
@@ -1,0 +1,80 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves I2S audio bus pin labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="PCM5102A"
+        pinLabels={{
+          pin1: ["GPIO1", "I2S_BCLK"],
+          pin2: ["GPIO2", "I2S_LRCLK"],
+          pin3: ["GPIO3", "SDOUT"],
+        }}
+      />
+      <resistor resistance="33Ω" name="R1" />
+      <resistor resistance="33Ω" name="R2" />
+      <resistor resistance="33Ω" name="R3" />
+
+      <trace from=".U1 .GPIO1" to=".R1 > .pin1" />
+      <trace from=".U1 .GPIO2" to=".R2 > .pin1" />
+      <trace from=".U1 .GPIO3" to=".R3 > .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: PCM5102A, soic8
+     - R1: 33Ω resistor
+     - R2: 33Ω resistor
+     - R3: 33Ω resistor
+
+    NET: U1_I2S_BCLK
+      - U1 GPIO1 (I2S_BCLK)
+      - R1 pin1
+
+    NET: U1_I2S_LRCLK
+      - U1 GPIO2 (I2S_LRCLK)
+      - R2 pin1
+
+    NET: U1_SDOUT
+      - U1 GPIO3 (SDOUT)
+      - R3 pin1
+
+
+    COMPONENT_PINS:
+    U1 (PCM5102A)
+    - pin1(GPIO1, I2S_BCLK): NETS(U1_I2S_BCLK)
+    - pin2(GPIO2, I2S_LRCLK): NETS(U1_I2S_LRCLK)
+    - pin3(GPIO3, SDOUT): NETS(U1_SDOUT)
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (33Ω undefined)
+    - pin1(anode, pos, left): NETS(U1_I2S_BCLK)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R2 (33Ω undefined)
+    - pin1(anode, pos, left): NETS(U1_I2S_LRCLK)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R3 (33Ω undefined)
+    - pin1(anode, pos, left): NETS(U1_SDOUT)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Summary
- Add focused scoring for NFC/RFID contactless-reader aliases such as `NFC_IRQ`, `NFC_FIELD`, `RFID_FIELD`, and `ISO14443_TX` before the generic numeric fallback.
- Preserve useful contactless-reader interrupt/field/protocol labels in generated `NET:` names and readable pin entries instead of falling back to lower-information physical or polarity labels.
- Add regression coverage for NFC, RFID, and ISO14443-style labels.

## Verification
- `bun test tests/contactless-reader-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/contactless-reader-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

## Scope note
This is intentionally separate from existing SPI/I2S, analog-audio, PDM/DMIC, SIM/UICC, 1-Wire, JESD204, RS-485/DMX/DALI, encoder, touch/proximity, LED/backlight, RF/antenna, display, PCIe, QSPI, SD/MMC, SWD/JTAG/UART, Ethernet/RMII, and power-management alias PR scopes.

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before submission.