### PR TITLE
Score avionics bus pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,23 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const avionicsBusSignalPatterns = [
+  /(?:^|[_-])ARINC(?:429)?(?:[_-]?(?:TX|RX|A|B)\d*|[_-]|$)/,
+  /(?:^|[_-])MIL(?:STD)?1553(?:[_-]?(?:A|B|TX|RX)\d*|[_-]|$)/,
+  /(?:^|[_-])1553(?:[_-]?(?:A|B|TX|RX)\d*|[_-]|$)/,
+  /(?:^|[_-])SPACEWIRE(?:[_-]|$)/,
+  /(?:^|[_-])SPW(?:[_-]?(?:DIN|DOUT|SIN|SOUT|STROBE|CLK|P|N)\d*|[_-]|$)/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  if (
+    avionicsBusSignalPatterns.some((pattern) => pattern.test(normalizedPhrase))
+  ) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/avionics-bus-pin-labels.test.tsx
+++ b/tests/avionics-bus-pin-labels.test.tsx
@@ -1,0 +1,35 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves avionics bus pin aliases in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="HI-3593"
+        pinLabels={{
+          pin1: ["ARINC429_TX1"],
+          pin2: ["ARINC429_RX1"],
+          pin3: ["MIL1553_A"],
+          pin4: ["SPACEWIRE_DOUT_P"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .ARINC429_TX1" to=".R1 .pin1" />
+      <trace from=".U1 .MIL1553_A" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ARINC429_TX1")
+  expect(netlist).toContain("  - U1 ARINC429_TX1")
+  expect(netlist).toContain("NET: U1_MIL1553_A")
+  expect(netlist).toContain("  - U1 MIL1553_A")
+  expect(netlist).toContain("- pin1(ARINC429_TX1): NETS(U1_ARINC429_TX1)")
+  expect(netlist).toContain("- pin3(MIL1553_A): NETS(U1_MIL1553_A)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for ARINC 429, MIL-STD-1553, and SpaceWire aliases before the generic digit fallback
- preserve labels such as `ARINC429_TX1`, `ARINC429_RX1`, `MIL1553_A`, and `SPACEWIRE_DOUT_P` in generated readable netlists
- add regression coverage proving avionics aliases drive NET names and readable pin entries

## Verification
- `bun test tests/avionics-bus-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/avionics-bus-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; diff reviewed locally.

/claim #4