### PR TITLE
Score legacy display pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const legacyDisplayLabelPattern =
+  /^(VGA[_-]?(R|G|B|RED|GREEN|BLUE|HSYNC|VSYNC|DDC[_-]?(SCL|SDA))|RGB[_-]?(R|G|B|RED|GREEN|BLUE|DE|PCLK|CLK|HSYNC|VSYNC)|TFT[_-]?(DE|PCLK|CLK|HSYNC|VSYNC))\d*$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (legacyDisplayLabelPattern.test(phrase)) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/legacy-display-pin-labels.test.ts
+++ b/tests/legacy-display-pin-labels.test.ts
@@ -1,0 +1,143 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves legacy display labels with numeric suffixes", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "ADV7125",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_2",
+      name: "R1",
+      resistance: 75,
+      display_resistance: "75 ohm",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_3",
+      name: "R2",
+      resistance: 75,
+      display_resistance: "75 ohm",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_capacitor",
+      source_component_id: "source_component_4",
+      name: "C1",
+      capacitance: 0.0000001,
+      display_capacitance: "100nF",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      pcb_component_id: "pcb_component_1",
+      source_component_id: "source_component_1",
+      position: { x: 0, y: 0, z: 0 },
+      footprinter_string: "tqfp48",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_2",
+      pcb_component_id: "pcb_component_2",
+      source_component_id: "source_component_2",
+      position: { x: 0, y: 0, z: 0 },
+      footprinter_string: "0402",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_3",
+      pcb_component_id: "pcb_component_3",
+      source_component_id: "source_component_3",
+      position: { x: 0, y: 0, z: 0 },
+      footprinter_string: "0402",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_4",
+      pcb_component_id: "pcb_component_4",
+      source_component_id: "source_component_4",
+      position: { x: 0, y: 0, z: 0 },
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      port_hints: ["VGA_RED1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin15",
+      port_hints: ["VGA_HSYNC1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      name: "pin16",
+      port_hints: ["RGB_DE1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_5",
+      source_component_id: "source_component_3",
+      name: "pin1",
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_6",
+      source_component_id: "source_component_4",
+      name: "pin1",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_4"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_5"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_port_ids: ["source_port_3", "source_port_6"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_VGA_RED1")
+  expect(readableNetlist).toContain("NET: U1_VGA_HSYNC1")
+  expect(readableNetlist).toContain("NET: U1_RGB_DE1")
+  expect(readableNetlist).toContain("- U1 pin14 (VGA_RED1)")
+  expect(readableNetlist).toContain("- U1 pin15 (VGA_HSYNC1)")
+  expect(readableNetlist).toContain("- U1 pin16 (RGB_DE1)")
+  expect(readableNetlist).toContain("- pin14(VGA_RED1): NETS(U1_VGA_RED1)")
+  expect(readableNetlist).toContain("- pin15(VGA_HSYNC1): NETS(U1_VGA_HSYNC1)")
+  expect(readableNetlist).toContain("- pin16(RGB_DE1): NETS(U1_RGB_DE1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for legacy VGA / parallel RGB / TFT display aliases before the generic digit fallback.
- Preserve labels such as `VGA_RED1`, `VGA_HSYNC1`, and `RGB_DE1` in generated NET names and readable pin entries.
- Add raw Circuit JSON regression coverage for this display-label family.

## Verification
- `npx --yes bun test tests/legacy-display-pin-labels.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/scorePhrase.ts tests/legacy-display-pin-labels.test.ts`
- `npm exec -- tsup ./lib/index.ts --format esm --dts`
- `git diff --check`

Note: full local `npx --yes bun test` still hits the existing dependency mismatch where `@tscircuit/circuit-json-util` does not export `distanceBetweenCircleAndPolygon`; the new focused regression passes.

/claim #4