### PR TITLE
Score analog mux pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const analogSwitchAliasPatterns = [
+  /(?:^|_)(?:MUX|DEMUX)(?:_|$)/i,
+  /^(?:MUXA|MUXS)\d+$/i,
+  /^(?:SEL|COM)\d*$/i,
+]
+
 export const scorePhrase = (phrase: string) => {
+  if (analogSwitchAliasPatterns.some((pattern) => pattern.test(phrase))) {
+    return 1.15
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/analog-mux-pin-labels.test.ts
+++ b/tests/analog-mux-pin-labels.test.ts
@@ -1,0 +1,83 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores analog mux aliases above generic numbered pins", () => {
+  expect(scorePhrase("MUX_A0")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("MUX_EN")).toBeGreaterThan(scorePhrase("pin15"))
+  expect(scorePhrase("SEL0")).toBeGreaterThan(scorePhrase("pin1"))
+  expect(scorePhrase("COM0")).toBeGreaterThan(scorePhrase("pin2"))
+})
+
+it("keeps analog mux control labels in generated net names and pin labels", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "ADG704",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["MUX_A0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["MUX_EN"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["neg", "cathode", "right"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_MUX_A0")
+  expect(netlist).toContain("  - U1 pin14 (MUX_A0)")
+  expect(netlist).toContain("- pin14(MUX_A0): NETS(U1_MUX_A0)")
+  expect(netlist).toContain("NET: U1_MUX_EN")
+  expect(netlist).toContain("  - U1 pin15 (MUX_EN)")
+  expect(netlist).toContain("- pin15(MUX_EN): NETS(U1_MUX_EN)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- Score analog switch and multiplexer aliases such as `MUX_A0`, `MUX_EN`, `SEL0`, and `COM0` above generic numbered pins.
- Preserve useful mux-control labels in generated NET names and readable pin entries.
- Add raw Circuit JSON regression coverage so the test avoids the render fixture and checks the netlist output directly.

## Validation
- `npx --yes bun test tests/analog-mux-pin-labels.test.ts`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check lib/scorePhrase.ts tests/analog-mux-pin-labels.test.ts`
- `npx --yes bun run build`
- `git diff --check`

Local note: the existing full `bun test` suite still fails in the render-based fixture tests with `TypeError: Attempting to define property on object that is not extensible` from `@tscircuit/core`; this new regression test passes and uses raw Circuit JSON instead of that fixture.

AI-assisted with Codex; diff and validation reviewed before opening.