### PR TITLE
Score RGMII PHY pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const rgmiiPhyLabelPattern =
+  /^(RGMII[_-]?(TXD|RXD)\d+|RGMII[_-]?(TX|RX)[_-]?CTL|RGMII[_-]?(TX|RX)[_-]?C|RGMII[_-]?(TX|RX)?CLK|GTXCLK)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (rgmiiPhyLabelPattern.test(phrase)) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/rgmii-phy-pin-labels.test.ts
+++ b/tests/rgmii-phy-pin-labels.test.ts
@@ -1,0 +1,78 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "../lib"
+
+it("preserves RGMII PHY labels with numeric suffixes", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 33,
+      display_resistance: "33ohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_3",
+      name: "R2",
+      ftype: "simple_resistor",
+      resistance: 33,
+      display_resistance: "33ohm",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      port_hints: ["RGMII_TXD0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      port_hints: ["RGMII_RXD1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_3",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_4"],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_RGMII_TXD0")
+  expect(readableNetlist).toContain("NET: U1_RGMII_RXD1")
+  expect(readableNetlist).toContain("- U1 Pin14 (RGMII_TXD0)")
+  expect(readableNetlist).toContain("- U1 Pin15 (RGMII_RXD1)")
+  expect(readableNetlist).toContain("- pin14(RGMII_TXD0): NETS(U1_RGMII_TXD0)")
+  expect(readableNetlist).toContain("- pin15(RGMII_RXD1): NETS(U1_RGMII_RXD1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for RGMII Ethernet PHY aliases before the generic digit fallback.
- Preserve labels such as `RGMII_TXD0`, `RGMII_RXD1`, `RGMII_TX_CTL`, and `GTXCLK` in generated NET names and readable pin entries.
- Add raw Circuit JSON regression coverage for this RGMII-specific label family, separate from existing RMII/Ethernet/PoE/SFP scopes.

## Verification
- `npx --yes bun test tests/rgmii-phy-pin-labels.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/scorePhrase.ts tests/rgmii-phy-pin-labels.test.ts`
- `npm exec -- tsup ./lib/index.ts --format esm --dts`
- `git diff --check`

Note: full local `npx --yes bun test` still hits the existing dependency mismatch where `@tscircuit/circuit-json-util` does not export `distanceBetweenCircleAndPolygon`; the new focused regression passes.

/claim #4