### PR TITLE
Score discrete transistor pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const discreteTransistorLabelPattern =
+  /^((N|P)MOS(FET)?[_-]?(GATE|DRAIN|SOURCE|G|D|S)\d*|BJT[_-]?(BASE|COLLECTOR|EMITTER|B|C|E)\d*|TRANSISTOR[_-]?(BASE|COLLECTOR|EMITTER|GATE|DRAIN|SOURCE)\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (discreteTransistorLabelPattern.test(phrase)) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/discrete-transistor-pin-labels.test.ts
+++ b/tests/discrete-transistor-pin-labels.test.ts
@@ -1,0 +1,111 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "../lib"
+
+it("preserves discrete transistor pin labels with numeric suffixes", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "Q1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_3",
+      name: "R2",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_4",
+      name: "R3",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      port_hints: ["NMOS_GATE1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      port_hints: ["PMOS_DRAIN1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      pin_number: 16,
+      port_hints: ["BJT_BASE1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_5",
+      source_component_id: "source_component_3",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_6",
+      source_component_id: "source_component_4",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_4"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_5"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_port_ids: ["source_port_3", "source_port_6"],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: Q1_NMOS_GATE1")
+  expect(readableNetlist).toContain("NET: Q1_PMOS_DRAIN1")
+  expect(readableNetlist).toContain("NET: Q1_BJT_BASE1")
+  expect(readableNetlist).toContain("- Q1 Pin14 (NMOS_GATE1)")
+  expect(readableNetlist).toContain("- Q1 Pin15 (PMOS_DRAIN1)")
+  expect(readableNetlist).toContain("- Q1 Pin16 (BJT_BASE1)")
+  expect(readableNetlist).toContain("- pin14(NMOS_GATE1): NETS(Q1_NMOS_GATE1)")
+  expect(readableNetlist).toContain(
+    "- pin15(PMOS_DRAIN1): NETS(Q1_PMOS_DRAIN1)",
+  )
+  expect(readableNetlist).toContain("- pin16(BJT_BASE1): NETS(Q1_BJT_BASE1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for discrete MOSFET and BJT pin aliases before the generic digit fallback.
- Preserve labels such as `NMOS_GATE1`, `PMOS_DRAIN1`, and `BJT_BASE1` in generated NET names and readable pin entries.
- Add raw Circuit JSON regression coverage for this transistor-specific label family, separate from semiconductor component descriptions and isolated gate-driver scopes.

## Verification
- `npx --yes bun test tests/discrete-transistor-pin-labels.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/scorePhrase.ts tests/discrete-transistor-pin-labels.test.ts`
- `npm exec -- tsup ./lib/index.ts --format esm --dts`
- `git diff --check`

Note: full local `npx --yes bun test` still hits the existing dependency mismatch where `@tscircuit/circuit-json-util` does not export `distanceBetweenCircleAndPolygon`; the new focused regression passes.

/claim #4