### PR TITLE
Score voltage reference pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const voltageReferenceAliasPattern =
+  /(^|_)(VREFP|VREFN|VREF|REFP|REFN|REFIN|REFOUT|REFCLK|BIAS|VBIAS|IBIAS)(\d|_|$)/
+
 export const scorePhrase = (phrase: string) => {
+  if (voltageReferenceAliasPattern.test(phrase.toUpperCase())) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/voltage-reference-pin-labels.test.ts
+++ b/tests/voltage-reference-pin-labels.test.ts
@@ -1,0 +1,80 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves voltage-reference and analog-bias aliases on generic pins", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      manufacturer_part_number: "AD5676",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r1",
+      name: "R1",
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r2",
+      name: "R2",
+      display_resistance: "100kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_14",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["VREFP"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_15",
+      source_component_id: "source_component_u1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["BIAS1_EN"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r2_1",
+      source_component_id: "source_component_r2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_vref",
+      connected_source_port_ids: ["source_port_u1_14", "source_port_r1_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_bias",
+      connected_source_port_ids: ["source_port_u1_15", "source_port_r2_1"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_VREFP")
+  expect(netlist).toContain("  - U1 pin14 (VREFP)")
+  expect(netlist).toContain("NET: U1_BIAS1_EN")
+  expect(netlist).toContain("  - U1 pin15 (BIAS1_EN)")
+})


### PR DESCRIPTION
Score voltage reference and analog-bias pin aliases so generic physical pins preserve useful labels such as `VREFP` and `BIAS1_EN` in generated readable NET names and pin entries.

This is a focused non-UI library fix for issue #4, separate from the existing ADC/DAC/JESD, op-amp/comparator, current-sense/shunt, power-management, oscillator, analog-audio, and generic numbered-pin scopes.

Verification:
- `~/.bun/bin/bun test tests/voltage-reference-pin-labels.test.ts`
- `~/.bun/bin/bun test`
- `~/.bun/bin/bun x biome check lib/scorePhrase.ts tests/voltage-reference-pin-labels.test.ts`
- `~/.bun/bin/bun x tsc --noEmit`
- `~/.bun/bin/bun run build`
- `PATH="$HOME/.bun/bin:$PATH" bunx @tscircuit/dependency-check`
- `git diff --check`

/claim #4