### PR TITLE
Score ARM trace pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const armTraceAliasPattern =
+  /(^|[_-])(TRACE(?:CLK|CK|_?D\d+|_?DATA\d+)|TRACED\d+|ETM\d*|TPIU(?:_TRACE)?|SWV)([_-]|$)/
+
 export const scorePhrase = (phrase: string) => {
+  if (armTraceAliasPattern.test(phrase.toUpperCase())) {
+    return 1.15
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/arm-trace-pin-labels.test.tsx
+++ b/tests/arm-trace-pin-labels.test.tsx
@@ -1,0 +1,41 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores ARM trace aliases before the generic digit fallback", () => {
+  expect(scorePhrase("TRACECLK")).toBeGreaterThan(1)
+  expect(scorePhrase("TRACED0")).toBeGreaterThan(1)
+  expect(scorePhrase("TRACE_D1")).toBeGreaterThan(1)
+  expect(scorePhrase("TPIU_TRACE")).toBeGreaterThan(1)
+  expect(scorePhrase("pin2")).toBe(0.5)
+})
+
+it("preserves ARM trace aliases in readable net names and pin entries", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="TRACE-MCU"
+        pinLabels={{
+          pin1: ["pin1", "TRACECLK"],
+          pin2: ["pin2", "TRACED0"],
+          pin3: ["pin3", "TPIU_TRACE"],
+        }}
+      />
+      <resistor resistance="1k" name="R1" />
+
+      <trace from=".U1 .pin1" to=".R1 .pin1" />
+      <trace from=".U1 .pin2" to=".R1 .pin2" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_TRACECLK")
+  expect(readableNetlist).toContain("NET: U1_TRACED0")
+  expect(readableNetlist).toContain("  - U1 pin1 (TRACECLK)")
+  expect(readableNetlist).toContain("  - U1 pin2 (TRACED0)")
+  expect(readableNetlist).not.toContain("NET: R1_neg")
+})


### PR DESCRIPTION
/claim #4

## Summary
- Add a focused ARM ETM/TPIU/SWV trace alias scorer for labels such as `TRACECLK`, `TRACED0`, `TRACE_D1`, and `TPIU_TRACE`.
- Score those aliases before the numeric fallback so digit-bearing trace pins do not lose net-name selection to lower-information passive hints like `neg`.
- Add regression coverage proving `TRACECLK` and `TRACED0` appear in generated NET names and readable pin entries.

## Scope check
I checked recent open PRs and issue attempts before opening this. This stays separate from SWD/JTAG debug pins, source-trace display-name handling, system timing/supervision, LoRa, IMU, presence detector, and RF/GNSS scopes.

## Validation
- `bun test tests/arm-trace-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/arm-trace-pin-labels.test.tsx`
- `bun x tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.