### PR TITLE
Score HDMI pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const hdmiAliasPatterns = [
+  /^(?:HDMI_)?TMDS_(?:CLK|D[0-2])_[PN]\d*$/,
+  /^(?:HDMI_)?(?:HPD|CEC)\d*$/,
+  /^(?:HDMI_)?DDC_(?:SCL|SDA)\d*$/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (hdmiAliasPatterns.some((pattern) => pattern.test(normalizedPhrase))) {
+    return 1.21
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/hdmi-pin-labels.test.tsx
+++ b/tests/hdmi-pin-labels.test.tsx
@@ -1,0 +1,36 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves HDMI TMDS and sideband aliases in generated net names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn16"
+        manufacturerPartNumber="HDMI_TX"
+        pinLabels={{
+          pin14: ["TMDS_CLK_P1"],
+          pin15: ["HDMI_HPD1"],
+          pin16: ["CEC1"],
+        }}
+      />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="10nF" footprint="0402" name="C2" />
+
+      <trace from=".U1 .TMDS_CLK_P1" to=".C1 .pin1" />
+      <trace from=".U1 .HDMI_HPD1" to=".R1 .pin1" />
+      <trace from=".U1 .CEC1" to=".C2 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_TMDS_CLK_P1")
+  expect(netlist).toContain("NET: U1_HDMI_HPD1")
+  expect(netlist).toContain("NET: U1_CEC1")
+  expect(netlist).toContain("  - U1 TMDS_CLK_P1")
+  expect(netlist).toContain("  - U1 HDMI_HPD1")
+  expect(netlist).toContain("  - U1 CEC1")
+})


### PR DESCRIPTION
## Summary

/claim #4

This adds a focused scoring path for HDMI connector aliases so digit-bearing labels such as `TMDS_CLK_P1`, `HDMI_HPD1`, `CEC1`, and DDC labels are considered before the generic digit fallback. Without this, generated net names can pick passive endpoints such as `C1_pos` instead of the useful HDMI signal label.

The regression covers TMDS clock, HPD, and CEC aliases against passive endpoints and verifies the generated net names keep the HDMI labels.

## Verification

- `bun test tests/hdmi-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/hdmi-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and ran the checks above.