### PR TITLE
Keep meaningful numbered pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.toUpperCase()
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-numbered-pin-labels.test.ts
+++ b/tests/test4-numbered-pin-labels.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("keeps meaningful numbered pin labels in readable pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "14", "GPIO14", "SCLK"],
+    },
+  ] as unknown as AnyCircuitElement[]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (GPIO14,SCLK)")
+})


### PR DESCRIPTION
## Summary

- Preserve meaningful numbered pin labels such as `GPIO14` when scoring pin hints
- Keep generic numeric labels like `14` and `pin14` lower priority unless they contain a known useful phrase
- Add a regression test for readable pin names with numbered labels

Fixes #4
/claim #4

## Verification

- `npx tsc --noEmit`
- `npx biome check .`
- `npm run build`

`bun test` was not run because Bun is not installed in my local environment.