### PR TITLE
Add stable COMPONENT_PINS fallback when name/pin_number is missing

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -156,10 +156,11 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
+        const portName = port.name?.trim()
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.pin_number !== undefined ? `pin${port.pin_number}` : portName || "pin"
         const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
+        if (portName && portName !== mainPin) aliases.push(portName)
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)

--- a/tests/test11-component-pins-main-pin-fallback.test.ts
+++ b/tests/test11-component-pins-main-pin-fallback.test.ts
@@ -1,0 +1,24 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses a stable fallback pin label when pin_number and name are missing", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "WS2812B_2020",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("- pin: NOT_CONNECTED")
+  expect(netlist).not.toContain("- undefined:")
+})


### PR DESCRIPTION
## Summary
- add a stable fallback (`pin`) for `COMPONENT_PINS` rows when both `port.name` and `pin_number` are missing
- trim `port.name` before using it as the main pin label
- add regression coverage for sparse source-port metadata

This prevents `undefined` labels in `COMPONENT_PINS` output.

## Validation
- Could not run tests in this environment because `bun` is not installed.

/claim #4