### PR TITLE
Score barcode scanner pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const barcodeScannerPattern =
+  /(^|[_-])(BARCODE|QRCODE|QR|SCAN_GOOD|SCANGOOD|LASER_EN|LASEREN)(\d+|[_-]|$)/i
+
 export const scorePhrase = (phrase: string) => {
+  if (barcodeScannerPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/barcode-scanner-pin-labels.test.tsx
+++ b/tests/barcode-scanner-pin-labels.test.tsx
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves barcode scanner aliases on generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="ScannerModule"
+        pinLabels={{
+          pin14: ["pin14", "BARCODE_TRIG"],
+          pin15: ["pin15", "QR_DECODE"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="2k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .BARCODE_TRIG" to=".R1 .pin1" />
+      <trace from=".U1 .QR_DECODE" to=".R2 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_BARCODE_TRIG")
+  expect(netlist).toContain("  - U1 pin14 (BARCODE_TRIG)")
+  expect(netlist).toContain("NET: U1_QR_DECODE")
+  expect(netlist).toContain("  - U1 pin15 (QR_DECODE)")
+  expect(scorePhrase("SCAN_GOOD")).toBeGreaterThan(1)
+  expect(scorePhrase("LASER_EN")).toBeGreaterThan(1)
+})


### PR DESCRIPTION
## Summary
- add focused scoring for barcode and QR scanner aliases before the generic digit/default fallback
- add a regression proving generic chip pins preserve `BARCODE_TRIG` and `QR_DECODE` in readable NET names and pin entries

## Verification
- `npm exec --yes bun -- test tests/barcode-scanner-pin-labels.test.tsx`
- `npm exec --yes bun -- x biome check lib/scorePhrase.ts tests/barcode-scanner-pin-labels.test.tsx`
- `npm exec --yes bun -- test`
- `npm exec --yes bun -- x tsc --noEmit`
- `npm exec --yes bun -- run build`
- `git diff --check`

Disclosure: AI-assisted with Codex and manually reviewed.

/claim #4