### PR TITLE
fix: preserve protocol pin aliases in net names

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,9 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  PCIE: 1.2,
+  PERST: 1.15,
+  CLKREQ: 1.15,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -36,13 +39,15 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.toUpperCase()
+
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-protocol-pin-labels.test.tsx
+++ b/tests/test4-protocol-pin-labels.test.tsx
@@ -1,0 +1,72 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores known protocol aliases before generic digit fallback", () => {
+  expect(scorePhrase("PCIE_TXP0")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("PCIE_RXN0")).toBeGreaterThan(scorePhrase("pin15"))
+  expect(scorePhrase("PERST_N")).toBeGreaterThan(scorePhrase("pin16"))
+  expect(scorePhrase("CLKREQ_N")).toBeGreaterThan(scorePhrase("pin17"))
+})
+
+it("keeps PCIe lane aliases readable on generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="TEST-PCIe"
+        pinLabels={{
+          pin14: ["pin14", "PCIE_TXP0"],
+          pin15: ["pin15", "PCIE_RXN0"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <trace from=".U1 .PCIE_TXP0" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: TEST-PCIe, soic16
+     - R1: 1kΩ 0402 resistor
+
+    NET: U1_PCIE_TXP0
+      - U1 pin14 (PCIE_TXP0)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (TEST-PCIe)
+    - pin1: NOT_CONNECTED
+    - pin2: NOT_CONNECTED
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+    - pin9: NOT_CONNECTED
+    - pin10: NOT_CONNECTED
+    - pin11: NOT_CONNECTED
+    - pin12: NOT_CONNECTED
+    - pin13: NOT_CONNECTED
+    - pin14(PCIE_TXP0): NETS(U1_PCIE_TXP0)
+    - pin15(PCIE_RXN0): NOT_CONNECTED
+    - pin16: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_PCIE_TXP0)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary

Fixes protocol-style pin aliases being penalized as overly short or digit-heavy when generating readable net names.

This changes `scorePhrase` so known technical aliases are recognized before the generic digit/length heuristics run. That preserves names like protocol and hardware pin labels instead of letting them degrade into `undefined` or worse net labels.

## Changes

- Add known protocol/pin aliases to the scoring table
- Prioritize these aliases before generic scoring penalties
- Add test coverage for protocol-style labels such as PCIe/PERST-style names

## Test plan

- [x] Added regression coverage
- [x] Verified the updated scoring prefers known protocol pin aliases

Fixes #4