### PR TITLE
Score barometric sensor pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const scoreBarometricSensorPhrase = (phrase: string) => {
+  if (
+    /^(BARO|BMP|BME|LPS|ALT)(?:_|$)/.test(phrase) ||
+    /(?:^|_)(PRESSURE|ALTIMETER)(?:_|$)/.test(phrase)
+  ) {
+    return 1.15
+  }
+}
+
 export const scorePhrase = (phrase: string) => {
+  const barometricSensorScore = scoreBarometricSensorPhrase(phrase)
+  if (barometricSensorScore) {
+    return barometricSensorScore
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/barometric-sensor-pin-labels.test.tsx
+++ b/tests/barometric-sensor-pin-labels.test.tsx
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves barometric sensor aliases in net entries", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn24"
+        manufacturerPartNumber="BMP388"
+        pinLabels={{
+          pin14: ["pin14", "BARO_INT1"],
+          pin15: ["pin15", "BMP_SDO1"],
+          pin16: ["pin16", "LPS_DRDY1"],
+        }}
+      />
+      <chip
+        name="J1"
+        footprint="pinrow3"
+        manufacturerPartNumber="CONN"
+        pinLabels={{
+          pin1: ["IRQ"],
+          pin2: ["SDO"],
+          pin3: ["DRDY"],
+        }}
+      />
+
+      <trace from=".U1 .pin14" to=".J1 .pin1" />
+      <trace from=".U1 .pin15" to=".J1 .pin2" />
+      <trace from=".U1 .pin16" to=".J1 .pin3" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_BARO_INT1")
+  expect(netlist).toContain("  - U1 pin14 (BARO_INT1)")
+  expect(netlist).toContain("NET: U1_BMP_SDO1")
+  expect(netlist).toContain("  - U1 pin15 (BMP_SDO1)")
+  expect(netlist).toContain("NET: U1_LPS_DRDY1")
+  expect(netlist).toContain("  - U1 pin16 (LPS_DRDY1)")
+})


### PR DESCRIPTION
/claim #4

## What changed

- Adds focused scoring for barometric pressure and altimeter sensor aliases before the generic digit fallback.
- Preserves aliases such as `BARO_INT1`, `BMP_SDO1`, and `LPS_DRDY1` in generated NET names and readable pin entries.
- Adds regression coverage using raw rendered Circuit JSON so the behavior is covered in the public test suite.

## Why this is non-overlapping

Before starting, I checked recent attempts on #4. I did not find an existing barometric pressure / BMP / BME / LPS / altimeter alias slice. This is separate from temperature, humidity, IMU, microphone, touch, switch, avionics, marine bus, wireless charging, level translator, and generic interrupt work.

## Verification

- `bun test tests/barometric-sensor-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/barometric-sensor-pin-labels.test.tsx`
- `bun x tsc --noEmit`
- `bun run build`
- `bun test`
- `git diff --check`