### PR TITLE
Fix readable labels for numbered GPIO pins

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -16,6 +16,7 @@ const wordQualityScore = {
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  GP: 1.1,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +37,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/get-readable-name-for-pin.test.ts
+++ b/tests/get-readable-name-for-pin.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("includes GPIO-style pin labels even when they contain digits", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      pin_number: 14,
+      port_hints: ["14", "GP0", "UART_TX"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 Pin14 (GP0,UART_TX)")
+})


### PR DESCRIPTION
## Summary
- Score semantic GPIO-style labels before applying the numeric-label penalty
- Add `GP` as a readable pin-label hint so labels like `GP0` are preserved
- Add a focused test covering `Pin14 (GP0,UART_TX)` output

## Testing
- `npx bun test tests/get-readable-name-for-pin.test.ts`
- `npm run build`

Note: the existing full test suite still fails locally in unrelated TSX fixture tests because `@tscircuit/circuit-json-util` does not export `distanceBetweenCircleAndPolygon` in the installed dependency version.