### PR TITLE
Score high-voltage display pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const highVoltageDisplayLabelPattern =
+  /^(?:(?:NIXIE|NEON)(?:[_-]?(?:A|K|ANODE|CATHODE|COM|COMMON|GRID|SEG|DIGIT|LAMP|HV|BIAS))?|VFD(?:[_-]?(?:GRID|SEG|SEGMENT|ANODE|CATHODE|FIL|FILAMENT|COM|COMMON|DIGIT|HV|BIAS))?)\d*$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (highVoltageDisplayLabelPattern.test(phrase)) {
+    return 1.1
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/hv-display-pin-labels.test.ts
+++ b/tests/hv-display-pin-labels.test.ts
@@ -1,0 +1,130 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("keeps high-voltage display aliases on generic pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "TUBE_DRIVER",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["NIXIE_A1", "pin14", "14"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["VFD_GRID1", "pin15", "15"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      pcb_component_id: "pcb_component_0",
+      source_component_id: "source_component_0",
+      footprinter_string: "qfn16",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1kΩ",
+      are_pins_interchangeable: true,
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["cathode", "neg", "right", "pin2", "2"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      pcb_component_id: "pcb_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      ftype: "simple_resistor",
+      name: "R2",
+      resistance: 470,
+      display_resistance: "470Ω",
+      are_pins_interchangeable: true,
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+      source_component_id: "source_component_2",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_5",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["cathode", "neg", "right", "pin2", "2"],
+      source_component_id: "source_component_2",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_2",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      pcb_component_id: "pcb_component_2",
+      source_component_id: "source_component_2",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_4"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_NIXIE_A1")
+  expect(netlist).toContain("  - U1 pin14 (NIXIE_A1)")
+  expect(netlist).toContain("- pin14(NIXIE_A1): NETS(U1_NIXIE_A1)")
+  expect(netlist).toContain("NET: U1_VFD_GRID1")
+  expect(netlist).toContain("  - U1 pin15 (VFD_GRID1)")
+  expect(netlist).toContain("- pin15(VFD_GRID1): NETS(U1_VFD_GRID1)")
+  expect(netlist).not.toContain("NET: R1_pos")
+  expect(netlist).not.toContain("NET: R2_pos")
+})


### PR DESCRIPTION
## Summary
- score Nixie, neon, and VFD display/tube aliases before the generic digit fallback
- add raw Circuit JSON regression coverage for generic pins carrying `NIXIE_A1` and `VFD_GRID1`
- keep the matcher limited to high-voltage display/tube labels so it does not overlap broader power-management or display-bus scopes

/claim #4

## Verification
- `bun test tests/hv-display-pin-labels.test.ts`
- `bun x biome check lib/scorePhrase.ts tests/hv-display-pin-labels.test.ts`
- `bun x tsc --noEmit`
- `bun run build`
- `bun test`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening the PR.