### PR TITLE
Score regulator topology pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const regulatorTopologyLabelPattern =
+  /^(BUCK[_-]?(SW|LX|PH|FB|COMP|BOOT|BST|PG|PGOOD|VOUT)\d*|BOOST[_-]?(SW|LX|PH|FB|COMP|BOOT|BST|PG|PGOOD|VOUT)\d*|LDO[_-]?(IN|OUT|FB|BYP|NR|PG|PGOOD)\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (regulatorTopologyLabelPattern.test(phrase)) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/regulator-topology-pin-labels.test.ts
+++ b/tests/regulator-topology-pin-labels.test.ts
@@ -1,0 +1,109 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "../lib"
+
+it("preserves buck boost and LDO regulator topology labels", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 10000,
+      display_resistance: "10kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_3",
+      name: "R2",
+      ftype: "simple_resistor",
+      resistance: 10000,
+      display_resistance: "10kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_4",
+      name: "C1",
+      ftype: "simple_capacitor",
+      capacitance: 0.000001,
+      display_capacitance: "1uF",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      port_hints: ["BUCK_SW1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      port_hints: ["BOOST_LX1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      pin_number: 16,
+      port_hints: ["LDO_OUT1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_5",
+      source_component_id: "source_component_3",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_6",
+      source_component_id: "source_component_4",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_4"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_5"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_port_ids: ["source_port_3", "source_port_6"],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_BUCK_SW1")
+  expect(readableNetlist).toContain("NET: U1_BOOST_LX1")
+  expect(readableNetlist).toContain("NET: U1_LDO_OUT1")
+  expect(readableNetlist).toContain("- U1 Pin14 (BUCK_SW1)")
+  expect(readableNetlist).toContain("- U1 Pin15 (BOOST_LX1)")
+  expect(readableNetlist).toContain("- U1 Pin16 (LDO_OUT1)")
+  expect(readableNetlist).toContain("- pin14(BUCK_SW1): NETS(U1_BUCK_SW1)")
+  expect(readableNetlist).toContain("- pin15(BOOST_LX1): NETS(U1_BOOST_LX1)")
+  expect(readableNetlist).toContain("- pin16(LDO_OUT1): NETS(U1_LDO_OUT1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for buck, boost, and LDO regulator topology aliases before the generic digit fallback.
- Preserve labels such as `BUCK_SW1`, `BOOST_LX1`, and `LDO_OUT1` in generated NET names and readable pin entries.
- Add raw Circuit JSON regression coverage for this regulator-specific label family, separate from PMIC control/status and charger/fuel-gauge scopes.

## Verification
- `npx --yes bun test tests/regulator-topology-pin-labels.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/scorePhrase.ts tests/regulator-topology-pin-labels.test.ts`
- `npm exec -- tsup ./lib/index.ts --format esm --dts`
- `git diff --check`

Note: full local `npx --yes bun test` still hits the existing dependency mismatch where `@tscircuit/circuit-json-util` does not export `distanceBetweenCircleAndPolygon`; the new focused regression passes.

/claim #4