### PR TITLE
Prevent undefined footprint text in passive component output

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -36,13 +36,21 @@ export const convertCircuitJsonToReadableNetlist = (
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
+      componentDescription = [
+        component.display_resistance,
+        footprint,
+        "resistor",
+      ]
+        .filter(Boolean)
+        .join(" ")
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
+      componentDescription = [
+        component.display_capacitance,
+        footprint,
+        "capacitor",
+      ]
+        .filter(Boolean)
+        .join(" ")
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -145,9 +153,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-no-footprint-passives.test.tsx
+++ b/tests/test4-no-footprint-passives.test.tsx
@@ -12,8 +12,8 @@ it("passives without footprints do not render undefined", () => {
 
   const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
   expect(netlist).not.toContain("undefined")
-  expect(netlist).toContain(" - R1: 10k resistor")
+  expect(netlist).toContain(" - R1: 10kΩ resistor")
   expect(netlist).toContain(" - C1: 100nF capacitor")
-  expect(netlist).toContain("R1 (10k)")
+  expect(netlist).toContain("R1 (10kΩ)")
   expect(netlist).toContain("C1 (100nF)")
 })

--- a/tests/test4-no-footprint-passives.test.tsx
+++ b/tests/test4-no-footprint-passives.test.tsx
@@ -1,0 +1,19 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("passives without footprints do not render undefined", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <resistor name="R1" resistance="10k" />
+      <capacitor name="C1" capacitance="100nF" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain(" - R1: 10k resistor")
+  expect(netlist).toContain(" - C1: 100nF capacitor")
+  expect(netlist).toContain("R1 (10k)")
+  expect(netlist).toContain("C1 (100nF)")
+})


### PR DESCRIPTION
## Summary
- stop rendering `undefined` when passive components have no `footprinter_string`
- apply the fix in both `COMPONENTS` descriptions and `COMPONENT_PINS` headers
- add a regression test for resistor/capacitor entries without footprints
- update the test expectations to match the renderer's Ω-formatted values

This keeps readable netlists clean for no-footprint passive components.

## Validation
- `npx --yes bun@latest x biome check tests/test4-no-footprint-passives.test.tsx`
- `git diff --check`
- GitHub Actions are rerunning after the test expectation fix

/claim #4