### PR TITLE
Score HDBaseT pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,9 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  HDBT: 1.2,
+  HDBaseT: 1.2,
+  VALENS: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +38,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) => ["HDBT", "HDBaseT", "VALENS"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/hdbaset-pin-labels.test.tsx
+++ b/tests/hdbaset-pin-labels.test.tsx
@@ -1,0 +1,40 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores HDBaseT transport aliases above passive labels", () => {
+  expect(scorePhrase("HDBT_TXP0")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("HDBT_RXN0")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("VALENS_LINK1")).toBeGreaterThan(scorePhrase("pos"))
+})
+
+it("preserves HDBaseT and Valens labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn64"
+        manufacturerPartNumber="HDBT-TX"
+        pinLabels={{
+          pin1: ["HDBT_TXP0"],
+          pin2: ["VALENS_LINK1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .HDBT_TXP0" to=".R1 > .pin1" />
+      <trace from=".U1 .VALENS_LINK1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_HDBT_TXP0")
+  expect(netlist).toContain("  - U1 HDBT_TXP0")
+  expect(netlist).toContain("- pin1(HDBT_TXP0): NETS(U1_HDBT_TXP0)")
+  expect(netlist).toContain("NET: U1_VALENS_LINK1")
+  expect(netlist).toContain("  - U1 VALENS_LINK1")
+  expect(netlist).toContain("- pin2(VALENS_LINK1): NETS(U1_VALENS_LINK1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for HDBaseT/HDBT and Valens AV transport aliases before the generic digit fallback
- add regression coverage showing `HDBT_TXP0`, `HDBT_RXN0`, and `VALENS_LINK1` beat passive labels and appear in generated NET names / component pins

## Verification
- `npx.cmd --yes bun@latest test tests/hdbaset-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/hdbaset-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

/claim #4