### PR TITLE
Improve digit-bearing pin label scoring

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -8,11 +8,16 @@
  * These unique port names are usually the best indicator of what the net is for
  */
 const wordQualityScore = {
+  I2C: 1.2,
+  SPI: 1.2,
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  ADC: 1.2,
+  DAC: 1.2,
+  PWM: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -36,11 +41,12 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
+  const normalizedPhrase = phrase.trim().toUpperCase()
+  if (normalizedPhrase.match(/^(PIN)?\d+$/)) {
     return 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word)) {
       return score
     }
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -46,7 +46,7 @@ export const scorePhrase = (phrase: string) => {
     return 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {
-    if (normalizedPhrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
   }

--- a/tests/score-phrase.test.ts
+++ b/tests/score-phrase.test.ts
@@ -9,6 +9,9 @@ it("scores technical aliases that contain pin numbers", () => {
   expect(scorePhrase("I2C1_SCL")).toBe(1.2)
   expect(scorePhrase("ADC0")).toBe(1.2)
   expect(scorePhrase("PWM1")).toBe(1.2)
+  expect(scorePhrase("anode")).toBe(0.5)
+  expect(scorePhrase("pos")).toBe(0.9)
+  expect(scorePhrase("left")).toBe(0.3)
 })
 
 it("includes digit-bearing technical aliases in readable pin names", () => {

--- a/tests/score-phrase.test.ts
+++ b/tests/score-phrase.test.ts
@@ -1,0 +1,38 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores technical aliases that contain pin numbers", () => {
+  expect(scorePhrase("14")).toBe(0.5)
+  expect(scorePhrase("pin14")).toBe(0.5)
+  expect(scorePhrase("GPIO1_RX")).toBe(1.15)
+  expect(scorePhrase("I2C1_SCL")).toBe(1.2)
+  expect(scorePhrase("ADC0")).toBe(1.2)
+  expect(scorePhrase("PWM1")).toBe(1.2)
+})
+
+it("includes digit-bearing technical aliases in readable pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "14", "ADC0", "PWM1"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (ADC0,PWM1)")
+})


### PR DESCRIPTION
## Summary
- Keep pure numeric aliases and generic `pin14`-style labels low-scoring
- Score alphanumeric technical aliases by their signal words before applying the numeric fallback
- Add coverage for GPIO/I2C/ADC/PWM aliases and readable pin output for `pin14` with useful digit-bearing labels

## Verification
- `bun test`
- `bunx biome check lib/scorePhrase.ts tests/score-phrase.test.ts`
- `bun run build`

/claim #4