### PR TITLE
Score I2S/PDM audio interface pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const scoreAudioInterfacePhrase = (phrase: string) => {
+  // Avoid the generic digit penalty for common audio interface pin aliases.
+  // Examples: I2S_BCLK, I2S_LRCLK, I2S_WS, I2S_SDOUT, PDM_CLK, PDM_DAT.
+  if (/(^|[_-])I2S([_-]|$)/.test(phrase)) return 1.2
+  if (/(^|[_-])(BCLK|LRCLK|WS|MCLK)([_-]|$)/.test(phrase)) return 1.15
+  if (/(^|[_-])(SDIN|SDOUT|DIN|DOUT|DATA)([_-]|$)/.test(phrase)) return 1.1
+  if (/(^|[_-])PDM([_-]|$)/.test(phrase)) return 1.2
+  if (/(^|[_-])(PDM_CLK|PDM_DAT)([_-]|$)/.test(phrase)) return 1.15
+}
+
 export const scorePhrase = (phrase: string) => {
+  const audioScore = scoreAudioInterfacePhrase(phrase)
+  if (audioScore) return audioScore
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-audio-interface-pin-labels.test.tsx
+++ b/tests/test4-audio-interface-pin-labels.test.tsx
@@ -1,0 +1,63 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("test4 audio interface pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="AUDIOCODEC"
+        pinLabels={{
+          pin1: ["GND"],
+          pin2: ["VDD"],
+          pin3: ["I2S_BCLK"],
+          pin4: ["I2S_LRCLK"],
+          pin5: ["I2S_SDOUT"],
+          pin6: ["I2S_SDIN"],
+          pin7: ["PDM_CLK"],
+          pin8: ["PDM_DAT"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .I2S_BCLK" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: AUDIOCODEC, soic8
+     - R1: 1kΩ 0402 resistor
+
+    NET: U1_I2S_BCLK
+      - U1 I2S_BCLK
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (AUDIOCODEC)
+    - pin1(GND): NOT_CONNECTED
+    - pin2(VDD): NOT_CONNECTED
+    - pin3(I2S_BCLK): NETS(U1_I2S_BCLK)
+    - pin4(I2S_LRCLK): NOT_CONNECTED
+    - pin5(I2S_SDOUT): NOT_CONNECTED
+    - pin6(I2S_SDIN): NOT_CONNECTED
+    - pin7(PDM_CLK): NOT_CONNECTED
+    - pin8(PDM_DAT): NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_I2S_BCLK)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## What changed

Adds a small scorer for common audio interface pin aliases so digit-bearing labels like `I2S_BCLK` and `PDM_CLK` beat the generic digit penalty. This helps readable NET sections preserve meaningful pin names instead of falling back to low-signal labels.

## Tests

- `bun test tests/test4-audio-interface-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/test4-audio-interface-pin-labels.test.tsx`
- `bun run build`

/claim #4
