### PR TITLE
Score digital audio transport pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitalAudioTransportLabelPattern =
+  /^(S\/?PDIF|SPDIF|TOSLINK|AES3)[_-]?(IN|OUT|RX|TX|DIN|DOUT)?\d*$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (digitalAudioTransportLabelPattern.test(phrase)) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/digital-audio-transport-pin-labels.test.ts
+++ b/tests/digital-audio-transport-pin-labels.test.ts
@@ -1,0 +1,109 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "../lib"
+
+it("preserves digital audio transport pin labels", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_3",
+      name: "R2",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_4",
+      name: "R3",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      port_hints: ["SPDIF_OUT1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      port_hints: ["TOSLINK_TX"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      pin_number: 16,
+      port_hints: ["AES3_RX"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_5",
+      source_component_id: "source_component_3",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_6",
+      source_component_id: "source_component_4",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_4"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_5"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_port_ids: ["source_port_3", "source_port_6"],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_SPDIF_OUT1")
+  expect(readableNetlist).toContain("NET: U1_TOSLINK_TX")
+  expect(readableNetlist).toContain("NET: U1_AES3_RX")
+  expect(readableNetlist).toContain("- U1 Pin14 (SPDIF_OUT1)")
+  expect(readableNetlist).toContain("- U1 Pin15 (TOSLINK_TX)")
+  expect(readableNetlist).toContain("- U1 Pin16 (AES3_RX)")
+  expect(readableNetlist).toContain("- pin14(SPDIF_OUT1): NETS(U1_SPDIF_OUT1)")
+  expect(readableNetlist).toContain("- pin15(TOSLINK_TX): NETS(U1_TOSLINK_TX)")
+  expect(readableNetlist).toContain("- pin16(AES3_RX): NETS(U1_AES3_RX)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- add focused scoring for S/PDIF, TOSLINK, and AES3 digital-audio transport aliases before the generic digit fallback
- preserve labels such as `SPDIF_OUT1`, `TOSLINK_TX`, and `AES3_RX` in generated NET names and readable pin entries
- add raw Circuit JSON regression coverage for this digital-audio transport label family, separate from analog audio, I2S, PDM/DMIC, MIDI, USB, RF, and generic numbered-pin scopes

## Verification
- `bun test tests/digital-audio-transport-pin-labels.test.ts`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/digital-audio-transport-pin-labels.test.ts`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before submission.