### PR TITLE
Support non-prefixed source_port ids in netlist connectivity pass

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -20,6 +20,9 @@ export const convertCircuitJsonToReadableNetlist = (
   const source_components = su(circuitJson).source_component.list()
   const source_nets = su(circuitJson).source_net.list()
   const source_traces = su(circuitJson).source_trace.list()
+  const sourcePortIdSet = new Set(source_ports.map((p) => p.source_port_id))
+  const isSourcePortId = (id: string) =>
+    sourcePortIdSet.has(id) || id.startsWith("source_port")
   // Build readable netlist
   const netlist: string[] = []
 
@@ -71,7 +74,7 @@ export const convertCircuitJsonToReadableNetlist = (
     }
 
     const connectedPortCount = connectedIds.filter((id) =>
-      id.startsWith("source_port"),
+      isSourcePortId(id),
     ).length
 
     if (connectedPortCount <= 1) continue
@@ -98,7 +101,7 @@ export const convertCircuitJsonToReadableNetlist = (
   let hasEmptyNets = false
   for (const [netId, connectedIds] of Object.entries(netMap)) {
     const connectedPortCount = connectedIds.filter((id) =>
-      id.startsWith("source_port"),
+      isSourcePortId(id),
     ).length
     if (connectedPortCount === 1) {
       if (!hasEmptyNets) {
@@ -107,7 +110,7 @@ export const convertCircuitJsonToReadableNetlist = (
         hasEmptyNets = true
       }
       const source_port_id = netMap[netId].find((id) =>
-        id.startsWith("source_port"),
+        isSourcePortId(id),
       )!
       const pinName = getReadableNameForPin({
         circuitJson,
@@ -122,7 +125,7 @@ export const convertCircuitJsonToReadableNetlist = (
   // build map of port ids to the nets they connect to
   const portIdToNetNames: Record<string, string[]> = {}
   for (const [netId, connectedIds] of Object.entries(netMap)) {
-    const portIds = connectedIds.filter((id) => id.startsWith("source_port"))
+    const portIds = connectedIds.filter((id) => isSourcePortId(id))
     if (portIds.length === 0) continue
     const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
     let netName = net?.name

--- a/tests/test8-support-nonprefixed-source-port-ids.test.tsx
+++ b/tests/test8-support-nonprefixed-source-port-ids.test.tsx
@@ -1,0 +1,27 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("handles source_port ids that do not start with source_port", () => {
+  const original = renderCircuit(
+    <board width="20mm" height="20mm">
+      <resistor name="R1" resistance="1k" />
+      <resistor name="R2" resistance="2k" />
+      <trace from=".R1 > .pin1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const sourcePorts = original.filter((element: any) => element.type === "source_port")
+  let rewritten = JSON.stringify(original)
+
+  sourcePorts.forEach((port: any, index: number) => {
+    rewritten = rewritten.split(port.source_port_id).join(`p${index}`)
+  })
+
+  const circuitJson = JSON.parse(rewritten)
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET:")
+  expect(netlist).toContain("R1")
+  expect(netlist).toContain("R2")
+})


### PR DESCRIPTION
## Summary
- stop assuming source-port ids must start with `source_port`
- treat known source-port ids from the circuit JSON as valid connectivity ids
- add regression coverage by rewriting rendered circuits with non-prefixed port ids

This keeps net grouping and empty-net classification correct across alternate id naming schemes.

## Validation
- Could not run tests in this environment because `bun` is not installed.

/claim #4