### PR TITLE
Score LoRa radio pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,14 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  DIO0: 1.15,
+  DIO1: 1.15,
+  DIO2: 1.15,
+  DIO3: 1.15,
+  DIO4: 1.15,
+  DIO5: 1.15,
+  RF_SW: 1.15,
+  TCXO_EN: 1.15,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -36,13 +44,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-lora-radio-pin-labels.test.ts
+++ b/tests/test4-lora-radio-pin-labels.test.ts
@@ -1,0 +1,71 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("shows LoRa radio aliases for generic chip pin labels", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "SX1276",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "J1",
+      manufacturer_part_number: "LORA-HEADER",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["DIO0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["DIO1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: SX1276
+     - J1: LORA-HEADER
+
+    NET: U1_DIO0
+      - U1 pin14 (DIO0)
+      - J1 pin3 (DIO1)
+
+
+    COMPONENT_PINS:
+    U1 (SX1276)
+    - pin14(DIO0): NETS(U1_DIO0)
+
+    J1 (LORA-HEADER)
+    - pin3(DIO1): NETS(U1_DIO0)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- score LoRa/Semtech radio aliases (`DIO0`-`DIO5`, `RF_SW`, `TCXO_EN`) as meaningful readable labels
- check known scored phrases before falling back to the generic digit score, matching the existing `GPIO1` scoring comment
- add raw Circuit JSON regression coverage for generic physical pins carrying `DIO0`/`DIO1` hints

## Why
Current main treats digit-bearing radio interrupt pins such as `DIO0` like generic numbered labels before known words are checked, so readable NET names and connected-pin entries can fall back to low-information physical labels like `pin14`.

## Verification
- `bunx biome check lib\\scorePhrase.ts tests\\test4-lora-radio-pin-labels.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and ran the local checks above.
