### PR TITLE
Score crypto security pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const cryptoSecurityAliasPattern =
+  /(^|[^A-Z0-9])(TRNG|RNG|AES|SHA|SHA256|SHA512|HMAC|PUF|CRYPTO|SECURE_BOOT|SECBOOT|OTP|KEYSTORE)(\d+)?($|[^A-Z0-9])/
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (cryptoSecurityAliasPattern.test(normalizedPhrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/crypto-security-pin-labels.test.ts
+++ b/tests/crypto-security-pin-labels.test.ts
@@ -1,0 +1,82 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves crypto and entropy-source pin aliases in readable netlists", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "ATECC608B",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      resistance: 10000,
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_capacitor",
+      source_component_id: "source_component_2",
+      name: "C1",
+      capacitance: 0.0000001,
+      display_capacitance: "100nF",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["TRNG1_RDY"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["AES_DONE"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_TRNG1_RDY")
+  expect(readableNetlist).toContain("  - U1 pin14 (TRNG1_RDY)")
+  expect(readableNetlist).toContain("NET: U1_AES_DONE")
+  expect(readableNetlist).toContain("  - U1 pin15 (AES_DONE)")
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Summary
- score cryptographic accelerator and entropy-source aliases such as `TRNG1_RDY`, `AES_DONE`, `HMAC`, `PUF`, and `KEYSTORE` before the generic digit fallback
- preserve those aliases in generated readable NET names and NET pin entries for otherwise generic chip pins
- add raw Circuit JSON regression coverage for `TRNG1_RDY` and `AES_DONE`

## Verification
- `npx --yes bun test tests/crypto-security-pin-labels.test.ts`
- `npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check lib/scorePhrase.ts tests/crypto-security-pin-labels.test.ts`
- `npx --yes bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before submission.