### PR TITLE
Preserve EEPROM and FRAM pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const nonvolatileMemorySignalPattern =
+  /(^|[_-])(EEPROM|FRAM|NVM|NVRAM|NVSRAM|EDID|SPD)([_-]|$|\d)/i
+
 export const scorePhrase = (phrase: string) => {
+  if (nonvolatileMemorySignalPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/eeprom-fram-pin-labels.test.ts
+++ b/tests/eeprom-fram-pin-labels.test.ts
@@ -1,0 +1,81 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib"
+
+it("preserves EEPROM and FRAM control aliases on generic pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "24LC256",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      ftype: "simple_resistor",
+      name: "R2",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin7",
+      pin_number: 7,
+      port_hints: ["pin7", "EEPROM_WP1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["pin3", "FRAM_HOLD1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "pos", "anode"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "pos", "anode"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+  ] as any[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_EEPROM_WP1")
+  expect(netlist).toContain("  - U1 pin7 (EEPROM_WP1)")
+  expect(netlist).toContain("- pin7(EEPROM_WP1): NETS(U1_EEPROM_WP1)")
+  expect(netlist).toContain("NET: U1_FRAM_HOLD1")
+  expect(netlist).toContain("  - U1 pin3 (FRAM_HOLD1)")
+  expect(netlist).toContain("- pin3(FRAM_HOLD1): NETS(U1_FRAM_HOLD1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for serial nonvolatile memory aliases such as `EEPROM_WP1` and `FRAM_HOLD1`
- add regression coverage proving these aliases win generated NET names and readable pin entries over low-information passive labels

## Verification
- `bun test tests/eeprom-fram-pin-labels.test.ts --timeout 30000`
- `bun test --timeout 30000`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/eeprom-fram-pin-labels.test.ts`
- `bun run build`
- `git diff --check`

This is a non-UI library change, so the verification above is the demo.

/claim #4