### PR TITLE
Score buzzer and piezo pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const buzzerAliasPattern =
+  /^(?:BUZZER\d*|BZ\d+|PIEZO|BEEP(?:ER)?)(?:[_-]?(?:PWM|OUT|EN|DRIVE))?$/
+
 export const scorePhrase = (phrase: string) => {
+  if (buzzerAliasPattern.test(phrase.toUpperCase())) {
+    return 1.16
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/buzzer-pin-labels.test.tsx
+++ b/tests/buzzer-pin-labels.test.tsx
@@ -1,0 +1,35 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores buzzer and piezo aliases above generic pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="DRV8210"
+        pinLabels={{
+          pin1: ["pin14", "BUZZER1_PWM"],
+          pin2: ["pin15", "PIEZO_DRIVE"],
+          pin3: ["pin16", "BEEP_OUT"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .BUZZER1_PWM" to=".R1 .pin1" />
+      <trace from=".U1 .PIEZO_DRIVE" to=".R1 .pin2" />
+      <trace from=".U1 .BEEP_OUT" to=".R2 .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_BUZZER1_PWM")
+  expect(readableNetlist).toContain("NET: U1_PIEZO_DRIVE")
+  expect(readableNetlist).toContain("NET: U1_BEEP_OUT")
+  expect(readableNetlist).toContain("- U1 pin14 (BUZZER1_PWM)")
+  expect(readableNetlist).toContain("- U1 pin15 (PIEZO_DRIVE)")
+  expect(readableNetlist).toContain("- U1 pin16 (BEEP_OUT)")
+})


### PR DESCRIPTION
﻿Fixes part of #4
/claim #4

## Summary
- Add focused scoring for audible-alert aliases such as `BUZZER1_PWM`, `PIEZO_DRIVE`, and `BEEP_OUT` before the generic digit/default fallback.
- Preserve useful buzzer/piezo labels in generated `NET:` names and readable pin entries instead of falling back to generic physical pins or lower-information passive labels.
- Add regression coverage for buzzer, piezo, and beeper labels on generic chip pins.

## Verification
- `bun test tests/buzzer-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/buzzer-pin-labels.test.tsx`
- `bun run build`
- `git diff --check -- lib/scorePhrase.ts tests/buzzer-pin-labels.test.tsx`

## Scope note
This is intentionally separate from existing analog-audio, PDM/DMIC, haptic/vibrator, LED/backlight, optical/ambient, relay/solenoid, motor/fan, fieldbus, camera, environmental-sensor, FPGA configuration, and power-management alias scopes.

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before submission.
