### PR TITLE
fix: use descriptive pin names instead of bare pin numbers in COMPONENT_PINS

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -156,10 +156,17 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const hasNamedPin = port.name && port.name !== `pin${port.pin_number}`
+        const mainPin = hasNamedPin
+          ? port.name!
+          : port.pin_number !== undefined
+            ? `pin${port.pin_number}`
+            : port.name || "?"
         const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
+        // When using a named pin (e.g. "GND"), show pin number as supplementary info
+        if (hasNamedPin && port.pin_number !== undefined) {
+          aliases.push(`pin${port.pin_number}`)
+        }
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)


### PR DESCRIPTION
## Summary

Fix pin labels in COMPONENT_PINS section to show descriptive pin names (GND, VDD, GPIO1) as primary labels instead of bare pin numbers (pin1, pin14).

When a source_port has a meaningful name (e.g. "GND", "VDD", "GPIO1"), use it as the primary pin label and show the pin number as supplementary info alongside existing port hints. For unnamed pins (simple components like resistors), the behavior is unchanged.

## Before / After

```
# Before:
U1 (ATMEGA328P)
- pin1(GND): NETS(GND)
- pin2(AGND): NETS(GND)
- pin3(GPIO1, SCL): NETS(GND)

# After:
U1 (ATMEGA328P)
- GND(pin1): NETS(GND)
- AGND(pin2): NETS(GND)
- GPIO1(pin3, SCL): NETS(GND)
```

## Verification

- `bun test` — all 3 tests pass (snapshots updated)
- `bun run build` — compiles successfully
- `bun x tsc --noEmit` — no type errors

/claim #4