### PR TITLE
Fix readable labels for generic chip pins

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,19 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const description = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = description
+          ? `${component.name} (${description})`
+          : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const description = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = description
+          ? `${component.name} (${description})`
+          : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -1,11 +1,33 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
+
+const isGenericPinLabel = (label: string | undefined, pinNumber?: number) => {
+  if (!label) return false
+  const normalized = label.toLowerCase()
+  return (
+    normalized === "pin" ||
+    normalized === `pin${pinNumber}` ||
+    normalized === String(pinNumber) ||
+    /^pin\d+$/i.test(label)
+  )
+}
+
+const getBestDescriptivePinName = ({
+  name,
+  portHints,
+  pinNumber,
+}: {
+  name?: string
+  portHints?: string[]
+  pinNumber?: number
+}) => {
+  if (name && !isGenericPinLabel(name, pinNumber)) return name
+
+  return [...new Set(portHints ?? [])].find(
+    (hint) => !isGenericPinLabel(hint, pinNumber),
+  )
+}
 
 export const getReadableNameForPin = ({
   circuitJson,
@@ -34,9 +56,25 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const fallbackPinName =
+    port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+  const mainPinName =
+    getBestDescriptivePinName({
+      name: port.name,
+      portHints: port.port_hints,
+      pinNumber: port.pin_number,
+    }) ??
+    fallbackPinName ??
+    "pin"
 
   const additionalPinLabels: string[] = []
+
+  if (
+    isGenericPinLabel(port.name, port.pin_number) &&
+    port.name !== mainPinName
+  ) {
+    additionalPinLabels.push(port.name)
+  }
 
   if (isPositive && component.ftype !== "simple_resistor") {
     additionalPinLabels.push("+")
@@ -46,6 +84,8 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (port_hint === port.name) continue
+    if (port_hint === String(port.pin_number)) continue
     const score = scorePhrase(port_hint)
     if (score > 1) {
       additionalPinLabels.push(port_hint)
@@ -55,5 +95,6 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  const uniqueAdditionalPinLabels = Array.from(new Set(additionalPinLabels))
+  return `${component.name} ${mainPinName}${uniqueAdditionalPinLabels.length > 0 ? ` (${uniqueAdditionalPinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -17,12 +17,15 @@ const getBestDescriptivePinName = ({
   name,
   portHints,
   pinNumber,
+  preferDescriptiveHints,
 }: {
   name?: string
   portHints?: string[]
   pinNumber?: number
+  preferDescriptiveHints: boolean
 }) => {
   if (name && !isGenericPinLabel(name, pinNumber)) return name
+  if (!preferDescriptiveHints) return undefined
 
   return [...new Set(portHints ?? [])].find(
     (hint) => !isGenericPinLabel(hint, pinNumber),
@@ -63,6 +66,7 @@ export const getReadableNameForPin = ({
       name: port.name,
       portHints: port.port_hints,
       pinNumber: port.pin_number,
+      preferDescriptiveHints: component.ftype === "simple_chip",
     }) ??
     fallbackPinName ??
     "pin"

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -11,11 +11,15 @@ const wordQualityScore = {
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
+  SCK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  GP: 1.1,
+  ADC: 1.1,
+  PWM: 1.1,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +40,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.toUpperCase()
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-generic-pin-labels.test.ts
+++ b/tests/test4-generic-pin-labels.test.ts
@@ -1,0 +1,75 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses descriptive pin hints instead of generic pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "J1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "pin14", "GP10", "SPI1_SCK"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "SCK",
+      pin_number: 1,
+      port_hints: ["SCK"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("  - U1 GP10 (pin14,SPI1_SCK)")
+  expect(netlist).not.toContain("  - U1 pin14")
+  expect(netlist).toContain("- pin14(GP10, SPI1_SCK): NETS(")
+})
+
+it("does not print undefined when passives have no footprint", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      resistance: 10000,
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_capacitor",
+      source_component_id: "source_component_2",
+      name: "C1",
+      capacitance: 1e-7,
+      display_capacitance: "100nF",
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("R1 (10kΩ)")
+  expect(netlist).toContain("C1 (100nF)")
+})


### PR DESCRIPTION
## Summary
- Prefer descriptive port hints when source port names are generic, e.g. `pin14`
- Preserve generic pin names and alternate functions as aliases
- Improve phrase scoring for pin/net names such as `GP10`, `SCK`, `ADC`, and `PWM`
- Avoid printing `undefined` in passive component pin headers when footprint data is absent

Fixes #4.

## Tests
- npm run build
- npx tsc --noEmit
- npx biome check lib/convertCircuitJsonToReadableNetlist.ts lib/getReadableNameForPin.ts lib/scorePhrase.ts tests/test4-generic-pin-labels.test.ts
- Node smoke test against built dist output

Note: `npm test` requires Bun, which is not installed in this environment.
