### PR TITLE
Score automotive sensor interface pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -15,6 +15,8 @@ const wordQualityScore = {
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
+  SENT: 1.15,
+  PSI5: 1.15,
   GPIO: 1.1,
   cathode: 0.5,
   anode: 0.5,
@@ -35,7 +37,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) => ["SENT", "PSI5"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/automotive-sensor-interface-pin-labels.test.tsx
+++ b/tests/automotive-sensor-interface-pin-labels.test.tsx
@@ -1,0 +1,45 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores SENT and PSI5 automotive sensor aliases above passive labels", () => {
+  expect(scorePhrase("SENT_OUT1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("PSI5_DATA1")).toBeGreaterThan(scorePhrase("pos"))
+})
+
+it("preserves SENT and PSI5 pin labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="SENSOR-HUB"
+        pinLabels={{
+          pin1: ["SENT_OUT1"],
+          pin2: ["PSI5_DATA1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .SENT_OUT1" to=".R1 > .pin1" />
+      <trace from=".U1 .PSI5_DATA1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_SENT_OUT1")
+  expect(netlist).toContain("  - U1 SENT_OUT1")
+  expect(netlist).toContain("- pin1(SENT_OUT1): NETS(U1_SENT_OUT1)")
+  expect(netlist).toContain("NET: U1_PSI5_DATA1")
+  expect(netlist).toContain("  - U1 PSI5_DATA1")
+  expect(netlist).toContain("- pin2(PSI5_DATA1): NETS(U1_PSI5_DATA1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for SENT and PSI5 automotive sensor-interface pin aliases before the generic digit fallback
- add regression coverage showing `SENT_OUT1` and `PSI5_DATA1` beat passive labels and appear in generated NET names / component pins

## Verification
- `npx.cmd --yes bun@latest test tests/automotive-sensor-interface-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/automotive-sensor-interface-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and kept the scope to SENT/PSI5 sensor-interface labels.