### PR TITLE
Preserve UFS storage aliases in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,12 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const ufsStorageAliasPattern = /(?:^|[_-])(?:UFS|UNIPRO|M_PHY|MPHY)(?:[_-]|$)/
+
 export const scorePhrase = (phrase: string) => {
+  if (ufsStorageAliasPattern.test(phrase.toUpperCase())) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-ufs-pin-labels.test.tsx
+++ b/tests/test4-ufs-pin-labels.test.tsx
@@ -1,0 +1,39 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves UFS storage aliases on generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn20"
+        manufacturerPartNumber="UFSCTRL"
+        pinLabels={{
+          pin14: ["pin14", "UFS_TXP0"],
+          pin15: ["pin15", "UFS_RXN0"],
+          pin16: ["pin16", "UFS_REFCLK"],
+          pin17: ["pin17", "UFS_RESET_N"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .UFS_TXP0" to=".R1 .pin1" />
+      <trace from=".U1 .UFS_RXN0" to=".R1 .pin2" />
+      <trace from=".U1 .UFS_REFCLK" to=".C1 .pin1" />
+      <trace from=".U1 .UFS_RESET_N" to=".C1 .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_UFS_TXP0")
+  expect(netlist).toContain("  - U1 pin14 (UFS_TXP0)")
+  expect(netlist).toContain("NET: U1_UFS_RXN0")
+  expect(netlist).toContain("  - U1 pin15 (UFS_RXN0)")
+  expect(netlist).toContain("NET: U1_UFS_REFCLK")
+  expect(netlist).toContain("  - U1 pin16 (UFS_REFCLK)")
+  expect(netlist).toContain("NET: U1_UFS_RESET_N")
+  expect(netlist).toContain("  - U1 pin17 (UFS_RESET_N)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for UFS / UniPro storage-interface aliases before the generic digit fallback.
- Preserve labels such as `UFS_TXP0`, `UFS_RXN0`, `UFS_REFCLK`, and `UFS_RESET_N` in generated readable NET names and NET pin entries.
- Add regression coverage for generic physical pins carrying UFS aliases.

## Verification
- `npm.cmd exec --yes bun@latest -- test tests/test4-ufs-pin-labels.test.tsx`
- `npm.cmd exec --yes bun@latest -- test`
- `npm.cmd exec --yes bun@latest -- x tsc --noEmit`
- `npm.cmd exec --yes bun@latest -- run build`
- `npm.cmd exec --yes bun@latest -- x biome check lib/scorePhrase.ts tests/test4-ufs-pin-labels.test.tsx`
- `git diff --check -- lib/scorePhrase.ts tests/test4-ufs-pin-labels.test.tsx`

/claim #4

Transparency: AI-assisted with Codex; I reviewed the diff and ran the verification above locally.