### PR TITLE
Score haptic driver pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -16,6 +16,13 @@ const wordQualityScore = {
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  HAPTIC: 1.18,
+  VIB: 1.18,
+  VIBE: 1.18,
+  VIBRATOR: 1.18,
+  LRA: 1.18,
+  ERM: 1.18,
+  DRV: 1.12,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,6 +43,9 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  if (phrase.match(/(?:HAPTIC|VIBRATOR|VIBE|VIB|LRA|ERM|DRV)/)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-haptic-pin-labels.test.ts
+++ b/tests/test4-haptic-pin-labels.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves haptic driver aliases for generic numbered pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "DRV2605L",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "LRA1_OUT", "HAPTIC_OUT"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_LRA1_OUT")
+  expect(readableNetlist).toContain("  - U1 pin14 (LRA1_OUT,HAPTIC_OUT)")
+  expect(readableNetlist).toContain(
+    "- pin14(LRA1_OUT, HAPTIC_OUT): NETS(U1_LRA1_OUT)",
+  )
+})


### PR DESCRIPTION
## Summary
- add focused scoring for haptic/vibrator driver aliases (`HAPTIC`, `VIB`, `VIBE`, `VIBRATOR`, `LRA`, `ERM`, `DRV`) before the generic digit fallback
- add raw Circuit JSON regression coverage for a generic `pin14` preserving `LRA1_OUT` / `HAPTIC_OUT` in readable net names and pin entries

/claim #4

## Verification
- `npm exec --yes bun -- test tests/test4-haptic-pin-labels.test.ts`
- `npm exec --yes bun -- run build`
- `npx biome check lib/scorePhrase.ts tests/test4-haptic-pin-labels.test.ts`
- `git diff --check -- lib/scorePhrase.ts tests/test4-haptic-pin-labels.test.ts`

Note: full `npm exec --yes bun -- test` currently fails in the fresh Windows temp install before reaching this patch because existing JSX fixture tests hit `Export named 'distanceBetweenCircleAndPolygon' not found in module '@tscircuit/circuit-json-util/dist/index.js'`. The new focused regression passes.