### PR TITLE
Fix readable labels for generic chip pins

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,9 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${[component.display_resistance, footprint].filter(Boolean).join(" ")})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${[component.display_capacitance, footprint].filter(Boolean).join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,28 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinLabel = (label: string, pinNumber?: number) => {
+  const normalized = label.toLowerCase()
+  if (pinNumber !== undefined && normalized === `pin${pinNumber}`) return true
+  return /^pin\d+$/.test(normalized)
+}
+
+const isLowInformationPinHint = (hint: string, pinNumber?: number) => {
+  const normalized = hint.toLowerCase()
+  if (pinNumber !== undefined && normalized === String(pinNumber)) return true
+  if (isGenericPinLabel(hint, pinNumber)) return true
+  return [
+    "anode",
+    "cathode",
+    "pos",
+    "positive",
+    "neg",
+    "negative",
+    "left",
+    "right",
+  ].includes(normalized)
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -35,6 +57,7 @@ export const getReadableNameForPin = ({
 
   // Format pin description
   const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinNameIsGeneric = isGenericPinLabel(mainPinName, port.pin_number)
 
   const additionalPinLabels: string[] = []
 
@@ -47,7 +70,11 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (
+      score > 1 ||
+      (mainPinNameIsGeneric &&
+        !isLowInformationPinHint(port_hint, port.pin_number))
+    ) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/test4-readable-pin-labels.test.ts
+++ b/tests/test4-readable-pin-labels.test.ts
@@ -1,0 +1,82 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("keeps descriptive labels for generic chip pins and omits undefined footprints", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "GPIO10", "SCL"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["pin15", "GPIO11", "SDA"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_2",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "anode", "pos", "left"],
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_1",
+      name: "I2C_SCL",
+      member_source_group_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: [
+        "source_port_1",
+        "source_port_2",
+        "source_port_3",
+      ],
+      connected_source_net_ids: ["source_net_1"],
+    },
+  ]
+
+  expect(convertCircuitJsonToReadableNetlist(circuitJson)).toBe(`COMPONENTS:
+ - U1: RP2040
+ - R1: 1kΩ resistor
+
+NET: I2C_SCL
+  - U1 pin14 (GPIO10,SCL)
+  - U1 pin15 (GPIO11,SDA)
+  - R1 pin1
+
+
+COMPONENT_PINS:
+U1 (RP2040)
+- pin14(GPIO10, SCL): NETS(I2C_SCL)
+- pin15(GPIO11, SDA): NETS(I2C_SCL)
+
+R1 (1kΩ)
+- pin1(anode, pos, left): NETS(I2C_SCL)
+`)
+})


### PR DESCRIPTION
## Summary
- include descriptive port hints like GPIO10/SCL when a source port is only named with a generic pin label such as pin14
- avoid rendering undefined in passive component pin headers when no footprint is present
- add a focused regression test for generic chip pin aliases and missing passive footprints

Fixes #4.
/claim #4

## Tests
- bun test tests/test4-readable-pin-labels.test.ts
- bun run format:check
- bun run build

Note: the full local `bun test` run still fails before this change's tests because the existing JSX fixture tests hit a dependency export mismatch: `distanceBetweenCircleAndCircle` is not exported by the installed `@tscircuit/circuit-json-util`.