### PR TITLE
Score chassis and shield pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const chassisShieldGroundLabelPattern =
+  /^(?:(?:CHASSIS|SHIELD|SHLD|FRAME|EARTH|PE|FG)(?:[_-]?(?:GND|GROUND|RTN|REF))?|CASE[_-]?(?:GND|GROUND|SHIELD)|(?:GND|GROUND|EARTH)[_-]?(?:CHASSIS|SHIELD|SHLD|FRAME|PE|FG|CASE))\d*$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (chassisShieldGroundLabelPattern.test(phrase)) {
+    return 1.1
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/chassis-shield-pin-labels.test.ts
+++ b/tests/chassis-shield-pin-labels.test.ts
@@ -1,0 +1,130 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("keeps chassis and shield aliases on generic pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "SHIELD_CTRL",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["CHASSIS_GND1", "pin14", "14"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["SHIELD1", "pin15", "15"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      pcb_component_id: "pcb_component_0",
+      source_component_id: "source_component_0",
+      footprinter_string: "qfn16",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1kΩ",
+      are_pins_interchangeable: true,
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["cathode", "neg", "right", "pin2", "2"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      pcb_component_id: "pcb_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      ftype: "simple_resistor",
+      name: "R2",
+      resistance: 470,
+      display_resistance: "470Ω",
+      are_pins_interchangeable: true,
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+      source_component_id: "source_component_2",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_5",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["cathode", "neg", "right", "pin2", "2"],
+      source_component_id: "source_component_2",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_2",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      pcb_component_id: "pcb_component_2",
+      source_component_id: "source_component_2",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_4"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_CHASSIS_GND1")
+  expect(netlist).toContain("  - U1 pin14 (CHASSIS_GND1)")
+  expect(netlist).toContain("- pin14(CHASSIS_GND1): NETS(U1_CHASSIS_GND1)")
+  expect(netlist).toContain("NET: U1_SHIELD1")
+  expect(netlist).toContain("  - U1 pin15 (SHIELD1)")
+  expect(netlist).toContain("- pin15(SHIELD1): NETS(U1_SHIELD1)")
+  expect(netlist).not.toContain("NET: R1_pos")
+  expect(netlist).not.toContain("NET: R2_pos")
+})


### PR DESCRIPTION
## Summary
- score chassis, shield, frame, protective-earth, and earth-ground pin aliases before the generic digit fallback
- add raw Circuit JSON regression coverage for generic pins carrying `CHASSIS_GND1` and `SHIELD1`
- keep this limited to `scorePhrase` so it does not overlap the existing simple-ground component-description PR

/claim #4

## Verification
- `bun test tests/chassis-shield-pin-labels.test.ts`
- `bun x biome check lib/scorePhrase.ts tests/chassis-shield-pin-labels.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `bun test`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening the PR.