### PR TITLE
Preserve eFuse and hot-swap pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const efuseHotSwapSignalPattern =
+  /(^|[_-])(EFUSE|HOTSWAP|ILIM|OCP|OVP|UVLO)([_-]|$|\d)/i
+
 export const scorePhrase = (phrase: string) => {
+  if (efuseHotSwapSignalPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,7 +36,7 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 const efuseHotSwapSignalPattern =
-  /(^|[_-])(EFUSE|HOTSWAP|ILIM|OCP|OVP|UVLO)([_-]|$|\d)/i
+  /(^|[_/-])(EFUSE|HOTSWAP|ILIM|OCP|OVP|OVLO|OVCSEL|UVLO)([_/-]|$|\d)/i
 
 export const scorePhrase = (phrase: string) => {
   if (efuseHotSwapSignalPattern.test(phrase)) {

--- a/tests/efuse-hotswap-pin-labels.test.ts
+++ b/tests/efuse-hotswap-pin-labels.test.ts
@@ -1,0 +1,81 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib"
+
+it("preserves eFuse and hot-swap aliases on generic pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "TPS25947",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      ftype: "simple_resistor",
+      name: "R2",
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "EFUSE_FAULT1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["pin15", "HOTSWAP_PG"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "pos", "anode"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "pos", "anode"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+  ] as any[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_EFUSE_FAULT1")
+  expect(netlist).toContain("  - U1 pin14 (EFUSE_FAULT1)")
+  expect(netlist).toContain("- pin14(EFUSE_FAULT1): NETS(U1_EFUSE_FAULT1)")
+  expect(netlist).toContain("NET: U1_HOTSWAP_PG")
+  expect(netlist).toContain("  - U1 pin15 (HOTSWAP_PG)")
+  expect(netlist).toContain("- pin15(HOTSWAP_PG): NETS(U1_HOTSWAP_PG)")
+})

--- a/tests/efuse-hotswap-pin-labels.test.ts
+++ b/tests/efuse-hotswap-pin-labels.test.ts
@@ -25,6 +25,20 @@ it("preserves eFuse and hot-swap aliases on generic pins", () => {
       display_resistance: "10kΩ",
     },
     {
+      type: "source_component",
+      source_component_id: "source_component_3",
+      ftype: "simple_resistor",
+      name: "R3",
+      display_resistance: "100kΩ",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_4",
+      ftype: "simple_resistor",
+      name: "R4",
+      display_resistance: "200kΩ",
+    },
+    {
       type: "source_port",
       source_port_id: "source_port_0",
       source_component_id: "source_component_0",
@@ -57,6 +71,38 @@ it("preserves eFuse and hot-swap aliases on generic pins", () => {
       port_hints: ["pin1", "pos", "anode"],
     },
     {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_0",
+      name: "pin16",
+      pin_number: 16,
+      port_hints: ["pin16", "EN/UVLO"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_5",
+      source_component_id: "source_component_0",
+      name: "pin17",
+      pin_number: 17,
+      port_hints: ["pin17", "OVLO/OVCSEL"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_6",
+      source_component_id: "source_component_3",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "pos", "anode"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_7",
+      source_component_id: "source_component_4",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "pos", "anode"],
+    },
+    {
       type: "source_trace",
       source_trace_id: "source_trace_0",
       connected_source_port_ids: ["source_port_0", "source_port_2"],
@@ -66,6 +112,18 @@ it("preserves eFuse and hot-swap aliases on generic pins", () => {
       type: "source_trace",
       source_trace_id: "source_trace_1",
       connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_4", "source_port_6"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_port_ids: ["source_port_5", "source_port_7"],
       connected_source_net_ids: [],
     },
   ] as any[]
@@ -78,4 +136,10 @@ it("preserves eFuse and hot-swap aliases on generic pins", () => {
   expect(netlist).toContain("NET: U1_HOTSWAP_PG")
   expect(netlist).toContain("  - U1 pin15 (HOTSWAP_PG)")
   expect(netlist).toContain("- pin15(HOTSWAP_PG): NETS(U1_HOTSWAP_PG)")
+  expect(netlist).toContain("NET: U1_EN/UVLO")
+  expect(netlist).toContain("  - U1 pin16 (EN/UVLO)")
+  expect(netlist).toContain("- pin16(EN/UVLO): NETS(U1_EN/UVLO)")
+  expect(netlist).toContain("NET: U1_OVLO/OVCSEL")
+  expect(netlist).toContain("  - U1 pin17 (OVLO/OVCSEL)")
+  expect(netlist).toContain("- pin17(OVLO/OVCSEL): NETS(U1_OVLO/OVCSEL)")
 })


### PR DESCRIPTION
## Summary
- add focused scoring for eFuse / hot-swap protection aliases such as `EFUSE_FAULT1` and `HOTSWAP_PG`
- add raw Circuit JSON regression coverage so generated NET names and readable pin entries preserve those labels instead of falling back to passive/generic pin labels

## Verification
- `bun test tests/efuse-hotswap-pin-labels.test.ts --timeout 30000`
- `bun test --timeout 30000`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/efuse-hotswap-pin-labels.test.ts`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and verified locally.

/claim #4