### PR TITLE
Score DDR SDRAM SRAM pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isDdrSdramSramAlias = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  return /^(DDR\d*|LPDDR\d*|SDRAM|DRAM|SRAM)_(DQ|DQS|DQM|DM|A|BA|CK|CLK|CKE|CS|RAS|CAS|WE|OE|ODT|RESET)(?:[_-]?[PN])?\d*$/.test(
+    normalizedPhrase,
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isDdrSdramSramAlias(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/ddr-sdram-pin-labels.test.tsx
+++ b/tests/ddr-sdram-pin-labels.test.tsx
@@ -1,0 +1,32 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves DDR SDRAM and SRAM aliases in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="tqfp48"
+        manufacturerPartNumber="MEM-CTRL"
+        pinLabels={{
+          pin14: ["pin14", "DDR_DQ0"],
+          pin15: ["pin15", "SDRAM_A1"],
+          pin16: ["pin16", "SRAM_DQ1"],
+        }}
+      />
+      <resistor name="R1" resistance="33" footprint="0402" />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 .DDR_DQ0" to=".R1 .pin1" />
+      <trace from=".U1 .SDRAM_A1" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_DDR_DQ0")
+  expect(netlist).toContain("  - U1 pin14 (DDR_DQ0)")
+  expect(netlist).toContain("NET: U1_SDRAM_A1")
+  expect(netlist).toContain("  - U1 pin15 (SDRAM_A1)")
+  expect(netlist).toContain("- pin16(SRAM_DQ1): NOT_CONNECTED")
+})


### PR DESCRIPTION
/claim #4

## Summary
- add focused scoring for DDR/LPDDR, SDRAM, DRAM, and SRAM memory-bus aliases before the generic digit fallback
- preserve useful memory interface labels such as `DDR_DQ0`, `SDRAM_A1`, and `SRAM_DQ1` in generated readable net names and pin output
- add regression coverage for the DDR/SDRAM/SRAM alias case

## Verification
- `npx --yes bun@latest test tests/ddr-sdram-pin-labels.test.tsx`
- `npx --yes bun@latest test`
- `npx --yes bun@latest x biome check lib/scorePhrase.ts tests/ddr-sdram-pin-labels.test.tsx`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest run build`
- `git diff --check`