### PR TITLE
Score stepper driver pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,26 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const stepperDriverSignalPatterns = [
+  /(?:^|[_-])STEP(?:\d+|[_-]|$)/,
+  /(?:^|[_-])DIR(?:\d+|[_-]|$)/,
+  /(?:^|[_-])MS[123](?:[_-]|$)/,
+  /(?:^|[_-])MICROSTEP(?:[_-]|$)/,
+  /(?:^|[_-])DECAY(?:\d+|[_-]|$)/,
+  /(?:^|[_-])N?SLEEP(?:\d+|[_-]|$)/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  if (
+    stepperDriverSignalPatterns.some((pattern) =>
+      pattern.test(normalizedPhrase),
+    )
+  ) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/stepper-driver-pin-labels.test.tsx
+++ b/tests/stepper-driver-pin-labels.test.tsx
@@ -1,0 +1,35 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves stepper driver pin aliases in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="TMC2209"
+        pinLabels={{
+          pin1: ["STEP1"],
+          pin2: ["DIR1"],
+          pin3: ["MS1"],
+          pin4: ["MS2"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .STEP1" to=".R1 .pin1" />
+      <trace from=".U1 .MS1" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_STEP1")
+  expect(netlist).toContain("  - U1 STEP1")
+  expect(netlist).toContain("NET: U1_MS1")
+  expect(netlist).toContain("  - U1 MS1")
+  expect(netlist).toContain("- pin1(STEP1): NETS(U1_STEP1)")
+  expect(netlist).toContain("- pin3(MS1): NETS(U1_MS1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for stepper motor driver aliases before the generic digit fallback
- preserve labels such as `STEP1`, `DIR1`, `MS1`, `MS2`, `MICROSTEP`, `DECAY`, and `NSLEEP` in generated readable netlists
- add regression coverage proving stepper aliases drive NET names and readable pin entries

## Verification
- `bun test tests/stepper-driver-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/stepper-driver-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; diff reviewed locally.

/claim #4