### PR TITLE
Avoid Pinundefined fallback in readable pin labels

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -34,7 +34,10 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const normalizedPortName = port.name?.trim()
+  const mainPinName =
+    normalizedPortName ??
+    (port.pin_number !== undefined ? `Pin${port.pin_number}` : "Pin")
 
   const additionalPinLabels: string[] = []
 
@@ -44,7 +47,9 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
-  for (const port_hint of port.port_hints ?? []) {
+  for (const port_hint_raw of port.port_hints ?? []) {
+    const port_hint = port_hint_raw.trim()
+    if (!port_hint) continue
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
     if (score > 1) {

--- a/tests/test6-readable-name-with-missing-port-name-and-pin-number.test.ts
+++ b/tests/test6-readable-name-with-missing-port-name-and-pin-number.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("does not emit Pinundefined when source_port lacks both name and pin_number", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      port_hints: ["  ", "SDA"],
+    },
+  ] as any
+
+  const readable = getReadableNameForPin({
+    circuitJson,
+    source_port_id: "source_port_0",
+  })
+
+  expect(readable).toBe("U1 Pin (SDA)")
+  expect(readable).not.toContain("Pinundefined")
+})


### PR DESCRIPTION
## Summary
- prevent `Pinundefined` output when `source_port` has neither `name` nor `pin_number`
- trim and ignore whitespace-only `port_hints` before scoring/alias output
- add regression coverage for missing-name/missing-pin-number source ports

This keeps readable pin labels stable for sparse source-port metadata.

## Validation
- Could not run tests in this environment because `bun` is not installed.

/claim #4