### PR TITLE
Use full pin labels for generic pin names

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -34,7 +34,16 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const fallbackPinName =
+    port.name ?? (port.pin_number !== undefined ? `Pin${port.pin_number}` : "")
+  const semanticPinLabel = (port.port_hints ?? [])
+    .filter((hint) => hint !== fallbackPinName)
+    .map((hint) => ({ hint, score: scorePhrase(hint) }))
+    .sort((a, b) => b.score - a.score)
+    .find(({ score }) => score > 1)?.hint
+  const mainPinName = /^pin\d+$/i.test(fallbackPinName)
+    ? (semanticPinLabel ?? fallbackPinName)
+    : fallbackPinName
 
   const additionalPinLabels: string[] = []
 
@@ -46,6 +55,7 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (port_hint === fallbackPinName) continue
     const score = scorePhrase(port_hint)
     if (score > 1) {
       additionalPinLabels.push(port_hint)

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (/^(?:pin)?\d+$/i.test(phrase)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-generic-pin-name.test.ts
+++ b/tests/test4-generic-pin-name.test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("uses full pin labels instead of generic pin names", () => {
+  expect(
+    getReadableNameForPin({
+      source_port_id: "source_port_1",
+      circuitJson: [
+        {
+          type: "source_component",
+          source_component_id: "source_component_1",
+          name: "U1",
+          ftype: "simple_chip",
+        },
+        {
+          type: "source_port",
+          source_port_id: "source_port_1",
+          source_component_id: "source_component_1",
+          name: "pin14",
+          pin_number: 14,
+          port_hints: ["14", "GPIO1", "SCL"],
+        },
+      ],
+    }),
+  ).toBe("U1 SCL (GPIO1)")
+})


### PR DESCRIPTION
/claim #4

Fixes #4.

This makes readable pin names prefer semantic `port_hints` when the source port name is only a generic pin number such as `pin14`.

It also updates phrase scoring so labels that include useful words plus numbers, like `GPIO1`, are still treated as useful labels instead of being down-ranked just because they contain a digit. Pure numeric labels and generic `pin14`-style labels remain low quality.

Verification:
- `bun test`
- `bun run build`
- `bun x biome check lib/getReadableNameForPin.ts lib/scorePhrase.ts tests/test4-generic-pin-name.test.ts`
