### PR TITLE
Score watchdog supervisor pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -21,6 +21,15 @@ const wordQualityScore = {
   GND: 1.1,
   VDD: 1.1,
   AGND: 1.1,
+  WATCHDOG: 1.15,
+  SUPERVISOR: 1.15,
+  UVLO: 1.15,
+  OVLO: 1.15,
+  WDI: 1.1,
+  WDO: 1.1,
+  PFI: 1.1,
+  PFO: 1.1,
+  SEQ: 1.1,
   V5: 1.1,
   V3: 1.1,
   V1: 1.1,
@@ -36,13 +45,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/watchdog-supervisor-pin-labels.test.ts
+++ b/tests/watchdog-supervisor-pin-labels.test.ts
@@ -1,0 +1,100 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves watchdog and supervisor pin labels on generic chip pins", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "TPS386000",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_2",
+      name: "R1",
+      resistance: 10_000,
+      display_resistance: "10k",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_3",
+      name: "R2",
+      resistance: 10_000,
+      display_resistance: "10k",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      pcb_component_id: "pcb_component_1",
+      source_component_id: "source_component_2",
+      footprinter_string: "0402",
+      position: { x: 0, y: 0, z: 0 },
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_2",
+      pcb_component_id: "pcb_component_2",
+      source_component_id: "source_component_3",
+      footprinter_string: "0402",
+      position: { x: 0, y: 0, z: 0 },
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["WDI1", "WATCHDOG_IN1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["UVLO1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_3",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_4"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_WATCHDOG_IN1")
+  expect(netlist).toContain("  - U1 pin14 (WDI1,WATCHDOG_IN1)")
+  expect(netlist).toContain("NET: U1_UVLO1")
+  expect(netlist).toContain("  - U1 pin15 (UVLO1)")
+  expect(netlist).not.toContain("NET: R1_pos")
+  expect(netlist).not.toContain("NET: R2_pos")
+})


### PR DESCRIPTION
/claim #4

## Summary
- score watchdog/supervisor/power-sequencer aliases before the generic digit fallback
- preserve useful labels such as `WDI1`, `WATCHDOG_IN1`, and `UVLO1` in generated net names and readable pin labels
- add raw Circuit JSON regression coverage for generic chip pins connected to passive endpoints

## Verification
- `npx --yes bun test tests/watchdog-supervisor-pin-labels.test.ts`
- `npx --yes biome check lib/scorePhrase.ts tests/watchdog-supervisor-pin-labels.test.ts`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun run build`
- `git diff --check`

Note: `npx --yes bun test` currently fails locally in existing TSX fixture tests before this new regression test, with `@tscircuit/core` throwing `TypeError: Attempting to define property on object that is not extensible` while rendering fixture circuits. The new raw Circuit JSON regression test passes independently.