### PR TITLE
Score PMOD pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,15 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const pmodExpansionHeaderAliasPatterns = [/^PMOD(?:_|$)/]
+
 export const scorePhrase = (phrase: string) => {
+  if (
+    pmodExpansionHeaderAliasPatterns.some((pattern) => pattern.test(phrase))
+  ) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/pmod-pin-labels.test.ts
+++ b/tests/pmod-pin-labels.test.ts
@@ -1,0 +1,81 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves PMOD expansion header aliases in readable net names and pins", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "PMOD_HOST",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "J1",
+      manufacturer_part_number: "PMOD_DEVICE",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "J2",
+      manufacturer_part_number: "PMOD_DEVICE",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["PMOD_JA1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_0",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["PMOD_INT"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_2", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_PMOD_JA1")
+  expect(readableNetlist).toContain("NET: U1_PMOD_INT")
+  expect(readableNetlist).toContain("  - U1 pin14 (PMOD_JA1)")
+  expect(readableNetlist).toContain("  - U1 pin15 (PMOD_INT)")
+  expect(readableNetlist).not.toContain("undefined")
+})


### PR DESCRIPTION
/claim #4

## Summary
- Scores PMOD expansion-header aliases before the generic digit fallback.
- Adds raw Circuit JSON regression coverage proving `PMOD_JA1` and `PMOD_INT` are preserved in generated NET names and readable pin entries.
- Keeps the change scoped to PMOD labels only; no generic scorer rewrite.

## Why
PMOD labels such as `PMOD_JA1` contain digits, so the old scorer returned the generic numeric score before treating the alias as useful. That could make generated net names prefer low-information endpoints and render NET pin lines like `U1 pin14` instead of showing the useful PMOD label.

## Demo / Verification
This is a non-UI library change, so the demo is the focused terminal regression plus full local checks:

- `bun test tests/pmod-pin-labels.test.ts`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/pmod-pin-labels.test.ts`
- `bun run build`
- `git diff --check`