### PR TITLE
Preserve GNSS time-sync pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,25 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const timeSyncSignalTokens = [
+  "1PPS",
+  "GNSS_PPS",
+  "GPS_PPS",
+  "PPS_IN",
+  "PPS_OUT",
+  "PTP_SYNC",
+  "IEEE1588",
+  "TIMEPULSE",
+  "TIME_PULSE",
+  "CLKOUT",
+  "CLK_OUT",
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (timeSyncSignalTokens.some((token) => normalizedPhrase.includes(token))) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/gnss-time-sync-pin-labels.test.ts
+++ b/tests/gnss-time-sync-pin-labels.test.ts
@@ -1,0 +1,89 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves GNSS and precision time-sync pin labels", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_gnss",
+      name: "U1",
+      manufacturer_part_number: "GNSS-MODULE",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_mcu",
+      name: "U2",
+      manufacturer_part_number: "TIMEKEEPER-MCU",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_gnss_pps",
+      source_component_id: "source_component_gnss",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "GNSS_PPS", "1PPS"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_mcu_pps",
+      source_component_id: "source_component_mcu",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["2", "PPS_IN"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_ptp_sync",
+      source_component_id: "source_component_mcu",
+      name: "pin8",
+      pin_number: 8,
+      port_hints: ["8", "PTP_SYNC", "CLKOUT"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_ptp_header",
+      source_component_id: "source_component_gnss",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["3", "PTP_SYNC_OUT"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_pps",
+      connected_source_port_ids: [
+        "source_port_gnss_pps",
+        "source_port_mcu_pps",
+      ],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_ptp",
+      connected_source_port_ids: [
+        "source_port_ptp_sync",
+        "source_port_ptp_header",
+      ],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(
+    circuitJson as any,
+  )
+
+  expect(readableNetlist).toContain("NET: U1_GNSS_PPS")
+  expect(readableNetlist).toContain("  - U1 pin14 (GNSS_PPS,1PPS)")
+  expect(readableNetlist).toContain("  - U2 pin2 (PPS_IN)")
+  expect(readableNetlist).toContain("NET: U2_PTP_SYNC")
+  expect(readableNetlist).toContain("  - U2 pin8 (PTP_SYNC,CLKOUT)")
+  expect(readableNetlist).toContain("  - U1 pin3 (PTP_SYNC_OUT)")
+  expect(readableNetlist).toContain(
+    "- pin14(GNSS_PPS, 1PPS): NETS(U1_GNSS_PPS)",
+  )
+  expect(readableNetlist).toContain("- pin3(PTP_SYNC_OUT): NETS(U2_PTP_SYNC)")
+  expect(readableNetlist).toContain(
+    "- pin8(PTP_SYNC, CLKOUT): NETS(U2_PTP_SYNC)",
+  )
+})


### PR DESCRIPTION
/claim #4

## Summary
- add focused scoring for GNSS/PPS/PTP/time-sync aliases such as `1PPS`, `GNSS_PPS`, `PPS_IN`, `PTP_SYNC`, and `CLKOUT`
- add raw Circuit JSON regression coverage proving those aliases appear in readable NET entries and COMPONENT_PINS output
- keep the change scoped to time-sync labels without changing the broad generic digit fallback

## Verification
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/gnss-time-sync-pin-labels.test.ts`
- `git diff --check`
- `node --experimental-strip-types -e "import('./lib/scorePhrase.ts').then((m)=>{console.log(['1PPS','GNSS_PPS','PTP_SYNC','pin14'].map((x)=>[x,m.scorePhrase(x)]))})"`

Local note: `bun test` and `tsup`/esbuild did not complete in this Codex macOS session because the processes hung locally, so GitHub Actions should provide the final full Bun/build signal.