### PR TITLE
Score RS232 RS422 pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const rs232Rs422LabelPattern =
+  /^(RS[_-]?232[_-]?(TX|RX|RTS|CTS|DTR|DSR|DCD|RI)\d*|RS[_-]?422[_-]?(A|B|Y|Z|TX|RX|TXP|TXN|RXP|RXN)\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (rs232Rs422LabelPattern.test(phrase)) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/rs232-rs422-pin-labels.test.ts
+++ b/tests/rs232-rs422-pin-labels.test.ts
@@ -1,0 +1,109 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "../lib"
+
+it("preserves RS232 and RS422 transceiver pin labels", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_3",
+      name: "R2",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_4",
+      name: "R3",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      port_hints: ["RS232_TX1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      port_hints: ["RS422_A1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      pin_number: 16,
+      port_hints: ["RS422_B1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_5",
+      source_component_id: "source_component_3",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_6",
+      source_component_id: "source_component_4",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_4"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_5"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_port_ids: ["source_port_3", "source_port_6"],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_RS232_TX1")
+  expect(readableNetlist).toContain("NET: U1_RS422_A1")
+  expect(readableNetlist).toContain("NET: U1_RS422_B1")
+  expect(readableNetlist).toContain("- U1 Pin14 (RS232_TX1)")
+  expect(readableNetlist).toContain("- U1 Pin15 (RS422_A1)")
+  expect(readableNetlist).toContain("- U1 Pin16 (RS422_B1)")
+  expect(readableNetlist).toContain("- pin14(RS232_TX1): NETS(U1_RS232_TX1)")
+  expect(readableNetlist).toContain("- pin15(RS422_A1): NETS(U1_RS422_A1)")
+  expect(readableNetlist).toContain("- pin16(RS422_B1): NETS(U1_RS422_B1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for RS232 and RS422 transceiver aliases before the generic digit fallback.
- Preserve labels such as `RS232_TX1`, `RS422_A1`, and `RS422_B1` in generated NET names and readable pin entries.
- Add raw Circuit JSON regression coverage for this serial-transceiver label family, separate from RS-485/DMX/DALI/MODBUS scopes.

## Verification
- `npx --yes bun test tests/rs232-rs422-pin-labels.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/scorePhrase.ts tests/rs232-rs422-pin-labels.test.ts`
- `npm exec -- tsup ./lib/index.ts --format esm --dts`
- `git diff --check`

Note: full local `npx --yes bun test` still hits the existing dependency mismatch where `@tscircuit/circuit-json-util` does not export `distanceBetweenCircleAndPolygon`; the new focused regression passes.

/claim #4