### PR TITLE
Score SFP/QSFP transceiver pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,24 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isOpticalTransceiverManagementAlias = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase().replace(/[^A-Z0-9]+/g, "_")
+
+  return [
+    /^MOD_ABS\d*$/,
+    /^MODSEL(L)?\d*$/,
+    /^RATE_SELECT\d*$/,
+    /^RS[01]$/,
+    /^TX_FAULT\d*$/,
+    /^TX_DISABLE\d*$/,
+    /^RX_LOS\d*$/,
+  ].some((pattern) => pattern.test(normalizedPhrase))
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isOpticalTransceiverManagementAlias(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/optical-transceiver-pin-labels.test.tsx
+++ b/tests/optical-transceiver-pin-labels.test.tsx
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves SFP/QSFP optical transceiver management pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn16"
+        manufacturerPartNumber="SFP-MGMT"
+        pinLabels={{
+          pin14: ["MOD_ABS"],
+          pin15: ["RATE_SELECT"],
+          pin16: ["RS1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+      <resistor resistance="10k" footprint="0402" name="R3" />
+
+      <trace from=".U1 .MOD_ABS" to=".R1 .pin1" />
+      <trace from=".U1 .RATE_SELECT" to=".R2 .pin1" />
+      <trace from=".U1 .RS1" to=".R3 .pin1" />
+    </board>,
+  )
+
+  for (const element of circuitJson) {
+    if (element.type !== "source_port") continue
+    if (element.port_hints?.includes("MOD_ABS")) element.name = "pin14"
+    if (element.port_hints?.includes("RATE_SELECT")) element.name = "pin15"
+    if (element.port_hints?.includes("RS1")) element.name = "pin16"
+  }
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_MOD_ABS")
+  expect(readableNetlist).toContain("  - U1 pin14 (MOD_ABS)")
+  expect(readableNetlist).toContain("NET: U1_RATE_SELECT")
+  expect(readableNetlist).toContain("  - U1 pin15 (RATE_SELECT)")
+  expect(readableNetlist).toContain("NET: U1_RS1")
+  expect(readableNetlist).toContain("  - U1 pin16 (RS1)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- Add focused scoring for SFP/QSFP optical transceiver management aliases (`MOD_ABS`, `MODSEL`, `RATE_SELECT`, `RS0`/`RS1`, `TX_FAULT`, `TX_DISABLE`, `RX_LOS`) before the generic digit fallback.
- Add regression coverage for generic physical pins with `MOD_ABS`, `RATE_SELECT`, and `RS1` hints so generated NET names and readable pin entries preserve the useful labels.

## Verification
- `npx bun test tests/optical-transceiver-pin-labels.test.tsx`
- `npx bun test`
- `npx bun x biome check lib/scorePhrase.ts tests/optical-transceiver-pin-labels.test.tsx`
- `npx bun x tsc --noEmit`
- `npx bun run build`
- `git diff --check -- lib/scorePhrase.ts tests/optical-transceiver-pin-labels.test.tsx`

AI-assisted with Codex; I reviewed the diff and ran the verification above before submitting.