### PR TITLE
Score thermal pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const thermalManagementAliasPattern =
+  /(?:^|[_-])(?:TEMP|THERM|THERMAL|NTC|PTAT|CTAT|TSENSE)(?:$|[_\d-])/
+
 export const scorePhrase = (phrase: string) => {
+  if (thermalManagementAliasPattern.test(phrase.toUpperCase())) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/thermal-pin-labels.test.tsx
+++ b/tests/thermal-pin-labels.test.tsx
@@ -1,0 +1,62 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves temperature and thermal-management pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic14"
+        manufacturerPartNumber="TMP117"
+        pinLabels={{
+          pin14: ["pin14", "TEMP_ALERT1", "THERM_WARN"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .TEMP_ALERT1" to=".R1 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: TMP117, soic14
+     - R1: 10kΩ 0402 resistor
+
+    NET: U1_TEMP_ALERT1
+      - U1 pin14 (TEMP_ALERT1,THERM_WARN)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (TMP117)
+    - pin1: NOT_CONNECTED
+    - pin2: NOT_CONNECTED
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+    - pin9: NOT_CONNECTED
+    - pin10: NOT_CONNECTED
+    - pin11: NOT_CONNECTED
+    - pin12: NOT_CONNECTED
+    - pin13: NOT_CONNECTED
+    - pin14(TEMP_ALERT1, THERM_WARN): NETS(U1_TEMP_ALERT1)
+
+    R1 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_TEMP_ALERT1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
Fixes #4

This adds focused scoring for temperature and thermal-management pin aliases (`TEMP_ALERT1`, `THERM_WARN`, `NTC`, `PTAT`, `CTAT`, `TSENSE`) before the generic digit fallback. That lets generated net names and readable pin entries preserve meaningful thermal labels instead of falling back to lower-information labels like `pin14` or passive endpoint labels.

The regression covers a TMP117-style thermal alert pin and verifies the output keeps:
- `NET: U1_TEMP_ALERT1`
- `U1 pin14 (TEMP_ALERT1,THERM_WARN)`
- `pin14(TEMP_ALERT1, THERM_WARN): NETS(U1_TEMP_ALERT1)`

Verification passed:
- `bun test tests\thermal-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib\scorePhrase.ts tests\thermal-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

This is a non-UI library change, so the terminal regression and verification above are the demo evidence.

AI-assisted with Codex; I reviewed the diff and ran the checks above.

/claim #4