### PR TITLE
Fix full pin labels in readable netlist

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -7,6 +7,10 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
+import {
+  getDisplayNameForPort,
+  getPinNumberName,
+} from "./getDisplayNameForPort"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
 export const convertCircuitJsonToReadableNetlist = (
@@ -156,10 +160,12 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const mainPin = getDisplayNameForPort(port)
         const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
+        const pinNumberName = getPinNumberName(port)
+        if (pinNumberName && pinNumberName !== mainPin) {
+          aliases.push(pinNumberName)
+        }
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)

--- a/lib/getDisplayNameForPort.ts
+++ b/lib/getDisplayNameForPort.ts
@@ -1,0 +1,7 @@
+import type { SourcePort } from "circuit-json"
+
+export const getPinNumberName = (port: SourcePort): string | undefined =>
+  port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+
+export const getDisplayNameForPort = (port: SourcePort): string =>
+  port.name || getPinNumberName(port) || port.source_port_id

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -5,6 +5,7 @@ import type {
   SourceNet,
   SourcePort,
 } from "circuit-json"
+import { getDisplayNameForPort } from "./getDisplayNameForPort"
 import { scorePhrase } from "./scorePhrase"
 
 export const getReadableNameForPin = ({
@@ -34,7 +35,7 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = getDisplayNameForPort(port)
 
   const additionalPinLabels: string[] = []
 

--- a/tests/pin-labels.test.ts
+++ b/tests/pin-labels.test.ts
@@ -1,0 +1,63 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses full source port labels in component pin listings", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      name: "D13_GPIO4_BOOT_RESET",
+      port_hints: ["D13_GPIO4_BOOT_RESET", "BOOT_RESET", "14"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      name: "D14_GPIO5_STATUS_LED",
+      port_hints: ["D14_GPIO5_STATUS_LED", "STATUS_LED", "15"],
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      pcb_component_id: "pcb_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "soic16",
+      position: { x: 0, y: 0, z: 0 },
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: RP2040, soic16
+
+    NET: U1_BOOT_RESET
+      - U1 D13_GPIO4_BOOT_RESET
+      - U1 D14_GPIO5_STATUS_LED
+
+
+    COMPONENT_PINS:
+    U1 (RP2040)
+    - D13_GPIO4_BOOT_RESET(pin14, BOOT_RESET): NETS(U1_BOOT_RESET)
+    - D14_GPIO5_STATUS_LED(pin15, STATUS_LED): NETS(U1_BOOT_RESET)
+    "
+  `)
+})

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)


### PR DESCRIPTION
## Summary
- prefer full source port names when rendering component pin rows
- keep physical pin numbers as aliases instead of using them as the primary label
- add a focused Circuit JSON regression test for long chip pin labels

Fixes #4.

## Test plan
- npx biome check .
- npx tsc --noEmit
- npx bun test tests/pin-labels.test.ts

Note: npx bun test still hits an existing @tscircuit/core TSX fixture render error in the older tests (`Attempting to define property on object that is not extensible`) before exercising this change.