### PR TITLE
Fix digit-containing pin labels

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -47,7 +47,7 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score >= 1) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/^(?:\d+|pin\d+)$/i)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-pin-labels-with-digits.test.ts
+++ b/tests/test4-pin-labels-with-digits.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("keeps descriptive pin labels that contain digits", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GPIO14", "ADC2_CH6"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 pin14 (GPIO14,ADC2_CH6)")
+})


### PR DESCRIPTION
Fixes #4

This preserves descriptive pin hints that contain digits, such as GPIO14 and ADC2_CH6, while still treating placeholder-only names like pin14 as low-information labels.

Added a regression test for digit-containing pin labels.

Validation:
- npx biome check lib/scorePhrase.ts lib/getReadableNameForPin.ts tests/test4-pin-labels-with-digits.test.ts
- npx tsc --noEmit
- npm exec bun -- test tests/test4-pin-labels-with-digits.test.ts

Note: the full local test suite currently fails in the existing TSX fixture tests due to a dependency export error: distanceBetweenCircleAndPolygon is not exported by @tscircuit/circuit-json-util.
