### PR TITLE
Score SD card pin aliases in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const sdCardSignalPattern =
+  /^(?:SDIO|SDMMC|MMC|MICROSD|SDCARD)[_-]?(?:D[0-7]|DAT[0-7]|CMD|CLK|CK|CD|WP)$/
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase().replace(/\s+/g, "_")
+  if (
+    sdCardSignalPattern.test(normalizedPhrase) ||
+    normalizedPhrase.match(/^DAT[0-7]$/)
+  ) {
+    return 1.16
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,14 +36,11 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 const sdCardSignalPattern =
-  /^(?:SDIO|SDMMC|MMC|MICROSD|SDCARD)[_-]?(?:D[0-7]|DAT[0-7]|CMD|CLK|CK|CD|WP)$/
+  /^(?:(?:SDIO|MMC|MICROSD|SDCARD)[_-]?(?:D[0-7]|DAT[0-7])|SDMMC[_-]CK|DAT[0-7])$/
 
 export const scorePhrase = (phrase: string) => {
   const normalizedPhrase = phrase.toUpperCase().replace(/\s+/g, "_")
-  if (
-    sdCardSignalPattern.test(normalizedPhrase) ||
-    normalizedPhrase.match(/^DAT[0-7]$/)
-  ) {
+  if (sdCardSignalPattern.test(normalizedPhrase)) {
     return 1.16
   }
   if (phrase.match(/\d+/)) {

--- a/tests/sd-card-pin-labels.test.tsx
+++ b/tests/sd-card-pin-labels.test.tsx
@@ -2,7 +2,7 @@ import { expect, it } from "bun:test"
 import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
 import { renderCircuit } from "tests/fixtures/render-circuit"
 
-it("keeps SD card aliases for generic data pins", () => {
+it("keeps digit-bearing SD card aliases for generic data pins", () => {
   const circuitJson = renderCircuit(
     <board width="10mm" height="10mm" routingDisabled>
       <chip
@@ -11,8 +11,7 @@ it("keeps SD card aliases for generic data pins", () => {
         manufacturerPartNumber="RP2040"
         pinLabels={{
           pin14: ["D0", "SDIO_D0"],
-          pin15: ["CMD", "SDIO_CMD"],
-          pin16: ["CLK", "SDMMC_CK"],
+          pin15: ["CLK", "SDMMC_CK"],
         }}
       />
       <chip
@@ -20,24 +19,23 @@ it("keeps SD card aliases for generic data pins", () => {
         footprint="soic8"
         manufacturerPartNumber="MICROSD_SOCKET"
         pinLabels={{
-          pin1: ["DAT0"],
-          pin2: ["CMD"],
-          pin3: ["CLK"],
+          pin1: ["pin1", "DAT0"],
+          pin3: ["pin3", "CLK"],
         }}
       />
+      <resistor resistance="10k" footprint="0402" name="R1" />
 
       <trace from=".U1 .D0" to=".J1 .DAT0" />
-      <trace from=".U1 .CMD" to=".J1 .CMD" />
       <trace from=".U1 .CLK" to=".J1 .CLK" />
+      <trace from=".J1 .pin1" to=".R1 .pin1" />
     </board>,
   )
 
   const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
 
   expect(netlist).toContain("NET: U1_SDIO_D0")
-  expect(netlist).toContain("NET: U1_SDIO_CMD")
   expect(netlist).toContain("NET: U1_SDMMC_CK")
   expect(netlist).toContain("U1 D0 (SDIO_D0)")
-  expect(netlist).toContain("U1 CMD (SDIO_CMD)")
   expect(netlist).toContain("U1 CLK (SDMMC_CK)")
+  expect(netlist).toContain("J1 pin1 (DAT0)")
 })

--- a/tests/sd-card-pin-labels.test.tsx
+++ b/tests/sd-card-pin-labels.test.tsx
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("keeps SD card aliases for generic data pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="RP2040"
+        pinLabels={{
+          pin14: ["D0", "SDIO_D0"],
+          pin15: ["CMD", "SDIO_CMD"],
+          pin16: ["CLK", "SDMMC_CK"],
+        }}
+      />
+      <chip
+        name="J1"
+        footprint="soic8"
+        manufacturerPartNumber="MICROSD_SOCKET"
+        pinLabels={{
+          pin1: ["DAT0"],
+          pin2: ["CMD"],
+          pin3: ["CLK"],
+        }}
+      />
+
+      <trace from=".U1 .D0" to=".J1 .DAT0" />
+      <trace from=".U1 .CMD" to=".J1 .CMD" />
+      <trace from=".U1 .CLK" to=".J1 .CLK" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_SDIO_D0")
+  expect(netlist).toContain("NET: U1_SDIO_CMD")
+  expect(netlist).toContain("NET: U1_SDMMC_CK")
+  expect(netlist).toContain("U1 D0 (SDIO_D0)")
+  expect(netlist).toContain("U1 CMD (SDIO_CMD)")
+  expect(netlist).toContain("U1 CLK (SDMMC_CK)")
+})


### PR DESCRIPTION
## Summary
- score only the uncovered SD/MMC aliases that need handling before the generic numeric fallback: `SDIO_Dn` / `DATn` style labels and `SDMMC_CK`
- add a regression covering `SDIO_D0`, `SDMMC_CK`, and `DAT0` in readable NET/pin output

## Validation
- `bun test tests/sd-card-pin-labels.test.tsx`
- `bunx biome check lib/scorePhrase.ts tests/sd-card-pin-labels.test.tsx`
- `bunx tsc --noEmit`
- `bun run build`
- `bun test`

Validation follow-up: after opening this, I found older PR #122 in the broader SD/MMC label area. I narrowed this PR so it avoids the broad `CMD`/`CLK` style aliases there and focuses on the digit-bearing aliases that still hit the numeric fallback first.

Transparency: AI-assisted with Codex; I reviewed the diff before submission.

/claim #4