### PR TITLE
Deduplicate port-hint aliases case-insensitively in readable labels

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -36,24 +36,33 @@ export const getReadableNameForPin = ({
   // Format pin description
   const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
 
-  const additionalPinLabels: string[] = []
+  const additionalPinLabels = new Map<string, string>()
+  const addPinAlias = (label: string) => {
+    const normalized = label.trim()
+    if (!normalized) return
+    const key = normalized.toLowerCase()
+    if (!additionalPinLabels.has(key)) {
+      additionalPinLabels.set(key, normalized)
+    }
+  }
 
   if (isPositive && component.ftype !== "simple_resistor") {
-    additionalPinLabels.push("+")
+    addPinAlias("+")
   } else if (isNegative && component.ftype !== "simple_resistor") {
-    additionalPinLabels.push("-")
+    addPinAlias("-")
   }
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
     if (score > 1) {
-      additionalPinLabels.push(port_hint)
+      addPinAlias(port_hint)
     }
   }
 
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  const additionalLabels = Array.from(additionalPinLabels.values())
+  return `${component.name} ${mainPinName}${additionalLabels.length > 0 ? ` (${additionalLabels.join(",")})` : ""}${displayValue}`
 }

--- a/tests/test7-dedupe-port-hints-case-insensitively.test.ts
+++ b/tests/test7-dedupe-port-hints-case-insensitively.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("deduplicates equivalent port hints regardless of case", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["SDA", "sda", " SDA "],
+    },
+  ] as any
+
+  const readable = getReadableNameForPin({
+    circuitJson,
+    source_port_id: "source_port_0",
+  })
+
+  expect(readable).toBe("U1 pin14 (SDA)")
+})


### PR DESCRIPTION
## Summary
- dedupe `getReadableNameForPin` aliases case-insensitively
- trim aliases before dedupe to avoid whitespace duplicates
- add regression coverage for `SDA`/`sda` duplicate-hint output

This prevents noisy duplicate aliases in readable netlist pin labels.

## Validation
- Could not run tests in this environment because `bun` is not installed.

/claim #4