### PR TITLE
Score environmental gas sensor pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -15,6 +15,11 @@ const wordQualityScore = {
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
+  PRESS: 1.15,
+  HUM: 1.15,
+  VOC: 1.15,
+  CO2: 1.15,
+  PM25: 1.15,
   GPIO: 1.1,
   cathode: 0.5,
   anode: 0.5,
@@ -35,7 +40,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingEnvironmentalAliases = new Set(["CO2", "PM25"])
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of wordQualityScoreEntries) {
+    if (digitBearingEnvironmentalAliases.has(word) && phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/environmental-gas-sensor-pin-labels.test.ts
+++ b/tests/environmental-gas-sensor-pin-labels.test.ts
@@ -1,0 +1,60 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves environmental and gas sensor aliases for generic chip pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_u1",
+      ftype: "simple_chip",
+      name: "U1",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_r1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_14",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: [
+        "pin14",
+        "14",
+        "PRESS_INT",
+        "HUM_DRDY",
+        "VOC_INT",
+        "CO2_RDY",
+        "PM25_OUT",
+      ],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_u1_14", "source_port_r1_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_PRESS_INT")
+  expect(readableNetlist).toContain(
+    "  - U1 pin14 (PRESS_INT,HUM_DRDY,VOC_INT,CO2_RDY,PM25_OUT)",
+  )
+  expect(readableNetlist).toContain(
+    "- pin14(PRESS_INT, HUM_DRDY, VOC_INT, CO2_RDY, PM25_OUT): NETS(U1_PRESS_INT)",
+  )
+})


### PR DESCRIPTION
/claim #4

## Summary
- Score environmental and gas sensor aliases (`PRESS`, `HUM`, `VOC`, `CO2`, `PM25`) above generic physical pin labels.
- Add focused handling so digit-bearing environmental aliases like `CO2_RDY` and `PM25_OUT` are recognized before the generic numeric fallback.
- Add raw Circuit JSON regression coverage for a generic chip pin carrying pressure, humidity, VOC, CO2, and particulate sensor hints.

## Root Cause
`getReadableNameForPin` only includes extra pin hints when `scorePhrase` returns a score above `1`. Environmental sensor aliases were previously unrecognized, and digit-bearing aliases like `CO2_RDY` / `PM25_OUT` were caught by the numeric fallback, so readable NET entries omitted useful sensor signal names even when the hints were present.

## Verification
- `npm exec --yes bun -- test tests/environmental-gas-sensor-pin-labels.test.ts` failed before the scoring change and passed after it.
- `npm exec --yes bun -- test`
- `npm exec --yes bun -- x tsc --noEmit`
- `npm exec --yes bun -- run build`
- `npm exec --yes bun -- x biome check lib/scorePhrase.ts tests/environmental-gas-sensor-pin-labels.test.ts`
- `git diff --check`