### PR TITLE
Score PoE pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,19 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const scorePoePhrase = (phrase: string) => {
+  if (/(^|[_-])POE([_-]|$)/.test(phrase)) return 1.2
+  if (
+    /(^|[_-])(PSE|PD|VPORT[PN]?|RDET\d*|CLASS\d*|CLS\d*)([_-]|$)/.test(phrase)
+  ) {
+    return 1.15
+  }
+}
+
 export const scorePhrase = (phrase: string) => {
+  const poeScore = scorePoePhrase(phrase)
+  if (poeScore) return poeScore
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-poe-pin-labels.test.ts
+++ b/tests/test4-poe-pin-labels.test.ts
@@ -1,0 +1,106 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves PoE power-interface aliases on generic pin labels", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_poe_pd",
+      name: "U1",
+      manufacturer_part_number: "TPS2378",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_rj45",
+      name: "J1",
+      manufacturer_part_number: "RJ45-POE",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_vportp",
+      source_component_id: "source_component_poe_pd",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "POE_VPORTP"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_vportp",
+      source_component_id: "source_component_rj45",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "POE_VPORTP"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_class",
+      source_component_id: "source_component_poe_pd",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["pin15", "PSE_CLASS0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_class",
+      source_component_id: "source_component_rj45",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["pin2", "PSE_CLASS0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_rdet",
+      source_component_id: "source_component_poe_pd",
+      name: "pin16",
+      pin_number: 16,
+      port_hints: ["pin16", "RDET1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_j1_rdet",
+      source_component_id: "source_component_rj45",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["pin3", "RDET1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_vportp",
+      connected_source_port_ids: [
+        "source_port_u1_vportp",
+        "source_port_j1_vportp",
+      ],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_class",
+      connected_source_port_ids: [
+        "source_port_u1_class",
+        "source_port_j1_class",
+      ],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_rdet",
+      connected_source_port_ids: ["source_port_u1_rdet", "source_port_j1_rdet"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_POE_VPORTP")
+  expect(netlist).toContain("  - U1 pin14 (POE_VPORTP)")
+  expect(netlist).toContain("  - J1 pin1 (POE_VPORTP)")
+  expect(netlist).toContain("NET: U1_PSE_CLASS0")
+  expect(netlist).toContain("  - U1 pin15 (PSE_CLASS0)")
+  expect(netlist).toContain("  - J1 pin2 (PSE_CLASS0)")
+  expect(netlist).toContain("NET: U1_RDET1")
+  expect(netlist).toContain("  - U1 pin16 (RDET1)")
+  expect(netlist).toContain("  - J1 pin3 (RDET1)")
+})


### PR DESCRIPTION
## What changed

This adds a narrow scorer for Power-over-Ethernet interface labels: `POE_*`, `PSE`, `PD`, `VPORT`, `RDET`, `CLASS`, and `CLS`. Those labels now beat the generic digit fallback before the netlist falls back to physical names like `pin14`.

## Why

PoE powered-device pins often carry useful labels such as `POE_VPORTP`, `PSE_CLASS0`, or `RDET1`. Before this change, readable NET sections could hide those labels even though they are the meaningful part of the connection.

## Checks

- `bun test tests/test4-poe-pin-labels.test.ts`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/test4-poe-pin-labels.test.ts`
- `bun run build`
- `git diff --check`

/claim #4