### PR TITLE
Score rangefinder pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const rangefinderPattern =
+  /(^|[_-])(ULTRASONIC|SONAR|LIDAR|TOF|TIME_OF_FLIGHT|HC_SR04)(\d+|[_-]|$)/i
+
 export const scorePhrase = (phrase: string) => {
+  if (rangefinderPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/rangefinder-pin-labels.test.tsx
+++ b/tests/rangefinder-pin-labels.test.tsx
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves rangefinder aliases on generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="RangeSensorHub"
+        pinLabels={{
+          pin14: ["pin14", "ULTRASONIC_TRIG"],
+          pin15: ["pin15", "TOF_READY"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="2k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .ULTRASONIC_TRIG" to=".R1 .pin1" />
+      <trace from=".U1 .TOF_READY" to=".R2 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ULTRASONIC_TRIG")
+  expect(netlist).toContain("  - U1 pin14 (ULTRASONIC_TRIG)")
+  expect(netlist).toContain("NET: U1_TOF_READY")
+  expect(netlist).toContain("  - U1 pin15 (TOF_READY)")
+  expect(scorePhrase("SONAR_ECHO")).toBeGreaterThan(1)
+  expect(scorePhrase("LIDAR_INT")).toBeGreaterThan(1)
+})


### PR DESCRIPTION
## Summary
- add focused scoring for ultrasonic, sonar, LiDAR, and time-of-flight rangefinder aliases before the generic digit/default fallback
- add a regression proving generic chip pins preserve `ULTRASONIC_TRIG` and `TOF_READY` in readable NET names and pin entries

## Verification
- `npm exec --yes bun -- test tests/rangefinder-pin-labels.test.tsx`
- `npm exec --yes bun -- x biome check lib/scorePhrase.ts tests/rangefinder-pin-labels.test.tsx`
- `npm exec --yes bun -- test`
- `npm exec --yes bun -- x tsc --noEmit`
- `npm exec --yes bun -- run build`
- `git diff --check`

Disclosure: AI-assisted with Codex and manually reviewed.

/claim #4