### PR TITLE
Fix scorePhrase for semantic digit-bearing aliases (GPIO1, GPIO1_RX)

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,19 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const cleanedPhrase = phrase?.trim()
+  if (!cleanedPhrase) return 0
+  const upperPhrase = cleanedPhrase.toUpperCase()
+
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (upperPhrase.includes(word.toUpperCase())) {
       return score
     }
   }
+
+  if (cleanedPhrase.match(/\d+/)) {
+    return 0.5
+  }
+
   return 1
 }

--- a/tests/score-phrase.test.ts
+++ b/tests/score-phrase.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { scorePhrase } from "../lib/scorePhrase"
+
+test("preserves semantic score for digit-bearing aliases like GPIO1", () => {
+  expect(scorePhrase("GPIO1")).toBe(1.1)
+  expect(scorePhrase("GPIO1_RX")).toBe(1.15)
+})
+
+test("matches known words case-insensitively", () => {
+  expect(scorePhrase("sda")).toBe(1.2)
+  expect(scorePhrase("gNd")).toBe(1.1)
+})
+
+test("still falls back to generic digit score for unknown numeric labels", () => {
+  expect(scorePhrase("pin14")).toBe(0.5)
+})


### PR DESCRIPTION
## Summary
- fix `scorePhrase` ordering so known semantic words are matched before generic digit fallback
- make known-word scoring case-insensitive
- add focused regression tests for `GPIO1`, `GPIO1_RX`, and lowercase aliases

This keeps meaningful signal labels from being demoted to generic `pinN`-style scores.

## Validation
- GitHub Actions are green: test, dependency-check, format-check, and type-check

/claim #4