### PR TITLE
Score biomedical sensor pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const biomedicalSignalWords = ["ECG", "EEG", "EMG", "PPG", "BIOZ", "RESP"]
+const biomedicalSignalScore = 1.2
+
 export const scorePhrase = (phrase: string) => {
+  const uppercasePhrase = phrase.toUpperCase()
+  if (biomedicalSignalWords.some((word) => uppercasePhrase.includes(word))) {
+    return biomedicalSignalScore
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-biomedical-pin-labels.test.tsx
+++ b/tests/test4-biomedical-pin-labels.test.tsx
@@ -1,0 +1,37 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves biomedical sensor pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="BIO1"
+        footprint="qfn32"
+        manufacturerPartNumber="MAX86150"
+        pinLabels={{
+          pin11: ["pin11", "ECG_RA"],
+          pin12: ["pin12", "PPG_LED1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".BIO1 .pin11" to=".R1 .pin1" />
+      <trace from=".BIO1 .pin12" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: BIO1_ECG_RA")
+  expect(netlist).toContain("NET: BIO1_PPG_LED1")
+  expect(netlist).toContain("BIO1 pin11 (ECG_RA)")
+  expect(netlist).toContain("BIO1 pin12 (PPG_LED1)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- add focused scoring for biomedical sensor aliases before the generic digit fallback
- preserve useful labels like `ECG_RA` and `PPG_LED1` in readable NET names and pin entries
- add regression coverage for biomedical sensor / AFE pin hints

## Testing
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/test4-biomedical-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and ran local verification before opening this PR.