### PR TITLE
Score current-sense pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const currentSenseAliasPattern =
+  /^(?:[IVC]_?SENSE\d*|CURRENT_?SENSE\d*|SENSE_[PN]|SHUNT(?:_[PN]|[PN])?)$/
+
 export const scorePhrase = (phrase: string) => {
+  if (currentSenseAliasPattern.test(phrase.toUpperCase())) {
+    return 1.15
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-current-sense-pin-labels.test.tsx
+++ b/tests/test4-current-sense-pin-labels.test.tsx
@@ -1,0 +1,114 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves current-sense and shunt aliases on generic chip pins", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      manufacturer_part_number: "INA228",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_14",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["ISENSE1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_15",
+      source_component_id: "source_component_u1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["VSENSE"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_16",
+      source_component_id: "source_component_u1",
+      name: "pin16",
+      pin_number: 16,
+      port_hints: ["SHUNT_P"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r1",
+      name: "R1",
+      resistance: 10000,
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r2",
+      name: "R2",
+      resistance: 20000,
+      display_resistance: "20kΩ",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r3",
+      name: "R3",
+      resistance: 30000,
+      display_resistance: "30kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r2_1",
+      source_component_id: "source_component_r2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r3_1",
+      source_component_id: "source_component_r3",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_isense",
+      connected_source_port_ids: ["source_port_u1_14", "source_port_r1_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_vsense",
+      connected_source_port_ids: ["source_port_u1_15", "source_port_r2_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_shunt",
+      connected_source_port_ids: ["source_port_u1_16", "source_port_r3_1"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ISENSE1")
+  expect(netlist).toContain("  - U1 pin14 (ISENSE1)")
+  expect(netlist).toContain("NET: U1_VSENSE")
+  expect(netlist).toContain("  - U1 pin15 (VSENSE)")
+  expect(netlist).toContain("NET: U1_SHUNT_P")
+  expect(netlist).toContain("  - U1 pin16 (SHUNT_P)")
+})


### PR DESCRIPTION
## Summary
- Score current-sense and shunt-monitor aliases (`ISENSE1`, `VSENSE`, `CSENSE`, `SHUNT_P`) before the generic digit fallback.
- Preserve useful sensing signal names in generated NET names and readable pin entries instead of falling back to generic `pin14`-style labels.
- Add raw Circuit JSON regression coverage for generic chip pins carrying current-sense aliases.

/claim #4

## Verification
- `npm exec --yes bun@1.2.17 -- test tests/test4-current-sense-pin-labels.test.tsx`
- `npm exec --yes bun@1.2.17 -- x biome check lib/scorePhrase.ts tests/test4-current-sense-pin-labels.test.tsx`
- `npm exec --yes bun@1.2.17 -- x tsc --noEmit`
- `npm exec --yes bun@1.2.17 -- run build`
- `git diff --check`

## Note
- `npm exec --yes bun@1.2.17 -- test` currently fails in existing `renderCircuit`-based tests before running assertions because `@tscircuit/core` imports `distanceBetweenCircleAndCircle` from the locked `@tscircuit/circuit-json-util@0.0.90`. The new regression test avoids that existing harness issue and passes independently.

Transparency: AI-assisted with Codex; I reviewed the diff and verification before submitting.