### PR TITLE
Score model railroad control pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -2,8 +2,12 @@
  * Ranks how good a word is for a net name. Usually uncommon words are better.
  * If a word isn't on this list, it's given a score of 1
  *
- * A phrase is scored by finding the highest scoring word that it contains, so
- * for example GPIO1 would score 1.1, but GPIO1_RX would score 1.15
+ * Model railroad control aliases are scored first because their digits are part
+ * of the domain-specific name. Other phrases with digits are treated as generic
+ * pin labels and score 0.5 before matching against the word list.
+ *
+ * Phrases without digits are scored by finding the highest scoring word that
+ * they contain, so for example GPIO_RX would score 1.15
  *
  * These unique port names are usually the best indicator of what the net is for
  */
@@ -35,7 +39,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const modelRailroadControlAliasRegex =
+  /^(DCC|DCC_RAIL|RAILCOM|LOCONET)(?:[_-]?[A-Z0-9]+)*$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (modelRailroadControlAliasRegex.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/model-railroad-pin-labels.test.ts
+++ b/tests/model-railroad-pin-labels.test.ts
@@ -1,0 +1,84 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("keeps model railroad control aliases on generic chip pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "DCC-DECODER",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["DCC_RAIL1", "pin14", "14"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["LOCONET_TX1", "pin15", "15"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "pin1", "1"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["cathode", "neg", "pin2", "2"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      source_component_id: "source_component_1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_DCC_RAIL1")
+  expect(readableNetlist).toContain("  - U1 pin14 (DCC_RAIL1)")
+  expect(readableNetlist).toContain("- pin14(DCC_RAIL1): NETS(U1_DCC_RAIL1)")
+
+  expect(readableNetlist).toContain("NET: U1_LOCONET_TX1")
+  expect(readableNetlist).toContain("  - U1 pin15 (LOCONET_TX1)")
+  expect(readableNetlist).toContain(
+    "- pin15(LOCONET_TX1): NETS(U1_LOCONET_TX1)",
+  )
+})


### PR DESCRIPTION
## Summary
- add focused scoring for model railroad control aliases such as `DCC_RAIL1` and `LOCONET_TX1`
- add raw Circuit JSON regression coverage so those aliases drive generated NET names and readable pin entries instead of falling behind `pos` / `pin14`

## Verification
- `bun test tests/model-railroad-pin-labels.test.ts`
- `bun x biome check lib/scorePhrase.ts tests/model-railroad-pin-labels.test.ts`
- `bun x tsc --noEmit`
- `bun test`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.

/claim #4