### PR TITLE
Score isolated gate-driver pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isGateDriverProtectionPhrase = (phrase: string) => {
+  const normalized = phrase.toUpperCase()
+  return /^(GATE\d*(?:_[HL])?|DESAT\d*|ISO_(?:IN|OUT)\d*|HIN\d*|LIN\d*|HO\d*|LO\d*|MILLER_CLAMP\d*)$/.test(
+    normalized,
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isGateDriverProtectionPhrase(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/gate-driver-pin-labels.test.ts
+++ b/tests/gate-driver-pin-labels.test.ts
@@ -1,0 +1,83 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves isolated gate-driver protection aliases", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      manufacturer_part_number: "ISO5852S",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_q1",
+      name: "Q1",
+      manufacturer_part_number: "IGBT",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r1",
+      name: "R1",
+      resistance: 10000,
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_gate",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GATE1_H"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_q1_gate",
+      source_component_id: "source_component_q1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["gate"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_desat",
+      source_component_id: "source_component_u1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["DESAT1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_pos",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_gate",
+      connected_source_port_ids: ["source_port_u1_gate", "source_port_q1_gate"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_desat",
+      connected_source_port_ids: ["source_port_u1_desat", "source_port_r1_pos"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_GATE1_H")
+  expect(netlist).toContain("  - U1 pin14 (GATE1_H)")
+  expect(netlist).toContain("NET: U1_DESAT1")
+  expect(netlist).toContain("  - U1 pin15 (DESAT1)")
+  expect(netlist).toContain("- pin14(GATE1_H): NETS(U1_GATE1_H)")
+  expect(netlist).toContain("- pin15(DESAT1): NETS(U1_DESAT1)")
+})


### PR DESCRIPTION
## Summary
- score isolated gate-driver/protection aliases before the generic digit fallback
- preserve labels such as `GATE1_H`, `DESAT1`, `HO`, `LO`, and `ISO_OUT1` in generated readable NET names and pin entries
- add raw Circuit JSON regression coverage for `GATE1_H` and `DESAT1` on otherwise generic physical pins

## Status
Withdrawn from bounty consideration.

## Verification
- `npx --yes bun@1.2.17 test tests/gate-driver-pin-labels.test.ts`
- `npx --yes @biomejs/biome check lib/scorePhrase.ts tests/gate-driver-pin-labels.test.ts`
- `npx tsc --noEmit`
- `npx --yes bun@1.2.17 run build`
- `git diff --check`

## Note
- Full `npx --yes bun@1.2.17 test` still fails in the existing TSX fixture path before these raw regression assertions complete: `@tscircuit/circuit-json-util` does not export `distanceBetweenCircleAndCircle`. The new focused raw Circuit JSON test passes.

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.
