### PR TITLE
Score ESD and EMI pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,13 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  ESD: 1.2,
+  TVS: 1.2,
+  EMI: 1.2,
+  FERRITE: 1.2,
+  CMC: 1.2,
+  CHOKE: 1.2,
+  SURGE: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -36,13 +43,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/esd-emi-pin-labels.test.tsx
+++ b/tests/esd-emi-pin-labels.test.tsx
@@ -1,0 +1,40 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves ESD and EMI protection aliases over generic numbered pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="TPD4E05U06"
+        pinLabels={{
+          pin14: ["IO1", "ESD_IO1"],
+        }}
+      />
+      <chip
+        name="FL1"
+        footprint="soic16"
+        manufacturerPartNumber="EMI_FILTER_ARRAY"
+        pinLabels={{
+          pin14: ["IN1", "EMI_FLT_IN"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .IO1" to=".R1 .pin1" />
+      <trace from=".FL1 .IN1" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ESD_IO1")
+  expect(netlist).toContain("  - U1 IO1 (ESD_IO1)")
+  expect(netlist).toContain("- pin14(IO1, ESD_IO1): NETS(U1_ESD_IO1)")
+  expect(netlist).toContain("NET: FL1_EMI_FLT_IN")
+  expect(netlist).toContain("  - FL1 IN1 (EMI_FLT_IN)")
+  expect(netlist).toContain("- pin14(IN1, EMI_FLT_IN): NETS(FL1_EMI_FLT_IN)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for ESD, TVS, EMI, ferrite, common-mode choke, choke, and surge pin aliases before the generic digit fallback
- add a regression test proving ESD_IO1 and EMI_FLT_IN are preserved in generated NET names and COMPONENT_PINS entries

## Verification
- bun test tests/esd-emi-pin-labels.test.tsx
- bun test
- bun x tsc --noEmit
- bun x biome check lib/scorePhrase.ts tests/esd-emi-pin-labels.test.tsx
- bun run build
- git diff --check

This is a non-UI library change, so the regression test and terminal verification cover the behavior instead of a UI demo video.

Transparency: AI-assisted with Codex; I reviewed the diff and ran the checks above.

/claim #4