### PR TITLE
Score NAND flash pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -15,6 +15,11 @@ const wordQualityScore = {
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
+  NAND_CLE: 1.18,
+  NAND_ALE: 1.18,
+  NAND_RB: 1.18,
+  NAND_WE: 1.18,
+  NAND_RE: 1.18,
   GPIO: 1.1,
   cathode: 0.5,
   anode: 0.5,
@@ -36,13 +41,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/nand-flash-pin-labels.test.ts
+++ b/tests/nand-flash-pin-labels.test.ts
@@ -1,0 +1,80 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves NAND flash control pin aliases in readable netlists", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "MT29F1G08",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      ftype: "simple_resistor",
+      name: "R2",
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["NAND_CLE"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["NAND_RB1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_NAND_CLE")
+  expect(netlist).toContain("  - U1 pin14 (NAND_CLE)")
+  expect(netlist).toContain("NET: U1_NAND_RB1")
+  expect(netlist).toContain("  - U1 pin15 (NAND_RB1)")
+})


### PR DESCRIPTION
Closes #4

This adds focused scoring for parallel NAND flash-control/status aliases so generic physical pins preserve useful signal labels in readable netlists.

Changes:
- Score `NAND_CLE`, `NAND_ALE`, `NAND_RB`, `NAND_WE`, and `NAND_RE` above generic `pinN` labels.
- Check known scored aliases before the generic digit fallback so labels like `NAND_RB1` are not downgraded to `0.5`.
- Add raw Circuit JSON regression coverage proving `NAND_CLE` and `NAND_RB1` appear in generated NET names and readable pin entries.

Verification:
- `npm exec --yes bun@latest test tests/nand-flash-pin-labels.test.ts`
- `npm exec --yes bun@latest test`
- `npm exec --yes tsc -- --noEmit`
- `npm exec --yes bun@latest x biome check lib/scorePhrase.ts tests/nand-flash-pin-labels.test.ts`
- `npm exec --yes bun@latest run build`
- `git diff --check`

This is a non-UI library change, so no demo video is included.

/claim #4