### PR TITLE
Score SoundWire audio pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,8 +13,14 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  SOUNDWIRE: 1.2,
+  SLIMBUS: 1.2,
+  MCASP: 1.2,
   RX: 1.15,
   TX: 1.15,
+  SAI: 1.15,
+  TDM: 1.15,
+  AC97: 1.15,
   GPIO: 1.1,
   cathode: 0.5,
   anode: 0.5,
@@ -35,7 +41,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) =>
+    ["SOUNDWIRE", "SLIMBUS", "MCASP", "SAI", "TDM", "AC97"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/soundwire-audio-pin-labels.test.tsx
+++ b/tests/soundwire-audio-pin-labels.test.tsx
@@ -1,0 +1,40 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores SoundWire and SLIMbus audio aliases above passive labels", () => {
+  expect(scorePhrase("SOUNDWIRE_SD0")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("SLIMBUS_DATA1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("TDM_DOUT1")).toBeGreaterThan(scorePhrase("pos"))
+})
+
+it("preserves SoundWire and SLIMbus labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="AUDIO-CODEC"
+        pinLabels={{
+          pin1: ["SOUNDWIRE_SD0"],
+          pin2: ["SLIMBUS_DATA1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .SOUNDWIRE_SD0" to=".R1 > .pin1" />
+      <trace from=".U1 .SLIMBUS_DATA1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_SOUNDWIRE_SD0")
+  expect(netlist).toContain("  - U1 SOUNDWIRE_SD0")
+  expect(netlist).toContain("- pin1(SOUNDWIRE_SD0): NETS(U1_SOUNDWIRE_SD0)")
+  expect(netlist).toContain("NET: U1_SLIMBUS_DATA1")
+  expect(netlist).toContain("  - U1 SLIMBUS_DATA1")
+  expect(netlist).toContain("- pin2(SLIMBUS_DATA1): NETS(U1_SLIMBUS_DATA1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for SoundWire, SLIMbus, SAI, TDM, McASP, and AC97 audio-interface aliases before the generic digit fallback
- add regression coverage showing `SOUNDWIRE_SD0`, `SLIMBUS_DATA1`, and `TDM_DOUT1` beat passive labels and appear in generated NET names / component pins

## Verification
- `npx.cmd --yes bun@latest test tests/soundwire-audio-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/soundwire-audio-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

/claim #4