### PR TITLE
Score reed magnetic switch pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const reedMagneticSwitchLabelPattern =
+  /^((REED|REED[_-]?SW|MAG[_-]?SWITCH|MAGNETIC[_-]?SWITCH|LID[_-]?MAG|LID[_-]?SW)[_-]?(IN|OUT|DET|SENSE|SW)?\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (reedMagneticSwitchLabelPattern.test(phrase)) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/reed-magnetic-switch-pin-labels.test.ts
+++ b/tests/reed-magnetic-switch-pin-labels.test.ts
@@ -1,0 +1,111 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "../lib"
+
+it("preserves reed and magnetic switch pin labels", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_3",
+      name: "R2",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_4",
+      name: "R3",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      port_hints: ["REED_SW1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      port_hints: ["MAG_SWITCH1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      pin_number: 16,
+      port_hints: ["LID_MAG1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_5",
+      source_component_id: "source_component_3",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_6",
+      source_component_id: "source_component_4",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_4"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_5"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_port_ids: ["source_port_3", "source_port_6"],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_REED_SW1")
+  expect(readableNetlist).toContain("NET: U1_MAG_SWITCH1")
+  expect(readableNetlist).toContain("NET: U1_LID_MAG1")
+  expect(readableNetlist).toContain("- U1 Pin14 (REED_SW1)")
+  expect(readableNetlist).toContain("- U1 Pin15 (MAG_SWITCH1)")
+  expect(readableNetlist).toContain("- U1 Pin16 (LID_MAG1)")
+  expect(readableNetlist).toContain("- pin14(REED_SW1): NETS(U1_REED_SW1)")
+  expect(readableNetlist).toContain(
+    "- pin15(MAG_SWITCH1): NETS(U1_MAG_SWITCH1)",
+  )
+  expect(readableNetlist).toContain("- pin16(LID_MAG1): NETS(U1_LID_MAG1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for reed-switch and magnetic-switch aliases before the generic digit fallback.
- Preserve labels such as `REED_SW1`, `MAG_SWITCH1`, and `LID_MAG1` in generated NET names and readable pin entries.
- Add raw Circuit JSON regression coverage for this magnetic-switch label family, separate from Hall/motor and PIR/tamper/security scopes.

## Verification
- `npx --yes bun test tests/reed-magnetic-switch-pin-labels.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/scorePhrase.ts tests/reed-magnetic-switch-pin-labels.test.ts`
- `npm exec -- tsup ./lib/index.ts --format esm --dts`
- `git diff --check`

Note: full local `npx --yes bun test` still hits the existing dependency mismatch where `@tscircuit/circuit-json-util` does not export `distanceBetweenCircleAndPolygon`; the new focused regression passes.

/claim #4