### PR TITLE
Trim padded component metadata in readable netlist formatting

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -12,6 +12,12 @@ import { getReadableNameForPin } from "./getReadableNameForPin"
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
+  const cleanText = (value: unknown) => {
+    if (typeof value !== "string") return value
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : undefined
+  }
+
   const connectivityMap = getFullConnectivityMapFromCircuitJson(
     circuitJson.filter((e) => e.type.startsWith("source_")),
   )
@@ -33,7 +39,7 @@ export const convertCircuitJsonToReadableNetlist = (
       source_component_id: component.source_component_id,
     })
 
-    const footprint = cadComponent?.footprinter_string
+    const footprint = cleanText(cadComponent?.footprinter_string)
 
     if (component.ftype === "simple_resistor") {
       componentDescription = `${component.display_resistance}${
@@ -44,7 +50,9 @@ export const convertCircuitJsonToReadableNetlist = (
         footprint ? ` ${footprint}` : ""
       } capacitor`
     } else if (component.ftype === "simple_chip") {
-      const manufacturerPartNumber = component.manufacturer_part_number
+      const manufacturerPartNumber = cleanText(
+        component.manufacturer_part_number,
+      )
       componentDescription = [manufacturerPartNumber, footprint]
         .filter(Boolean)
         .join(", ")
@@ -142,14 +150,14 @@ export const convertCircuitJsonToReadableNetlist = (
       const cadComponent = su(circuitJson).cad_component.getWhere({
         source_component_id: component.source_component_id,
       })
-      const footprint = cadComponent?.footprinter_string
+      const footprint = cleanText(cadComponent?.footprinter_string)
       let header = component.name
       if (component.ftype === "simple_resistor") {
         header = `${component.name} (${component.display_resistance} ${footprint})`
       } else if (component.ftype === "simple_capacitor") {
         header = `${component.name} (${component.display_capacitance} ${footprint})`
-      } else if (component.manufacturer_part_number) {
-        header = `${component.name} (${component.manufacturer_part_number})`
+      } else if (cleanText(component.manufacturer_part_number)) {
+        header = `${component.name} (${cleanText(component.manufacturer_part_number)})`
       }
       netlist.push(header)
       const ports = source_ports

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -52,8 +52,8 @@ export const getReadableNameForPin = ({
     }
   }
 
-  const displayValue = component.display_value
-    ? ` (${component.display_value})`
+  const displayValue = component.display_value?.trim()
+    ? ` (${component.display_value.trim()})`
     : ""
   return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/tests/test9-trim-whitespace-component-metadata.test.ts
+++ b/tests/test9-trim-whitespace-component-metadata.test.ts
@@ -1,0 +1,33 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("trims whitespace-only padding in component metadata fields", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "  WS2812B_2020  ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "DIN",
+      pin_number: 1,
+    },
+    {
+      type: "cad_component",
+      source_component_id: "source_component_0",
+      footprinter_string: "  2020  ",
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("- U1: WS2812B_2020, 2020")
+  expect(netlist).toContain("U1 (WS2812B_2020)")
+  expect(netlist).not.toContain("  WS2812B_2020  ")
+  expect(netlist).not.toContain("  2020  ")
+})


### PR DESCRIPTION
## Summary
- trim leading/trailing whitespace from component metadata fields before formatting
- apply trimming to footprint/manufacturer-part metadata in component sections
- trim `display_value` before appending in readable pin labels
- add regression coverage for padded metadata values

This removes spacing noise and keeps readable netlist output stable for messy input metadata.

## Validation
- Could not run tests in this environment because `bun` is not installed.

/claim #4