### PR TITLE
Score Peltier TEC pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const peltierTecLabelPattern =
+  /^(PELTIER|TEC|THERMOELECTRIC)[_-]?(P|N|OUT|PWM|SENSE)\d*$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (peltierTecLabelPattern.test(phrase)) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/peltier-tec-pin-labels.test.ts
+++ b/tests/peltier-tec-pin-labels.test.ts
@@ -1,0 +1,111 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "../lib"
+
+it("preserves Peltier and thermoelectric cooler pin labels", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_3",
+      name: "R2",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_4",
+      name: "R3",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      port_hints: ["PELTIER_P1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      port_hints: ["TEC_OUT1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      pin_number: 16,
+      port_hints: ["THERMOELECTRIC_N1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_5",
+      source_component_id: "source_component_3",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_6",
+      source_component_id: "source_component_4",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_4"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_5"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_port_ids: ["source_port_3", "source_port_6"],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_PELTIER_P1")
+  expect(readableNetlist).toContain("NET: U1_TEC_OUT1")
+  expect(readableNetlist).toContain("NET: U1_THERMOELECTRIC_N1")
+  expect(readableNetlist).toContain("- U1 Pin14 (PELTIER_P1)")
+  expect(readableNetlist).toContain("- U1 Pin15 (TEC_OUT1)")
+  expect(readableNetlist).toContain("- U1 Pin16 (THERMOELECTRIC_N1)")
+  expect(readableNetlist).toContain("- pin14(PELTIER_P1): NETS(U1_PELTIER_P1)")
+  expect(readableNetlist).toContain("- pin15(TEC_OUT1): NETS(U1_TEC_OUT1)")
+  expect(readableNetlist).toContain(
+    "- pin16(THERMOELECTRIC_N1): NETS(U1_THERMOELECTRIC_N1)",
+  )
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for Peltier / TEC / thermoelectric cooler aliases before the generic digit fallback.
- Preserve labels such as `PELTIER_P1`, `TEC_OUT1`, and `THERMOELECTRIC_N1` in generated NET names and readable pin entries.
- Add raw Circuit JSON regression coverage for this cooler-driver label family, separate from thermal sensor and fan scopes.

## Verification
- `npx --yes bun test tests/peltier-tec-pin-labels.test.ts`
- `npx tsc --noEmit`
- `npx biome check lib/scorePhrase.ts tests/peltier-tec-pin-labels.test.ts`
- `npm exec -- tsup ./lib/index.ts --format esm --dts`
- `git diff --check`

Note: full local `npx --yes bun test` still hits the existing dependency mismatch where `@tscircuit/circuit-json-util` does not export `distanceBetweenCircleAndPolygon`; the new focused regression passes.

/claim #4