### PR TITLE
Score cooling fan pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,21 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isCoolingFanAlias = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  const fanControlWords = ["PWM", "TACH", "SENSE", "FG", "RPM", "ALERT"]
+
+  return (
+    normalizedPhrase.includes("FAN") &&
+    fanControlWords.some((word) => normalizedPhrase.includes(word))
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isCoolingFanAlias(phrase)) {
+    return 1.16
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/fan-control-pin-labels.test.tsx
+++ b/tests/fan-control-pin-labels.test.tsx
@@ -1,0 +1,79 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves cooling fan control aliases in generated net names and readable pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "FANCTRL16",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "J1",
+      manufacturer_part_number: "FAN_HEADER",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_3",
+      name: "J2",
+      manufacturer_part_number: "FAN_HEADER",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      name: "pin14",
+      port_hints: ["FAN_TACH1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      name: "pin15",
+      port_hints: ["FAN_PWM1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_3",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_3", "source_port_4"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_FAN_TACH1")
+  expect(netlist).toContain("NET: U1_FAN_PWM1")
+  expect(netlist).toContain("  - U1 pin14 (FAN_TACH1)")
+  expect(netlist).toContain("  - U1 pin15 (FAN_PWM1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for cooling fan aliases such as `FAN_TACH1` and `FAN_PWM1` before the generic digit fallback
- add a raw Circuit JSON regression test proving fan tach/PWM aliases are preserved in generated NET names and readable pin entries

## Verification
- `npx bun test tests/fan-control-pin-labels.test.tsx`
- `npx tsc --noEmit`
- `npx biome check lib/scorePhrase.ts tests/fan-control-pin-labels.test.tsx`
- `npx bun run build`
- `git diff --check`

`npx bun test` still fails in the existing JSX-rendered tests (`test1-basic-circuit`, `test2-chip`, `test3-no-footprint-chip`) with `TypeError: Attempting to define property on object that is not extensible` inside `@tscircuit/core` render setup. The new regression avoids that path by using raw Circuit JSON and passes.

/claim #4