### PR TITLE
Score seven-segment pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const sevenSegmentAliasPattern =
+  /^(?:SEG(?:MENT)?_?[A-G]|DIG(?:IT)?_?\d+|COM(?:MON)?_?\d+|DP|DECIMAL_?P(?:OINT)?)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (sevenSegmentAliasPattern.test(phrase)) {
+    return 1.16
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/seven-segment-pin-labels.test.tsx
+++ b/tests/seven-segment-pin-labels.test.tsx
@@ -1,0 +1,65 @@
+import { expect, it } from "bun:test"
+import type { SourcePort } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves seven-segment display driver aliases with digits", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{
+          pin1: ["SEG_A"],
+          pin2: ["DIG1"],
+        }}
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <trace from=".U1 .DIG1" to=".R1 .pin1" />
+    </board>,
+  )
+
+  const digitPort = circuitJson.find(
+    (element): element is SourcePort =>
+      element.type === "source_port" && element.name === "DIG1",
+  )
+  expect(digitPort).toBeDefined()
+
+  digitPort!.name = "pin2"
+  digitPort!.port_hints = ["DIG1", "DIGIT1", "pin2", "2"]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: soic8
+     - R1: 1kΩ 0402 resistor
+
+    NET: U1_DIG1
+      - U1 pin2 (DIG1,DIGIT1)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1
+    - pin1(SEG_A): NOT_CONNECTED
+    - pin2(DIG1, DIGIT1): NETS(U1_DIG1)
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_DIG1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- score focused seven-segment/display-driver aliases before the generic digit fallback
- preserve useful digit/common labels such as `DIG1`, `DIGIT1`, and `COM1` for generated readable net names and pin labels
- add regression coverage for a generic physical pin carrying seven-segment aliases

## Verification
- `bun test tests/seven-segment-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/seven-segment-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

Transparency note: this patch was prepared with AI-assisted coding and verified locally before submission.