### PR TITLE
Score MIPI RFFE pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,12 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const mipiRffeAliasPattern = /^RFFE\d*_(SCLK|SDATA|VIO)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (mipiRffeAliasPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/mipi-rffe-pin-labels.test.ts
+++ b/tests/mipi-rffe-pin-labels.test.ts
@@ -1,0 +1,56 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves numbered MIPI RFFE aliases for generic chip pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "RFFE_CTRL",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      display_resistance: "1k",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      source_component_id: "source_component_1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      pin_number: 14,
+      name: "pin14",
+      port_hints: ["RFFE0_SCLK"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 1,
+      name: "pin1",
+      port_hints: ["pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_RFFE0_SCLK")
+  expect(netlist).toContain("  - U1 pin14 (RFFE0_SCLK)")
+  expect(netlist).toContain("- pin14(RFFE0_SCLK): NETS(U1_RFFE0_SCLK)")
+})


### PR DESCRIPTION
## Summary
- score numbered MIPI RFFE aliases before the generic digit fallback
- add regression coverage for generic chip pins carrying `RFFE0_SCLK`

/claim #4

## Verification
```powershell
npx bun test tests\mipi-rffe-pin-labels.test.ts
npx biome check lib\scorePhrase.ts tests\mipi-rffe-pin-labels.test.ts
npx tsc --noEmit
npx tsup ./lib/index.ts --format esm --dts
```

Note: local full `npx bun test` is blocked by an existing dependency-resolution mismatch after npm install: `@tscircuit/circuit-json-util` does not export `distanceBetweenCircleAndPolygon` for existing JSX tests. The new focused raw Circuit JSON regression test passes.