### PR TITLE
Score wireless coexistence pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const wirelessControlAliasPattern =
+  /(?:^|[_-])(?:WLAN|WIFI|WL|BT|BLE|COEX|HOST_WAKE|DEV_WAKE|REG_ON)(?:[_-]|$)/
+
 export const scorePhrase = (phrase: string) => {
+  if (wirelessControlAliasPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-wireless-coexistence-pin-labels.test.ts
+++ b/tests/test4-wireless-coexistence-pin-labels.test.ts
@@ -1,0 +1,88 @@
+import { expect, it } from "bun:test"
+import type { CircuitJson } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves wireless coexistence pin labels in net entries", () => {
+  const circuitJson: CircuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "chip1",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "CYW43439",
+    },
+    {
+      type: "source_component",
+      source_component_id: "r1",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 10_000,
+      display_resistance: "10k",
+    },
+    {
+      type: "source_component",
+      source_component_id: "r2",
+      ftype: "simple_resistor",
+      name: "R2",
+      resistance: 10_000,
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_pin14",
+      source_component_id: "chip1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["BT_HOST_WAKE"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_pin15",
+      source_component_id: "chip1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["WLAN_IRQ0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_pin1",
+      source_component_id: "r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r2_pin1",
+      source_component_id: "r2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "trace1",
+      connected_source_port_ids: [
+        "source_port_u1_pin14",
+        "source_port_r1_pin1",
+      ],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "trace2",
+      connected_source_port_ids: [
+        "source_port_u1_pin15",
+        "source_port_r2_pin1",
+      ],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_BT_HOST_WAKE")
+  expect(netlist).toContain("  - U1 pin14 (BT_HOST_WAKE)")
+  expect(netlist).toContain("NET: U1_WLAN_IRQ0")
+  expect(netlist).toContain("  - U1 pin15 (WLAN_IRQ0)")
+})


### PR DESCRIPTION
## Summary

- Adds focused scoring for Wi-Fi/Bluetooth coexistence and wireless-module control aliases so they appear in readable NET pin entries.
- Adds a raw Circuit JSON regression for generic physical pins carrying `BT_HOST_WAKE` and `WLAN_IRQ0` aliases.

## Linked issue/bounty

- Related to #4
- Algora bounty issue: #4

/claim #4

## Verification command + result

- `bun test tests/test4-wireless-coexistence-pin-labels.test.ts` - passed, 1 test.
- `bun x biome check lib/scorePhrase.ts tests/test4-wireless-coexistence-pin-labels.test.ts` - passed, no fixes applied.
- `bun test` - passed, 4 tests.
- `bun x tsc --noEmit` - passed.
- `git diff --check` - passed.

## AI assistance disclosure

This PR was prepared with AI assistance using Codex. I manually reviewed the diff, kept the change scoped to the issue, and ran the verification listed below.
