### PR TITLE
Preserve I2S audio pin labels in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -11,6 +11,12 @@ const wordQualityScore = {
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
+  I2S: 1.2,
+  BCLK: 1.2,
+  LRCLK: 1.2,
+  MCLK: 1.2,
+  SDIN: 1.15,
+  SDOUT: 1.15,
   SDA: 1.2,
   SCL: 1.2,
   RX: 1.15,
@@ -36,13 +42,15 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.trim().toUpperCase()
+
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
+  }
+  if (normalizedPhrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/audio-pin-labels.test.tsx
+++ b/tests/audio-pin-labels.test.tsx
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("keeps I2S audio bus labels ahead of generic numbered pins", () => {
+  expect(scorePhrase("I2S_BCLK1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("audio_mclk1")).toBeGreaterThan(scorePhrase("pos"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="PCM5102A"
+        pinLabels={{
+          pin14: ["I2S_BCLK1", "AUDIO_MCLK1"],
+        }}
+      />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .I2S_BCLK1" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_I2S_BCLK1")
+  expect(netlist).not.toContain("NET: C1_pos")
+  expect(netlist).toContain("U1 I2S_BCLK1 (AUDIO_MCLK1)")
+  expect(netlist).toContain(
+    "- pin14(I2S_BCLK1, AUDIO_MCLK1): NETS(U1_I2S_BCLK1)",
+  )
+})


### PR DESCRIPTION
## Summary
- score I2S/audio clock labels before the generic digit fallback
- make scoring token matching case-insensitive
- add a regression test proving `I2S_BCLK1` wins over passive labels like `C1_pos`

## Verification
- `bun test tests/audio-pin-labels.test.tsx`
- `bun test`
- `tsc --noEmit`
- `biome check lib/scorePhrase.ts tests/audio-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

This is a non-UI library change, so the focused regression test and terminal verification cover the demo path.

/claim #4