### PR TITLE
fix: promote descriptive pin labels over pinN in COMPONENT_PINS (#4)

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -121,4 +121,127 @@ export const convertCircuitJsonToReadableNetlist = (
   }
 
   // build map of port ids to the nets they connect to
-  
+  const portIdToNetNames: Record<string, string[]> = {}
+  for (const [netId, connectedIds] of Object.entries(netMap)) {
+    const portIds = connectedIds.filter((id) => id.startsWith("source_port"))
+    if (portIds.length === 0) continue
+    const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
+    let netName = net?.name
+    if (!netName) {
+      netName = generateNetName({ circuitJson, connectedIds })
+    }
+    for (const portId of portIds) {
+      if (!portIdToNetNames[portId]) portIdToNetNames[portId] = []
+      portIdToNetNames[portId].push(netName)
+    }
+  }
+
+  if (source_components.length > 0) {
+    netlist.push("")
+    netlist.push("COMPONENT_PINS:")
+    for (const component of source_components) {
+      const cadComponent = su(circuitJson).cad_component.getWhere({
+        source_component_id: component.source_component_id,
+      })
+      const footprint = cadComponent?.footprinter_string
+      let header = component.name
+      if (component.ftype === "simple_resistor") {
+        const detail = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = detail ? `${component.name} (${detail})` : component.name
+      } else if (component.ftype === "simple_capacitor") {
+        const detail = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = detail ? `${component.name} (${detail})` : component.name
+      } else if (component.manufacturer_part_number) {
+        header = `${component.name} (${component.manufacturer_part_number})`
+      }
+      netlist.push(header)
+      const ports = source_ports
+        .filter((p) => p.source_component_id === component.source_component_id)
+        .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
+      for (const port of ports) {
+        const pinNumberLabel =
+          port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+
+        // Collect every textual label this port has, excluding the bare pin
+        // number string (e.g. "14") that often appears in port_hints.
+        const labelCandidates = Array.from(
+          new Set(
+            [
+              ...(port.port_hints ?? []),
+              ...(port.name ? [port.name] : []),
+            ].filter(
+              (label): label is string =>
+                typeof label === "string" &&
+                label.length > 0 &&
+                label !== String(port.pin_number),
+            ),
+          ),
+        )
+
+        // Prefer a meaningful label (e.g. GP14, SDA, VDD) as the primary
+        // identifier. Generic positional hints like "pos", "left", or
+        // "anode" are auto-attached to passives; they should stay as
+        // aliases rather than replace pinN. We rank labels by scorePhrase
+        // and only promote one above pinN if it is not one of these
+        // generic positional words.
+        const GENERIC_POSITIONAL = new Set([
+          "anode",
+          "cathode",
+          "pos",
+          "neg",
+          "positive",
+          "negative",
+          "left",
+          "right",
+          "top",
+          "bottom",
+        ])
+
+        // Among labels, find the highest-scoring "descriptive" one
+        // (i.e. not a generic positional hint). If one exists, promote it.
+        const descriptiveLabel = [...labelCandidates]
+          .filter((label) => !GENERIC_POSITIONAL.has(label.toLowerCase()))
+          .sort((a, b) => scorePhrase(b) - scorePhrase(a))[0]
+
+        let mainPin: string | undefined
+        if (descriptiveLabel) {
+          mainPin = descriptiveLabel
+        } else {
+          mainPin = pinNumberLabel ?? labelCandidates[0]
+        }
+
+        // If we still have nothing to call this pin, skip it rather than
+        // emit "undefined".
+        if (!mainPin) continue
+
+        // Preserve the original label order in aliases so passive component
+        // outputs stay stable (e.g. anode, pos, left rather than pos, anode,
+        // left).
+        const aliases: string[] = []
+        for (const label of labelCandidates) {
+          if (label !== mainPin) aliases.push(label)
+        }
+        // Surface pinN as an alias when a richer label became the main
+        // name, so the numeric pin is still recoverable.
+        if (pinNumberLabel && pinNumberLabel !== mainPin) {
+          aliases.push(pinNumberLabel)
+        }
+        const aliasPart =
+          aliases.length > 0
+            ? `(${Array.from(new Set(aliases)).join(", ")})`
+            : ""
+        const nets = portIdToNetNames[port.source_port_id] ?? []
+        const netsPart =
+          nets.length > 0 ? `NETS(${nets.join(", ")})` : "NOT_CONNECTED"
+        netlist.push(`- ${mainPin}${aliasPart}: ${netsPart}`)
+      }
+      netlist.push("")
+    }
+  }
+
+  return netlist.join("\n")
+}

--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -8,6 +8,7 @@ import type {
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { scorePhrase } from "./scorePhrase"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -120,62 +121,4 @@ export const convertCircuitJsonToReadableNetlist = (
   }
 
   // build map of port ids to the nets they connect to
-  const portIdToNetNames: Record<string, string[]> = {}
-  for (const [netId, connectedIds] of Object.entries(netMap)) {
-    const portIds = connectedIds.filter((id) => id.startsWith("source_port"))
-    if (portIds.length === 0) continue
-    const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
-    let netName = net?.name
-    if (!netName) {
-      netName = generateNetName({ circuitJson, connectedIds })
-    }
-    for (const portId of portIds) {
-      if (!portIdToNetNames[portId]) portIdToNetNames[portId] = []
-      portIdToNetNames[portId].push(netName)
-    }
-  }
-
-  if (source_components.length > 0) {
-    netlist.push("")
-    netlist.push("COMPONENT_PINS:")
-    for (const component of source_components) {
-      const cadComponent = su(circuitJson).cad_component.getWhere({
-        source_component_id: component.source_component_id,
-      })
-      const footprint = cadComponent?.footprinter_string
-      let header = component.name
-      if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
-      } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
-      } else if (component.manufacturer_part_number) {
-        header = `${component.name} (${component.manufacturer_part_number})`
-      }
-      netlist.push(header)
-      const ports = source_ports
-        .filter((p) => p.source_component_id === component.source_component_id)
-        .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
-      for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
-        const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
-        for (const hint of port.port_hints ?? []) {
-          if (hint === String(port.pin_number)) continue
-          if (hint !== mainPin && hint !== port.name) aliases.push(hint)
-        }
-        const aliasPart =
-          aliases.length > 0
-            ? `(${Array.from(new Set(aliases)).join(", ")})`
-            : ""
-        const nets = portIdToNetNames[port.source_port_id] ?? []
-        const netsPart =
-          nets.length > 0 ? `NETS(${nets.join(", ")})` : "NOT_CONNECTED"
-        netlist.push(`- ${mainPin}${aliasPart}: ${netsPart}`)
-      }
-      netlist.push("")
-    }
-  }
-
-  return netlist.join("\n")
-}
+  

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - SCL(GPIO1, pin3): NETS(GND)
+    - SDA(GPIO2, pin4): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - UART_TX(GPIO4, pin6): NOT_CONNECTED
+    - UART_RX(GPIO5, pin7): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)

--- a/tests/test4-pin-labels.test.tsx
+++ b/tests/test4-pin-labels.test.tsx
@@ -38,7 +38,7 @@ it("test4 chip with rich pin labels uses labels, not pinN, in COMPONENT_PINS", (
 
   // 2. The COMPONENT_PINS section must show the real label (GP14) not pinN
   expect(netlist).toContain("GP14")
-  expect(netlist).not.toMatch(/^- pin19(/m)
+  expect(netlist).not.toMatch(/^- pin19\(/m)
 
   // 3. The pin we wired up must be listed by its label in the NET section
   expect(netlist).toMatch(/U1 GP14/)

--- a/tests/test4-pin-labels.test.tsx
+++ b/tests/test4-pin-labels.test.tsx
@@ -1,0 +1,45 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("test4 chip with rich pin labels uses labels, not pinN, in COMPONENT_PINS", () => {
+  // Reproduces tscircuit/circuit-json-to-readable-netlist#4
+  // The Pico W has 40 pins where each pin has a meaningful label such as
+  // GP0, GP14, etc. The previous output showed `pin14` rather than `GP14`.
+  const circuitJson = renderCircuit(
+    <board width="20mm" height="20mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="dip40"
+        manufacturerPartNumber="RP2040_PICO_W"
+        pinLabels={{
+          pin1: ["GP0", "UART0_TX"],
+          pin2: ["GP1", "UART0_RX"],
+          pin14: ["GP10"],
+          pin19: ["GP14"],
+          pin36: ["3V3_OUT"],
+          pin38: ["GND"],
+        }}
+      />
+      <trace from=".U1 .GP14" to="net.LED_DATA" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  // 1. Output must never contain literal "undefined"
+  expect(netlist).not.toContain("undefined")
+
+  // 2. The COMPONENT_PINS section must show the real label (GP14) not pinN
+  expect(netlist).toContain("GP14")
+  expect(netlist).not.toMatch(/^- pin19(/m)
+
+  // 3. The pin we wired up must be listed by its label in the NET section
+  expect(netlist).toMatch(/U1 GP14/)
+})


### PR DESCRIPTION
Closes #4.

### Problem

The `COMPONENT_PINS` section was emitting `pin14(GP14)` instead of `GP14(pin14)` for chips with descriptive pin labels. The bare `pinN` identifier was always used as the main label, hiding the human-readable name inside the alias parentheses. For chips with many pins (e.g. RP2040 Pico W with `GP0`…`GP28`), this made the netlist hard to read.

A second, related defect: when a `simple_resistor` / `simple_capacitor` lacked a `display_value` or `footprint`, the header was rendered with literal `"undefined"` text (e.g. `R1 (undefined undefined)`).

### Fix

In `convertCircuitJsonToReadableNetlist.ts`, the `COMPONENT_PINS` loop now:

1. Collects every textual label for a port (from `port.name` and `port.port_hints`), excluding the bare pin-number string.
2. Picks the highest-scoring **descriptive** label as the main identifier, where "descriptive" means not one of the well-known auto-attached positional hints (`anode`, `cathode`, `pos`, `neg`, `positive`, `negative`, `left`, `right`, `top`, `bottom`).
3. Falls back to `pinN` when no descriptive label exists, preserving today's behavior for plain passives.
4. Keeps `pinN` as an alias when a descriptive label takes the primary slot, so the numeric pin is still recoverable.
5. Skips pins entirely when no usable label exists, instead of emitting `undefined`.

The resistor/capacitor header construction is also hardened with `.filter(Boolean).join(" ")` so missing `display_value` or `footprint` no longer produce `undefined` substrings.

### Before / after

For a chip with `pinLabels: { pin4: ["GPIO2", "SDA"] }` connected to a net:

**Before**

```
- pin4(GPIO2, SDA): NETS(U1_SDA)
```

**After**

```
- SDA(GPIO2, pin4): NETS(U1_SDA)
```

For a resistor (unchanged):

```
- pin1(anode, pos, left): NETS(C1_pos)
- pin2(cathode, neg, right): NOT_CONNECTED
```

### Tests

- All existing tests pass.
- `test2-chip` snapshot was updated to reflect the corrected ordering (this is the visible bug from #4).
- New `test4-pin-labels.test.tsx` reproduces the issue with an RP2040-style chip and asserts the netlist contains the real labels, no `undefined`, and no `pin19(...)` as the main identifier when `GP14` is available.

`bun test`, `bun run build`, and `bun run format:check` all pass locally.

/claim #4