### PR TITLE
Preserve SWD and JTAG debug pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const debugPortWords = ["SWDIO", "SWCLK", "JTMS", "JTCK", "JTDI", "JTDO"]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (debugPortWords.some((word) => normalizedPhrase.includes(word))) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/debug-port-pin-labels.test.tsx
+++ b/tests/debug-port-pin-labels.test.tsx
@@ -1,0 +1,45 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("prefers SWD and JTAG debug aliases over generic numbered pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="DBG_MCU"
+        pinLabels={{
+          pin14: ["SWDIO1"],
+          pin15: ["SWCLK1"],
+          pin16: ["JTMS1"],
+          pin17: ["JTCK1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+      <resistor resistance="10k" footprint="0402" name="R3" />
+      <resistor resistance="10k" footprint="0402" name="R4" />
+
+      <trace from=".U1 .SWDIO1" to=".R1 .pin1" />
+      <trace from=".U1 .SWCLK1" to=".R2 .pin1" />
+      <trace from=".U1 .JTMS1" to=".R3 .pin1" />
+      <trace from=".U1 .JTCK1" to=".R4 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_SWDIO1")
+  expect(netlist).toContain("NET: U1_SWCLK1")
+  expect(netlist).toContain("NET: U1_JTMS1")
+  expect(netlist).toContain("NET: U1_JTCK1")
+  expect(netlist).toContain("- U1 SWDIO1")
+  expect(netlist).toContain("- U1 SWCLK1")
+  expect(netlist).toContain("- U1 JTMS1")
+  expect(netlist).toContain("- U1 JTCK1")
+  expect(netlist).toContain("- pin14(SWDIO1): NETS(U1_SWDIO1)")
+  expect(netlist).toContain("- pin15(SWCLK1): NETS(U1_SWCLK1)")
+  expect(netlist).toContain("- pin16(JTMS1): NETS(U1_JTMS1)")
+  expect(netlist).toContain("- pin17(JTCK1): NETS(U1_JTCK1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for SWD/JTAG debug-port aliases before the generic digit fallback
- Cover digit-bearing `SWDIO1`, `SWCLK1`, `JTMS1`, and `JTCK1` labels so generated NET names and component pin entries keep the useful debug labels

## Verification
- `bun test tests/debug-port-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/debug-port-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the patch and local verification before opening this PR.

/claim #4