### PR TITLE
Score infrared pin aliases in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,21 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const scoreInfraredAlias = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /\bIR(?:DA)?(?:[_-]|$)/.test(normalizedPhrase) ||
+    normalizedPhrase.includes("INFRARED") ||
+    normalizedPhrase.includes("DEMOD")
+  ) {
+    return 1.18
+  }
+}
+
 export const scorePhrase = (phrase: string) => {
+  const infraredScore = scoreInfraredAlias(phrase)
+  if (infraredScore) return infraredScore
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-infrared-pin-labels.test.tsx
+++ b/tests/test4-infrared-pin-labels.test.tsx
@@ -1,0 +1,42 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves infrared remote and IrDA aliases on generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="IR-CONTROLLER"
+        pinLabels={{
+          pin14: ["IR_LED1"],
+          pin15: ["IRDA_SD"],
+        }}
+      />
+      <resistor resistance="100Ω" footprint="0402" name="R1" />
+      <resistor resistance="10kΩ" footprint="0402" name="R2" />
+
+      <trace from=".U1 .IR_LED1" to=".R1 > .pin1" />
+      <trace from=".U1 .IRDA_SD" to=".R2 > .pin1" />
+    </board>,
+  )
+  for (const element of circuitJson as any[]) {
+    if (element.type !== "source_port") continue
+    if (element.name === "IR_LED1") {
+      element.name = "pin14"
+      element.port_hints = ["IR_LED1"]
+    }
+    if (element.name === "IRDA_SD") {
+      element.name = "pin15"
+      element.port_hints = ["IRDA_SD"]
+    }
+  }
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_IR_LED1")
+  expect(netlist).toContain("  - U1 pin14 (IR_LED1)")
+  expect(netlist).toContain("NET: U1_IRDA_SD")
+  expect(netlist).toContain("  - U1 pin15 (IRDA_SD)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- Add focused scoring for infrared remote / IrDA aliases such as `IR_LED1`, `IRDA_SD`, and `IR_DEMOD_OUT` before the generic digit fallback.
- Preserve those aliases in generated readable NET names and NET pin entries for otherwise generic chip pins.
- Add raw Circuit JSON regression coverage for `IR_LED1` and `IRDA_SD`.

## Verification
- `npx --yes bun@latest test tests/test4-infrared-pin-labels.test.tsx`
- `npx --yes bun@latest test`
- `npx --yes tsc --noEmit`
- `npx --yes @biomejs/biome check lib/scorePhrase.ts tests/test4-infrared-pin-labels.test.tsx`
- `npx --yes bun@latest run build`

Disclosure: AI-assisted with Codex and manually reviewed before submission.