### PR TITLE
Score building automation bus pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const buildingAutomationBusLabelPattern =
+  /^(KNX|EIB)([_-]?(TP1|A|B|P|N|BUS|DATA))?\d*$|^(BACNET[_-]?MSTP|BACNET|MSTP)[_-]?(A|B|P|N|TX|RX)?\d*$|^(M[_-]?BUS|MBUS)[_-]?(A|B|P|N|TX|RX|DATA)?\d*$|^(LONWORKS|LON)([_-]?(NET[_-]?(A|B|P|N)|A|B|P|N|NET))?\d*$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (buildingAutomationBusLabelPattern.test(phrase)) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/building-automation-pin-labels.test.ts
+++ b/tests/building-automation-pin-labels.test.ts
@@ -1,0 +1,144 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "../lib"
+
+it("preserves building automation bus pin labels", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_3",
+      name: "R2",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_4",
+      name: "R3",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_5",
+      name: "R4",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      port_hints: ["KNX_TP1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      port_hints: ["BACNET_MSTP_A"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      pin_number: 16,
+      port_hints: ["MBUS_DATA1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_1",
+      pin_number: 17,
+      port_hints: ["LONWORKS_NET_A"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_5",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_6",
+      source_component_id: "source_component_3",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_7",
+      source_component_id: "source_component_4",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_8",
+      source_component_id: "source_component_5",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_5"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_6"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_port_ids: ["source_port_3", "source_port_7"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_4",
+      connected_source_port_ids: ["source_port_4", "source_port_8"],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_KNX_TP1")
+  expect(readableNetlist).toContain("NET: U1_BACNET_MSTP_A")
+  expect(readableNetlist).toContain("NET: U1_MBUS_DATA1")
+  expect(readableNetlist).toContain("NET: U1_LONWORKS_NET_A")
+  expect(readableNetlist).toContain("- U1 Pin14 (KNX_TP1)")
+  expect(readableNetlist).toContain("- U1 Pin15 (BACNET_MSTP_A)")
+  expect(readableNetlist).toContain("- U1 Pin16 (MBUS_DATA1)")
+  expect(readableNetlist).toContain("- U1 Pin17 (LONWORKS_NET_A)")
+  expect(readableNetlist).toContain("- pin14(KNX_TP1): NETS(U1_KNX_TP1)")
+  expect(readableNetlist).toContain(
+    "- pin15(BACNET_MSTP_A): NETS(U1_BACNET_MSTP_A)",
+  )
+  expect(readableNetlist).toContain("- pin16(MBUS_DATA1): NETS(U1_MBUS_DATA1)")
+  expect(readableNetlist).toContain(
+    "- pin17(LONWORKS_NET_A): NETS(U1_LONWORKS_NET_A)",
+  )
+})


### PR DESCRIPTION
## Summary

/claim #4

This adds a focused scoring path for building automation and metering bus aliases before the generic digit fallback. Labels such as `KNX_TP1`, `BACNET_MSTP_A`, `MBUS_DATA1`, and `LONWORKS_NET_A` now win over passive endpoint labels when generating readable net names and pin labels.

The regression uses raw Circuit JSON to cover generic chip pins connected to passive endpoints, so these digit-bearing aliases remain visible in `NET:` names and `COMPONENT_PINS`.

## Verification

- `npx --yes bun@latest test tests/building-automation-pin-labels.test.ts`
- `npx --yes bun@latest test`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest x biome check lib/scorePhrase.ts tests/building-automation-pin-labels.test.ts`
- `npx --yes bun@latest run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and ran the checks above before opening this PR.