### PR TITLE
Fallback simple_chip description when metadata is absent

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -48,6 +48,9 @@ export const convertCircuitJsonToReadableNetlist = (
       componentDescription = [manufacturerPartNumber, footprint]
         .filter(Boolean)
         .join(", ")
+      if (!componentDescription.trim()) {
+        componentDescription = component.type
+      }
     } else {
       componentDescription = [component.name, component.type]
         .filter(Boolean)

--- a/tests/test10-simple-chip-empty-metadata-description-fallback.test.ts
+++ b/tests/test10-simple-chip-empty-metadata-description-fallback.test.ts
@@ -1,0 +1,18 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("falls back to type description when simple_chip metadata is missing", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain(" - U1: source_component")
+  expect(netlist).not.toContain(" - U1: \n")
+})


### PR DESCRIPTION
## Summary
- add a fallback description for `simple_chip` when both footprint and manufacturer part number are missing
- prevent blank `COMPONENTS` lines like `- U1:`
- add regression coverage for the empty-metadata simple-chip case

This keeps `COMPONENTS` output readable even when chip metadata is sparse.

## Validation
- Could not run tests in this environment because `bun` is not installed.

/claim #4