### PR TITLE
Improve readable chip pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -1,13 +1,50 @@
 import { su } from "@tscircuit/circuit-json-util"
 import type {
   AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
+  AnySourceComponent,
   SourcePort,
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+
+const getPhysicalPinName = (port: SourcePort) =>
+  port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+
+const isGenericPinLabel = (label: string) =>
+  /^pin\d+$/i.test(label) || /^\d+$/.test(label)
+
+const getComponentPinLabelParts = ({
+  component,
+  port,
+}: {
+  component: AnySourceComponent
+  port: SourcePort
+}) => {
+  const physicalPinName = getPhysicalPinName(port)
+  const labels = [port.name, ...(port.port_hints ?? [])].filter(
+    (label): label is string => Boolean(label),
+  )
+
+  let mainPin = physicalPinName ?? port.source_port_id
+  if ("ftype" in component && component.ftype === "simple_chip") {
+    const readableLabel = labels.find((label) => !isGenericPinLabel(label))
+    if (readableLabel) mainPin = readableLabel
+  }
+
+  const aliases = [
+    physicalPinName,
+    ...labels.filter((label) => label !== mainPin),
+  ].filter(
+    (label): label is string =>
+      Boolean(label) && label !== mainPin && !/^\d+$/.test(label),
+  )
+
+  return {
+    mainPin,
+    aliases: Array.from(new Set(aliases)),
+  }
+}
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -156,18 +193,11 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
-        const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
-        for (const hint of port.port_hints ?? []) {
-          if (hint === String(port.pin_number)) continue
-          if (hint !== mainPin && hint !== port.name) aliases.push(hint)
-        }
-        const aliasPart =
-          aliases.length > 0
-            ? `(${Array.from(new Set(aliases)).join(", ")})`
-            : ""
+        const { mainPin, aliases } = getComponentPinLabelParts({
+          component,
+          port,
+        })
+        const aliasPart = aliases.length > 0 ? `(${aliases.join(", ")})` : ""
         const nets = portIdToNetNames[port.source_port_id] ?? []
         const netsPart =
           nets.length > 0 ? `NETS(${nets.join(", ")})` : "NOT_CONNECTED"

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)

--- a/tests/test4-readable-chip-pin-labels.test.tsx
+++ b/tests/test4-readable-chip-pin-labels.test.tsx
@@ -1,0 +1,31 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses readable chip pin labels before generic pin numbers", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="RP2040"
+        pinLabels={{
+          pin14: ["PICO_GPIO10", "SCLK", "SPI0_SCK"],
+        }}
+      />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain(
+    "- PICO_GPIO10(pin14, SCLK, SPI0_SCK): NOT_CONNECTED",
+  )
+  expect(netlist).not.toContain("- pin14(PICO_GPIO10")
+})


### PR DESCRIPTION
Fixes #4

This updates COMPONENT_PINS so simple_chip ports prefer meaningful pin labels such as PICO_GPIO10 over generic physical labels like pin14, while preserving the physical pin number as an alias.

Also filters empty labels to avoid undefined output and adds a regression test for long chip pin labels.

Verification:
- bun test
- bun run build
- bunx biome check .
