### PR TITLE
Score wireless charging pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const scoreWirelessChargingPhrase = (phrase: string) => {
+  if (
+    /^(QI|WPC|WLC)(?:_|$)/.test(phrase) ||
+    /^(RECT|RECTIFIER)(?:_|$)/.test(phrase)
+  ) {
+    return 1.15
+  }
+}
+
 export const scorePhrase = (phrase: string) => {
+  const wirelessChargingScore = scoreWirelessChargingPhrase(phrase)
+  if (wirelessChargingScore) {
+    return wirelessChargingScore
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/wireless-charging-pin-labels.test.tsx
+++ b/tests/wireless-charging-pin-labels.test.tsx
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves wireless charging receiver aliases in net entries", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn24"
+        manufacturerPartNumber="WLC1115"
+        pinLabels={{
+          pin14: ["pin14", "QI_AC1"],
+          pin15: ["pin15", "WPC_INT1"],
+          pin16: ["pin16", "RECT_OUT"],
+        }}
+      />
+      <chip
+        name="J1"
+        footprint="pinrow3"
+        manufacturerPartNumber="CONN"
+        pinLabels={{
+          pin1: ["COIL_A"],
+          pin2: ["IRQ"],
+          pin3: ["OUT"],
+        }}
+      />
+
+      <trace from=".U1 .pin14" to=".J1 .pin1" />
+      <trace from=".U1 .pin15" to=".J1 .pin2" />
+      <trace from=".U1 .pin16" to=".J1 .pin3" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_QI_AC1")
+  expect(netlist).toContain("  - U1 pin14 (QI_AC1)")
+  expect(netlist).toContain("NET: U1_WPC_INT1")
+  expect(netlist).toContain("  - U1 pin15 (WPC_INT1)")
+  expect(netlist).toContain("NET: U1_RECT_OUT")
+  expect(netlist).toContain("  - U1 pin16 (RECT_OUT)")
+})


### PR DESCRIPTION
## Summary
- Add focused phrase scoring for wireless charging / Qi receiver aliases before the generic digit fallback.
- Preserve Qi/WPC/WLC and rectifier labels such as QI_AC1, WPC_INT1, and RECT_OUT in generated NET names and readable pin entries.
- Add regression coverage for a wireless charging receiver connected to generic connector labels.

## Verification
- bun test tests/wireless-charging-pin-labels.test.tsx
- bun test
- bun x tsc --noEmit
- bun x biome check lib/scorePhrase.ts tests/wireless-charging-pin-labels.test.tsx
- bun run build
- git diff --check

/claim #4

AI-assisted with Codex; I reviewed the diff and ran the checks above.