### PR TITLE
Score automotive diagnostic pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const automotiveDiagnosticPattern =
+  /(^|[_-])(OBD|KLINE|K_LINE|K-LINE|L_LINE|L-LINE|J1850|FLEXRAY)(\d+|[_-]|$)/i
+
 export const scorePhrase = (phrase: string) => {
+  if (automotiveDiagnosticPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/automotive-diagnostic-pin-labels.test.tsx
+++ b/tests/automotive-diagnostic-pin-labels.test.tsx
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves automotive diagnostic aliases on generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="VehicleGateway"
+        pinLabels={{
+          pin14: ["pin14", "KLINE1"],
+          pin15: ["pin15", "FLEXRAY_BP"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="2k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .KLINE1" to=".R1 .pin1" />
+      <trace from=".U1 .FLEXRAY_BP" to=".R2 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_KLINE1")
+  expect(netlist).toContain("  - U1 pin14 (KLINE1)")
+  expect(netlist).toContain("NET: U1_FLEXRAY_BP")
+  expect(netlist).toContain("  - U1 pin15 (FLEXRAY_BP)")
+  expect(scorePhrase("J1850_PWM")).toBeGreaterThan(1)
+  expect(scorePhrase("OBD_WAKE")).toBeGreaterThan(1)
+})


### PR DESCRIPTION
## Summary
- add focused scoring for automotive diagnostic/network aliases such as K-line, OBD, J1850, and FlexRay before the generic digit fallback
- add a regression proving generic chip pins preserve `KLINE1` and `FLEXRAY_BP` in readable NET names and pin entries

## Verification
- `npm exec --yes bun -- test tests/automotive-diagnostic-pin-labels.test.tsx`
- `npm exec --yes bun -- x biome check lib/scorePhrase.ts tests/automotive-diagnostic-pin-labels.test.tsx`
- `npm exec --yes bun -- test`
- `npm exec --yes bun -- x tsc --noEmit`
- `npm exec --yes bun -- run build`
- `git diff --check`

Disclosure: AI-assisted with Codex and manually reviewed.

/claim #4