### PR TITLE
Score maker connector pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const makerConnectorAliasPattern =
+  /(?:QWIIC|STEMMA(?:_QT)?|GROVE|MIKROBUS|MIKROE|CLICK)/
+
 export const scorePhrase = (phrase: string) => {
+  if (makerConnectorAliasPattern.test(phrase.toUpperCase())) {
+    return 1.16
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/maker-connector-pin-labels.test.tsx
+++ b/tests/maker-connector-pin-labels.test.tsx
@@ -1,0 +1,39 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves maker connector aliases on generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="RP2040"
+        pinLabels={{
+          pin1: ["pin14", "QWIIC_SDA"],
+          pin2: ["pin15", "STEMMA_QT_SCL"],
+          pin3: ["pin16", "GROVE_SIG1"],
+          pin4: ["pin17", "MIKROBUS_INT"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .pin14" to=".R1 .pin1" />
+      <trace from=".U1 .pin15" to=".R1 .pin2" />
+      <trace from=".U1 .pin16" to=".C1 .pin1" />
+      <trace from=".U1 .pin17" to=".C1 .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_QWIIC_SDA")
+  expect(netlist).toContain("  - U1 pin14 (QWIIC_SDA)")
+  expect(netlist).toContain("NET: U1_STEMMA_QT_SCL")
+  expect(netlist).toContain("  - U1 pin15 (STEMMA_QT_SCL)")
+  expect(netlist).toContain("NET: U1_GROVE_SIG1")
+  expect(netlist).toContain("  - U1 pin16 (GROVE_SIG1)")
+  expect(netlist).toContain("NET: U1_MIKROBUS_INT")
+  expect(netlist).toContain("  - U1 pin17 (MIKROBUS_INT)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for Qwiic, STEMMA QT, Grove, and mikroBUS connector aliases before the generic digit fallback
- add regression coverage proving generic chip pins preserve those connector aliases in generated NET names and readable pin entries

## Verification
- bun test tests/maker-connector-pin-labels.test.tsx
- bun test
- bun x tsc --noEmit
- bun x biome check lib/scorePhrase.ts tests/maker-connector-pin-labels.test.tsx
- bun run build
- git diff --check

/claim #4