### PR TITLE
Score absolute encoder pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const absoluteEncoderAliasPattern =
+  /^(?:BISS(?:_|[0-9])|ENDAT(?:_|[0-9])|HIPERFACE(?:_|[0-9])|SSI(?:_|[0-9])|ABS_ENCODER(?:_|[0-9]))/
+
 export const scorePhrase = (phrase: string) => {
+  if (absoluteEncoderAliasPattern.test(phrase.toUpperCase())) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/absolute-encoder-pin-labels.test.ts
+++ b/tests/absolute-encoder-pin-labels.test.ts
@@ -1,0 +1,101 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves absolute encoder aliases in readable netlists", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "sc_u1",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "ABS-ENC",
+    },
+    {
+      type: "source_component",
+      source_component_id: "sc_r1",
+      name: "R1",
+      ftype: "simple_resistor",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_component",
+      source_component_id: "sc_r2",
+      name: "R2",
+      ftype: "simple_resistor",
+      display_resistance: "10k",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_u1",
+      source_component_id: "sc_u1",
+      footprinter_string: "qfn16",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_r1",
+      source_component_id: "sc_r1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_r2",
+      source_component_id: "sc_r2",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_14",
+      source_component_id: "sc_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["BISS_MA1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_15",
+      source_component_id: "sc_u1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["ENDAT2_DATA"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "sc_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r2_1",
+      source_component_id: "sc_r2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_biss",
+      connected_source_port_ids: ["source_port_u1_14", "source_port_r1_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_endat",
+      connected_source_port_ids: ["source_port_u1_15", "source_port_r2_1"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_BISS_MA1")
+  expect(netlist).toContain("  - U1 pin14 (BISS_MA1)")
+  expect(netlist).toContain("- pin14(BISS_MA1): NETS(U1_BISS_MA1)")
+  expect(netlist).toContain("NET: U1_ENDAT2_DATA")
+  expect(netlist).toContain("  - U1 pin15 (ENDAT2_DATA)")
+  expect(netlist).toContain("- pin15(ENDAT2_DATA): NETS(U1_ENDAT2_DATA)")
+  expect(netlist).not.toContain("NET: R1_pos")
+  expect(netlist).not.toContain("NET: R2_pos")
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Summary
- Add focused scoring for absolute encoder aliases before the generic digit fallback.
- Preserve `BISS_MA1` and `ENDAT2_DATA` in generated `NET:` names and readable pin entries instead of falling back to passive labels like `pos` or physical labels like `pin14`.
- Add raw Circuit JSON regression coverage for the BiSS and EnDat cases.

## Verification
- `npx --yes bun@latest test tests/absolute-encoder-pin-labels.test.ts`
- `npx --yes bun@latest x biome check lib/scorePhrase.ts tests/absolute-encoder-pin-labels.test.ts`
- `npx --yes bun@latest test`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.
