### PR TITLE
Fix undefined in netlist and improve pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,11 +145,26 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${[
+          component.display_resistance,
+          footprint,
+        ]
+          .filter(Boolean)
+          .join(" ")})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${[
+          component.display_capacitance,
+          footprint,
+        ]
+          .filter(Boolean)
+          .join(" ")})`
       } else if (component.manufacturer_part_number) {
-        header = `${component.name} (${component.manufacturer_part_number})`
+        header = `${component.name} (${[
+          component.manufacturer_part_number,
+          footprint,
+        ]
+          .filter(Boolean)
+          .join(" ")})`
       }
       netlist.push(header)
       const ports = source_ports
@@ -157,7 +172,9 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.pin_number !== undefined
+            ? `pin${port.pin_number}`
+            : (port.name ?? "unknown")
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -67,7 +67,8 @@ export const generateNetName = ({
     score: scorePhrase(name),
   }))
 
-  const bestPortName = phrases.sort((a, b) => b.score - a.score)[0].name
+  const sortedPhrases = phrases.sort((a, b) => b.score - a.score)
+  const bestPortName = sortedPhrases[0]?.name
 
   // Find the component that has the best port name
   const bestPort = ports.find(
@@ -77,5 +78,7 @@ export const generateNetName = ({
   const componentWithBestPort = all_source_components.find(
     (c) => c.source_component_id === bestPort?.source_component_id,
   )
-  return [componentWithBestPort?.name, bestPortName].filter(Boolean).join("_")
+  return [componentWithBestPort?.name, bestPortName]
+    .filter(Boolean)
+    .join("_") || "unnamed_net"
 }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -34,7 +34,9 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName =
+    port.name ||
+    (port.pin_number !== undefined ? `Pin${port.pin_number}` : "unknown")
 
   const additionalPinLabels: string[] = []
 

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  let bestScore = 1
   if (phrase.match(/\d+/)) {
-    return 0.5
+    bestScore = 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
-      return score
+      if (score > bestScore) {
+        bestScore = score
+      }
     }
   }
-  return 1
+  return bestScore
 }


### PR DESCRIPTION
This PR fixes issue #4 by handling undefined values in the netlist generation and improving pin label readability.

Changes:
- Fixed scorePhrase to correctly score labels with digits (e.g. GPIO1)
- Added fallbacks for undefined pin names and numbers
- Cleaned up string templates to avoid "undefined" text

/claim #4