### PR TITLE
Score security tamper pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const securityEventWords = ["TAMPER", "INTRUSION", "CASE_OPEN", "COVER_OPEN"]
+const securityEventScore = 1.2
+
 export const scorePhrase = (phrase: string) => {
+  const uppercasePhrase = phrase.toUpperCase()
+  if (securityEventWords.some((word) => uppercasePhrase.includes(word))) {
+    return securityEventScore
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-security-tamper-pin-labels.test.tsx
+++ b/tests/test4-security-tamper-pin-labels.test.tsx
@@ -1,0 +1,37 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves security tamper pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="SEC1"
+        footprint="soic16"
+        manufacturerPartNumber="ATECC608B"
+        pinLabels={{
+          pin14: ["pin14", "TAMPER1"],
+          pin15: ["pin15", "CASE_OPEN"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".SEC1 .pin14" to=".R1 .pin1" />
+      <trace from=".SEC1 .pin15" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: SEC1_TAMPER1")
+  expect(netlist).toContain("NET: SEC1_CASE_OPEN")
+  expect(netlist).toContain("SEC1 pin14 (TAMPER1)")
+  expect(netlist).toContain("SEC1 pin15 (CASE_OPEN)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- add focused scoring for security/tamper event aliases before the generic digit fallback
- preserve useful labels like `TAMPER1` and `CASE_OPEN` in readable NET names and pin entries
- add regression coverage for secure-element / enclosure tamper pin hints

## Testing
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/test4-security-tamper-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and ran local verification before opening this PR.