### PR TITLE
fix: preserve 1-Wire pin labels in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,22 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const oneWireAliasPatterns = [
+  /(^|_)1WIRE(_|$)/i,
+  /(^|_)ONEWIRE(_|$)/i,
+  /(^|_)ONE_WIRE(_|$)/i,
+  /(^|_)OWIO(_|$)/i,
+  /(^|_)OW_DQ\d*(_|$)/i,
+  /(^|_)ONEWIRE_DQ\d*(_|$)/i,
+]
+
 export const scorePhrase = (phrase: string) => {
+  for (const pattern of oneWireAliasPatterns) {
+    if (pattern.test(phrase)) {
+      return 1.2
+    }
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/onewire-pin-labels.test.ts
+++ b/tests/onewire-pin-labels.test.ts
@@ -1,0 +1,57 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { generateNetName } from "lib/generateNetName"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+import { scorePhrase } from "lib/scorePhrase"
+
+const circuitJson = [
+  {
+    type: "source_component",
+    ftype: "simple_chip",
+    source_component_id: "source_component_1",
+    name: "U1",
+    manufacturer_part_number: "DS18B20",
+  },
+  {
+    type: "source_component",
+    ftype: "simple_resistor",
+    source_component_id: "source_component_2",
+    name: "R1",
+    display_resistance: "4.7kΩ",
+  },
+  {
+    type: "source_port",
+    source_port_id: "source_port_1",
+    source_component_id: "source_component_1",
+    name: "pin14",
+    pin_number: 14,
+    port_hints: ["pin14", "ONEWIRE_DQ1"],
+  },
+  {
+    type: "source_port",
+    source_port_id: "source_port_2",
+    source_component_id: "source_component_2",
+    name: "pos",
+    pin_number: 1,
+    port_hints: ["pos", "anode", "left"],
+  },
+] as AnyCircuitElement[]
+
+it("prefers 1-Wire data aliases over generic numbered pins", () => {
+  expect(scorePhrase("ONEWIRE_DQ1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("1WIRE_DQ")).toBeGreaterThan(scorePhrase("pos"))
+
+  expect(
+    generateNetName({
+      circuitJson,
+      connectedIds: ["source_port_1", "source_port_2"],
+    }),
+  ).toBe("U1_ONEWIRE_DQ1")
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 pin14 (ONEWIRE_DQ1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for 1-Wire / single-wire aliases (`1WIRE`, `ONEWIRE`, `ONE_WIRE`, `OWIO`, `OW_DQ`, `ONEWIRE_DQ`) before the generic digit fallback.
- Add a regression test proving `ONEWIRE_DQ1` beats generic `pin14` and passive `pos` labels for net naming.
- Verify the readable pin output keeps the useful 1-Wire data alias instead of only showing the physical pin name.

## Verification
- `npx bun test tests/onewire-pin-labels.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/scorePhrase.ts tests/onewire-pin-labels.test.ts`
- `npm exec -- tsup ./lib/index.ts --format esm --dts`
- `git diff --check`

Note: `npx bun test` currently fails in the pre-existing fixture tests because the installed `@tscircuit/circuit-json-util` package does not export `distanceBetweenCircleAndPolygon`; the new focused regression passes.

/claim #4