### PR TITLE
Score marine NMEA pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,9 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  if (phrase.match(/NMEA(?:0183|2000)?|SEATALK/i)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/nmea-pin-labels.test.tsx
+++ b/tests/nmea-pin-labels.test.tsx
@@ -1,0 +1,32 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves marine NMEA pin labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{
+          pin1: ["pin14", "NMEA0183_TX1"],
+          pin2: ["pin15", "NMEA2000_CANH"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .pin14" to=".R1 .pin1" />
+      <trace from=".U1 .pin15" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_NMEA0183_TX1")
+  expect(netlist).toContain("  - U1 pin14 (NMEA0183_TX1)")
+  expect(netlist).toContain("NET: U1_NMEA2000_CANH")
+  expect(netlist).toContain("  - U1 pin15 (NMEA2000_CANH)")
+  expect(netlist).not.toContain("NET: R1_pos")
+  expect(netlist).not.toContain("NET: C1_pos")
+})


### PR DESCRIPTION
## Summary
- score NMEA 0183, NMEA 2000, and SeaTalk-style pin hints before the generic digit fallback
- add regression coverage showing NMEA labels are used for generated net names and readable pin entries instead of passive endpoint labels

## Verification
- npx --yes bun@latest test tests/nmea-pin-labels.test.tsx
- npx --yes bun@latest test
- npx --yes bun@latest x biome check lib/scorePhrase.ts tests/nmea-pin-labels.test.tsx
- npx --yes bun@latest run build
- git diff --check

/claim #4