### PR TITLE
Score industrial sensor link pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const industrialSensorLinkPattern =
+  /(^|[_-])(IOLINK|IO_LINK|IO-LINK|HART|LOOP_?4_?20MA|4_?20MA)(\d+|[_-]|$)/i
+
 export const scorePhrase = (phrase: string) => {
+  if (industrialSensorLinkPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/industrial-sensor-link-pin-labels.test.tsx
+++ b/tests/industrial-sensor-link-pin-labels.test.tsx
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves industrial sensor-link aliases on generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="IndustrialAfe"
+        pinLabels={{
+          pin14: ["pin14", "IOLINK_CQ"],
+          pin15: ["pin15", "LOOP_4_20MA"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="2k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .IOLINK_CQ" to=".R1 .pin1" />
+      <trace from=".U1 .LOOP_4_20MA" to=".R2 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_IOLINK_CQ")
+  expect(netlist).toContain("  - U1 pin14 (IOLINK_CQ)")
+  expect(netlist).toContain("NET: U1_LOOP_4_20MA")
+  expect(netlist).toContain("  - U1 pin15 (LOOP_4_20MA)")
+  expect(scorePhrase("IO_LINK_WAKE")).toBeGreaterThan(1)
+  expect(scorePhrase("HART_TX")).toBeGreaterThan(1)
+})


### PR DESCRIPTION
## Summary
- add focused scoring for IO-Link, HART, and 4-20mA process-loop aliases before the generic digit fallback
- add a regression proving generic chip pins preserve `IOLINK_CQ` and `LOOP_4_20MA` in readable NET names and pin entries

## Verification
- `npm exec --yes bun -- test tests/industrial-sensor-link-pin-labels.test.tsx`
- `npm exec --yes bun -- x biome check lib/scorePhrase.ts tests/industrial-sensor-link-pin-labels.test.tsx`
- `npm exec --yes bun -- test`
- `npm exec --yes bun -- x tsc --noEmit`
- `npm exec --yes bun -- run build`
- `git diff --check`

Disclosure: AI-assisted with Codex and manually reviewed.

/claim #4