### PR TITLE
Score isolated gate driver pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,32 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isolatedGateDriverSignalPatterns = [
+  /^(GATE|GATE_DRV|GATE_DRIVE|GATE_HI|GATE_LO|HIGH_GATE|LOW_GATE)$/,
+  /^GATE\d+(_[HL])?$/,
+  /^(GH|GL|HO|LO|HIN|DESAT|DESAT_N|FLT|FLT_N|FAULT_N)$/,
+  /^(GH|GL|HO|LO|HIN|DESAT|FLT)\d+(_N)?$/,
+  /^ISO[_-]?(IN|OUT|EN|FAULT|FLT)\d*(_N)?$/,
+  /^OPTO[_-]?(IN|OUT)\d*$/,
+]
+
+const scoreIsolatedGateDriverPhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    isolatedGateDriverSignalPatterns.some((pattern) =>
+      pattern.test(normalizedPhrase),
+    )
+  ) {
+    return 1.18
+  }
+}
+
 export const scorePhrase = (phrase: string) => {
+  const isolatedGateDriverScore = scoreIsolatedGateDriverPhrase(phrase)
+  if (isolatedGateDriverScore !== undefined) {
+    return isolatedGateDriverScore
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/gate-driver-pin-labels.test.tsx
+++ b/tests/gate-driver-pin-labels.test.tsx
@@ -1,0 +1,81 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves isolated gate-driver and protection pin labels", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "UCC21520",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "10Ω",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      ftype: "simple_capacitor",
+      name: "C1",
+      display_capacitance: "100nF",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "GATE1_H"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["pin15", "DESAT1", "ISO_OUT1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_GATE1_H")
+  expect(netlist).toContain("  - U1 pin14 (GATE1_H)")
+  expect(netlist).toContain("NET: U1_DESAT1")
+  expect(netlist).toContain("  - U1 pin15 (DESAT1,ISO_OUT1)")
+  expect(netlist).toContain("- pin15(DESAT1, ISO_OUT1): NETS(U1_DESAT1)")
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Summary
- Add focused scoring for isolated gate-driver/protection aliases such as `GATE1_H`, `DESAT1`, `HO`, `LO`, `GH`, `GL`, and `ISO_OUT1` before the generic numeric fallback.
- Preserve useful gate-drive and protection signal names in generated `NET:` names and readable pin entries instead of falling back to generic numbered pins or low-information labels.
- Add regression coverage for gate-driver and desaturation labels on generic chip pins.

## Verification
- `timeout 120s bun test ./tests/gate-driver-pin-labels.test.tsx`
- `git diff --check`

Local type/build/format checks were attempted, but this workspace is currently hitting dependency I/O timeouts unrelated to the patch; GitHub CI should provide the authoritative full check run.

## Scope note
This is intentionally separate from existing motor/fan, relay/solenoid, haptic, power-management, reset/control, semiconductor component metadata, and fieldbus PR scopes.

Transparency: AI-assisted with Codex; I reviewed the diff and ran focused local verification before submission.