### PR TITLE
Use semantic pin labels in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,16 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${[component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${[
+          component.display_capacitance,
+          footprint,
+        ]
+          .filter(Boolean)
+          .join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -25,6 +25,19 @@ export const getReadableNameForPin = ({
   )
   if (!component) return ""
 
+  const isNumberedPinName = (name: string) =>
+    port.pin_number !== undefined &&
+    (name.toLowerCase() === `pin${port.pin_number}` ||
+      name === String(port.pin_number))
+
+  const fallbackPinName =
+    port.name || (port.pin_number !== undefined ? `Pin${port.pin_number}` : "")
+
+  const bestHint = (port.port_hints ?? [])
+    .filter((hint) => hint !== fallbackPinName && !isNumberedPinName(hint))
+    .map((hint) => ({ hint, score: scorePhrase(hint) }))
+    .find(({ score }) => score > 1)?.hint
+
   // Determine pin polarity from hints
   const isPositive = port.port_hints?.some((hint) =>
     ["anode", "pos", "positive"].includes(hint.toLowerCase()),
@@ -34,7 +47,8 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName =
+    isNumberedPinName(fallbackPinName) && bestHint ? bestHint : fallbackPinName
 
   const additionalPinLabels: string[] = []
 

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,11 +36,12 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
+  const trimmedPhrase = phrase.trim()
+  if (/^\d+$/.test(trimmedPhrase) || /^pin\d+$/i.test(trimmedPhrase)) {
     return 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (trimmedPhrase.toLowerCase().includes(word.toLowerCase())) {
       return score
     }
   }

--- a/tests/test4-readable-pin-labels.test.ts
+++ b/tests/test4-readable-pin-labels.test.ts
@@ -1,0 +1,74 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses semantic pin labels when numbered pin names have better hints", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "PICO-W",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_2",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GPIO22", "SCL1", "pin14", "14"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).not.toContain("  - U1 pin14")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: PICO-W
+     - R1: 1k resistor
+
+    NET: U1_SCL1
+      - U1 GPIO22 (SCL1)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (PICO-W)
+    - pin14(GPIO22, SCL1): NETS(U1_SCL1)
+
+    R1 (1k)
+    - pin1: NETS(U1_SCL1)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary

- prefer semantic port hints like `GPIO22` over mechanical names like `pin14` in readable netlist pin entries
- keep numbered-only hints such as `14` and `pin14` low quality while allowing labels with numbers, such as `GPIO22` and `SCL1`, to score normally
- avoid `undefined` in resistor/capacitor pin headers when a footprint is absent
- add a regression test covering the short pin label and undefined output cases

## Tests

- bun test
- tsc --noEmit
- biome check lib/scorePhrase.ts lib/getReadableNameForPin.ts lib/convertCircuitJsonToReadableNetlist.ts tests/test4-readable-pin-labels.test.ts
- git diff --check

Fixes #4
/claim #4