### PR TITLE
Score camera sensor control and sync pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,26 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const cameraSignalPatterns = [
+  /^CAM_(PWDN|RESET|RST|STBY|EN|ENABLE|XCLK|PCLK|PIXCLK|VSYNC|HREF|HSYNC)$/,
+  /^DVP_D\d+$/,
+  /^DVP_(PCLK|PIXCLK|VSYNC|HREF|HSYNC)$/,
+  /^(XCLK|PCLK|PIXCLK|VSYNC|HREF|HSYNC)$/,
+]
+
+const scoreCameraSignalPhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (cameraSignalPatterns.some((pattern) => pattern.test(normalizedPhrase))) {
+    return 1.18
+  }
+}
+
 export const scorePhrase = (phrase: string) => {
+  const cameraSignalScore = scoreCameraSignalPhrase(phrase)
+  if (cameraSignalScore !== undefined) {
+    return cameraSignalScore
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/camera-sync-pin-labels.test.tsx
+++ b/tests/camera-sync-pin-labels.test.tsx
@@ -1,0 +1,33 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves parallel camera control and sync pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="OV2640"
+        pinLabels={{
+          pin14: ["pin14", "CAM_PWDN"],
+          pin15: ["pin15", "DVP_D0", "VSYNC"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .CAM_PWDN" to=".R1 .pin1" />
+      <trace from=".U1 .DVP_D0" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_CAM_PWDN")
+  expect(netlist).toContain("  - U1 pin14 (CAM_PWDN)")
+  expect(netlist).toContain("NET: U1_DVP_D0")
+  expect(netlist).toContain("  - U1 pin15 (DVP_D0,VSYNC)")
+  expect(netlist).toContain("- pin15(DVP_D0, VSYNC): NETS(U1_DVP_D0)")
+  expect(netlist).not.toContain("NET: U1_VSYNC")
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Summary
- Add focused scoring for parallel camera-sensor control and sync aliases such as `CAM_PWDN`, `CAM_RESET`, `DVP_D0`, `PIXCLK`, `VSYNC`, and `HREF` before the generic numeric fallback.
- Preserve useful camera signal names in generated `NET:` names and readable pin entries instead of falling back to generic numbered pins or lower-information labels.
- Add regression coverage for camera control and DVP/sync labels on generic chip pins.

## Verification
- `bun test tests/camera-sync-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/camera-sync-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

## Scope note
This is intentionally separate from existing MIPI CSI/DSI lane, HDMI/DisplayPort, audio/debug `MCLK`, RF/antenna, optical/ambient, power-management, NFC/RFID, and fieldbus alias PR scopes.

Transparency: AI-assisted with Codex; I reviewed the diff and ran local verification before submission.