### PR TITLE
Score radar frontend pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -37,7 +37,7 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 
 const isRadarFrontendAlias = (phrase: string) => {
   const normalizedPhrase = phrase.toUpperCase()
-  return /^(RADAR|FMCW|DOPPLER|IF|MIXER|LNA|PA|VCO|LO)_(TX|RX|IF|OUT|IN|IFOUT|IFIN|LO|RF|EN|TRIG|SYNC|CLK|DATA|I|Q)(?:[_-]?[PN])?\d*$/.test(
+  return /^(RADAR|FMCW|DOPPLER|IF|MIXER|LNA|PA|VCO|LO)_(TX|RX|IF|OUT|IN|IFOUT|IFIN|LO|RF|EN|TRIG|SYNC|CLK|DATA|I|Q)(?:[_-]?[PN])?\d*(?:[_-]?[PN])?$/.test(
     normalizedPhrase,
   )
 }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isRadarFrontendAlias = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  return /^(RADAR|FMCW|DOPPLER|IF|MIXER|LNA|PA|VCO|LO)_(TX|RX|IF|OUT|IN|IFOUT|IFIN|LO|RF|EN|TRIG|SYNC|CLK|DATA|I|Q)(?:[_-]?[PN])?\d*$/.test(
+    normalizedPhrase,
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isRadarFrontendAlias(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/radar-frontend-pin-labels.test.tsx
+++ b/tests/radar-frontend-pin-labels.test.tsx
@@ -1,0 +1,32 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves radar frontend aliases in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="RADAR-FRONTEND"
+        pinLabels={{
+          pin14: ["pin14", "RADAR_TX1"],
+          pin15: ["pin15", "IF_OUT1"],
+          pin16: ["pin16", "MIXER_LO1"],
+        }}
+      />
+      <resistor name="R1" resistance="50" footprint="0402" />
+      <capacitor name="C1" capacitance="100nF" footprint="0402" />
+      <trace from=".U1 .RADAR_TX1" to=".R1 .pin1" />
+      <trace from=".U1 .IF_OUT1" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_RADAR_TX1")
+  expect(netlist).toContain("  - U1 pin14 (RADAR_TX1)")
+  expect(netlist).toContain("NET: U1_IF_OUT1")
+  expect(netlist).toContain("  - U1 pin15 (IF_OUT1)")
+  expect(netlist).toContain("- pin16(MIXER_LO1): NOT_CONNECTED")
+})

--- a/tests/radar-frontend-pin-labels.test.tsx
+++ b/tests/radar-frontend-pin-labels.test.tsx
@@ -13,12 +13,16 @@ it("preserves radar frontend aliases in readable netlists", () => {
           pin14: ["pin14", "RADAR_TX1"],
           pin15: ["pin15", "IF_OUT1"],
           pin16: ["pin16", "MIXER_LO1"],
+          pin17: ["pin17", "RADAR_TX1_P"],
+          pin18: ["pin18", "RADAR_TX1N"],
         }}
       />
       <resistor name="R1" resistance="50" footprint="0402" />
       <capacitor name="C1" capacitance="100nF" footprint="0402" />
       <trace from=".U1 .RADAR_TX1" to=".R1 .pin1" />
       <trace from=".U1 .IF_OUT1" to=".C1 .pin1" />
+      <trace from=".U1 .RADAR_TX1_P" to=".R1 .pin2" />
+      <trace from=".U1 .RADAR_TX1N" to=".C1 .pin2" />
     </board>,
   )
 
@@ -28,5 +32,9 @@ it("preserves radar frontend aliases in readable netlists", () => {
   expect(netlist).toContain("  - U1 pin14 (RADAR_TX1)")
   expect(netlist).toContain("NET: U1_IF_OUT1")
   expect(netlist).toContain("  - U1 pin15 (IF_OUT1)")
+  expect(netlist).toContain("NET: U1_RADAR_TX1_P")
+  expect(netlist).toContain("  - U1 pin17 (RADAR_TX1_P)")
+  expect(netlist).toContain("NET: U1_RADAR_TX1N")
+  expect(netlist).toContain("  - U1 pin18 (RADAR_TX1N)")
   expect(netlist).toContain("- pin16(MIXER_LO1): NOT_CONNECTED")
 })


### PR DESCRIPTION
## Summary
- Add focused scoring for radar front-end aliases such as `RADAR_TX1`, `IF_OUT1`, and `MIXER_LO1` before the generic digit fallback.
- Add regression coverage showing generated NET names and readable pin entries preserve those aliases.

## Verification
- `npx --yes bun@latest test tests/radar-frontend-pin-labels.test.tsx`
- `npx --yes bun@latest test`
- `npx --yes bun@latest x biome check lib/scorePhrase.ts tests/radar-frontend-pin-labels.test.tsx`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest run build`
- `git diff --check`

/claim #4