### PR TITLE
Score PS/2 keyboard and mouse pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,18 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isPs2KeyboardMouseAlias = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  return (
+    /^PS2_?(CLK|CLOCK|DATA|DAT)\d*$/.test(normalizedPhrase) ||
+    /^(KBD|KEYBOARD|MOUSE)_(CLK|CLOCK|DATA|DAT)\d*$/.test(normalizedPhrase)
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isPs2KeyboardMouseAlias(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/ps2-pin-labels.test.tsx
+++ b/tests/ps2-pin-labels.test.tsx
@@ -1,0 +1,32 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves PS/2 keyboard and mouse aliases in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="PS2-CTRL"
+        pinLabels={{
+          pin14: ["pin14", "PS2_CLK"],
+          pin15: ["pin15", "KBD_DATA1"],
+          pin16: ["pin16", "MOUSE_CLK1"],
+        }}
+      />
+      <resistor name="R1" resistance="10k" footprint="0402" />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 .PS2_CLK" to=".R1 .pin1" />
+      <trace from=".U1 .KBD_DATA1" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_PS2_CLK")
+  expect(netlist).toContain("  - U1 pin14 (PS2_CLK)")
+  expect(netlist).toContain("NET: U1_KBD_DATA1")
+  expect(netlist).toContain("  - U1 pin15 (KBD_DATA1)")
+  expect(netlist).toContain("- pin16(MOUSE_CLK1): NOT_CONNECTED")
+})


### PR DESCRIPTION
/claim #4

## Summary
- add focused scoring for legacy PS/2 keyboard and mouse clock/data aliases before the generic digit fallback
- preserve useful aliases such as `PS2_CLK`, `KBD_DATA1`, and `MOUSE_CLK1` in generated NET names and readable pin output
- add regression coverage for the PS/2 alias case

## Verification
- `npx --yes bun@latest test`
- `npx --yes bun@latest x biome check lib/scorePhrase.ts tests/ps2-pin-labels.test.tsx`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest run build`