### PR TITLE
Score PLC and discrete industrial IO pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const industrialIoAliasPattern =
+  /^(PLC_(DI|DO|AI|AO)\d*|OPTO_(IN|OUT)\d*|SINK(_OUT)?\d*|SOURCE(_OUT)?\d*)$/
+
 export const scorePhrase = (phrase: string) => {
+  if (industrialIoAliasPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/industrial-io-pin-labels.test.ts
+++ b/tests/industrial-io-pin-labels.test.ts
@@ -1,0 +1,88 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves PLC and discrete industrial IO aliases on generic pins", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "PLC-IO",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_r1",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_r2",
+      name: "R2",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_pin14",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["PLC_DI1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_pin15",
+      source_component_id: "source_component_u1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["OPTO_IN1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_pin1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r2_pin1",
+      source_component_id: "source_component_r2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_plc_di1",
+      connected_source_port_ids: [
+        "source_port_u1_pin14",
+        "source_port_r1_pin1",
+      ],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_opto_in1",
+      connected_source_port_ids: [
+        "source_port_u1_pin15",
+        "source_port_r2_pin1",
+      ],
+    },
+  ] as any
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_PLC_DI1")
+  expect(readableNetlist).toContain("  - U1 pin14 (PLC_DI1)")
+  expect(readableNetlist).toContain("- pin14(PLC_DI1): NETS(U1_PLC_DI1)")
+  expect(readableNetlist).toContain("NET: U1_OPTO_IN1")
+  expect(readableNetlist).toContain("  - U1 pin15 (OPTO_IN1)")
+  expect(readableNetlist).toContain("- pin15(OPTO_IN1): NETS(U1_OPTO_IN1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for PLC/discrete industrial IO aliases before the numeric fallback
- preserve aliases like `PLC_DI1` and `OPTO_IN1` in generated readable NET names and pin entries
- add raw Circuit JSON regression coverage for generic physical pins carrying industrial IO labels

/claim #4

## Verification
- `npm exec --yes bun -- test tests/industrial-io-pin-labels.test.ts`
- `npm exec --yes bun -- test`
- `npm exec --yes bun -- x tsc --noEmit`
- `npm exec --yes bun -- run build`
- `git diff --check`