### PR TITLE
Score solar harvesting pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const solarHarvestingAliasPattern =
+  /^(?:PV(?:IN|OUT)?\d*|SOLAR(?:_[A-Z0-9]+)?|MPPT\d*|VMPP\d*|HARVEST(?:_EN)?|ENERGY_HARVEST(?:_EN)?)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (solarHarvestingAliasPattern.test(phrase)) {
+    return 1.17
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/solar-harvesting-pin-labels.test.tsx
+++ b/tests/solar-harvesting-pin-labels.test.tsx
@@ -1,0 +1,82 @@
+import { expect, it } from "bun:test"
+import type { SourcePort } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves solar charger and MPPT aliases on generic physical pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{
+          pin1: ["PVIN"],
+          pin2: ["MPPT1"],
+          pin3: ["VMPP"],
+        }}
+      />
+      <resistor name="R1" resistance="100k" footprint="0402" />
+      <capacitor name="C1" capacitance="1uF" footprint="0402" />
+      <trace from=".U1 .PVIN" to=".R1 .pin1" />
+      <trace from=".U1 .MPPT1" to=".C1 .pin1" />
+    </board>,
+  )
+
+  for (const [label, replacementHints] of [
+    ["PVIN", ["PVIN", "SOLAR_IN", "pin1", "1"]],
+    ["MPPT1", ["MPPT1", "VMPP", "pin2", "2"]],
+    ["VMPP", ["VMPP", "pin3", "3"]],
+  ] as const) {
+    const port = circuitJson.find(
+      (element): element is SourcePort =>
+        element.type === "source_port" && element.name === label,
+    )
+    expect(port).toBeDefined()
+    port!.name = `pin${port!.pin_number}`
+    port!.port_hints = [...replacementHints]
+  }
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: soic8
+     - R1: 100kΩ 0402 resistor
+     - C1: 1µF 0402 capacitor
+
+    NET: U1_PVIN
+      - U1 pin1 (PVIN,SOLAR_IN)
+      - R1 pin1
+
+    NET: U1_MPPT1
+      - U1 pin2 (MPPT1,VMPP)
+      - C1 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1
+    - pin1(PVIN, SOLAR_IN): NETS(U1_PVIN)
+    - pin2(MPPT1, VMPP): NETS(U1_MPPT1)
+    - pin3(VMPP): NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (100kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_PVIN)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    C1 (1µF 0402)
+    - pin1(pos, anode, left): NETS(U1_MPPT1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- add focused scoring for solar charger / energy-harvesting aliases such as `PVIN`, `SOLAR_IN`, `MPPT1`, `VMPP`, and `HARVEST_EN`
- preserve those aliases in generated NET names and readable NET pin entries when the physical source port name is generic, such as `pin1`
- add raw Circuit JSON regression coverage for PV input and MPPT/VMPP pins

/claim #4

## Verification
- `bun test tests/solar-harvesting-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/solar-harvesting-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

This is a non-UI library change, so the PR uses terminal regression output rather than a UI demo video.