### PR TITLE
Score IMU motion pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,9 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  if (/(ACCEL|GYRO|MAG|IMU)(_|$)/.test(phrase)) {
+    return 1.15
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-imu-motion-pin-labels.test.tsx
+++ b/tests/test4-imu-motion-pin-labels.test.tsx
@@ -1,0 +1,36 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves IMU motion sensor aliases on generic pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn24"
+        manufacturerPartNumber="ICM-42688-P"
+        pinLabels={{
+          pin14: ["ACCEL_X"],
+          pin15: ["GYRO_Z"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .ACCEL_X" to=".R1 > .pin1" />
+      <trace from=".U1 .GYRO_Z" to=".R2 > .pin1" />
+    </board>,
+  )
+  for (const element of circuitJson) {
+    if (element.type !== "source_port") continue
+    if (element.name === "ACCEL_X") element.name = "pin14"
+    if (element.name === "GYRO_Z") element.name = "pin15"
+  }
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ACCEL_X")
+  expect(netlist).toContain("  - U1 pin14 (ACCEL_X)")
+  expect(netlist).toContain("NET: U1_GYRO_Z")
+  expect(netlist).toContain("  - U1 pin15 (GYRO_Z)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- add focused scoring for IMU / motion-sensor aliases such as `ACCEL_X`, `GYRO_Z`, `MAG_*`, and `IMU_*`
- add regression coverage for generic physical pins that should preserve motion aliases in generated NET names and readable pin entries

Refs #4

## Verification
- `bun test tests/test4-imu-motion-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/test4-imu-motion-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and ran local verification before opening this PR.