### PR TITLE
test: preserve load-cell pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,22 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isLoadCellAlias = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  return (
+    /^(HX711|LOADCELL|LOAD_CELL|STRAIN_GAUGE)[_-]?[A-Z0-9_+-]*$/.test(
+      normalizedPhrase,
+    ) ||
+    /^(WHEATSTONE|BRIDGE)[_-]?(EXC|SIG|SENSE)?[_-]?[PN+-]?$/.test(
+      normalizedPhrase,
+    )
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isLoadCellAlias(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/load-cell-pin-labels.test.ts
+++ b/tests/load-cell-pin-labels.test.ts
@@ -1,0 +1,94 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toContain(expected: string): Promise<MatcherResult>
+  }
+}
+
+it("keeps load-cell and HX711 aliases in readable net names", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_adc",
+      name: "U1",
+      manufacturer_part_number: "HX711",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_dout_pullup",
+      name: "R1",
+      resistance: 10000,
+      display_resistance: "10k",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_exc_pullup",
+      name: "R2",
+      resistance: 10000,
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_pin14",
+      source_component_id: "source_component_adc",
+      pin_number: 14,
+      name: "pin14",
+      port_hints: ["HX711_DOUT"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_pin15",
+      source_component_id: "source_component_adc",
+      pin_number: 15,
+      name: "pin15",
+      port_hints: ["BRIDGE_EXC_P"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_pin1",
+      source_component_id: "source_component_dout_pullup",
+      pin_number: 1,
+      name: "pin1",
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r2_pin1",
+      source_component_id: "source_component_exc_pullup",
+      pin_number: 1,
+      name: "pin1",
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_hx711_dout",
+      connected_source_port_ids: [
+        "source_port_u1_pin14",
+        "source_port_r1_pin1",
+      ],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_bridge_exc",
+      connected_source_port_ids: [
+        "source_port_u1_pin15",
+        "source_port_r2_pin1",
+      ],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_HX711_DOUT")
+  expect(readableNetlist).toContain("  - U1 pin14 (HX711_DOUT)")
+  expect(readableNetlist).toContain("NET: U1_BRIDGE_EXC_P")
+  expect(readableNetlist).toContain("  - U1 pin15 (BRIDGE_EXC_P)")
+})


### PR DESCRIPTION
## Summary
- Score load-cell / HX711 aliases (`HX711_DOUT`, `BRIDGE_EXC_P`, etc.) before the generic digit fallback.
- Add raw Circuit JSON regression coverage proving those aliases appear in generated NET names and readable pin entries.

Fixes #4
/claim #4

## Verification
- `npm exec --yes bun -- test tests/load-cell-pin-labels.test.ts`
- `npm exec --yes bun -- x tsc --noEmit`
- `npm exec --yes bun -- x biome check lib/scorePhrase.ts tests/load-cell-pin-labels.test.ts`
- `npm exec --yes bun -- run build`

Note: `npm exec --yes bun -- test` passes the new test but the three existing JSX-rendered tests fail locally on Windows before this change with `TypeError: Attempting to define property on object that is not extensible` in `@tscircuit/core`'s `renderCircuit` path.