### PR TITLE
Score boundary scan pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,8 +13,13 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  BSCAN: 1.2,
+  BIST: 1.2,
+  SCAN_CHAIN: 1.2,
   RX: 1.15,
   TX: 1.15,
+  ICT: 1.15,
+  TESTMODE: 1.15,
   GPIO: 1.1,
   cathode: 0.5,
   anode: 0.5,
@@ -35,7 +40,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) => ["BSCAN", "BIST", "SCAN_CHAIN", "ICT", "TESTMODE"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/boundary-scan-pin-labels.test.tsx
+++ b/tests/boundary-scan-pin-labels.test.tsx
@@ -1,0 +1,40 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores boundary-scan aliases above passive labels", () => {
+  expect(scorePhrase("BSCAN_TDI1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("SCAN_CHAIN1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("BIST_DONE1")).toBeGreaterThan(scorePhrase("pos"))
+})
+
+it("preserves boundary-scan and BIST labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="bga100"
+        manufacturerPartNumber="TEST-ASIC"
+        pinLabels={{
+          pin1: ["BSCAN_TDI1"],
+          pin2: ["BIST_DONE1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .BSCAN_TDI1" to=".R1 > .pin1" />
+      <trace from=".U1 .BIST_DONE1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_BSCAN_TDI1")
+  expect(netlist).toContain("  - U1 BSCAN_TDI1")
+  expect(netlist).toContain("- pin1(BSCAN_TDI1): NETS(U1_BSCAN_TDI1)")
+  expect(netlist).toContain("NET: U1_BIST_DONE1")
+  expect(netlist).toContain("  - U1 BIST_DONE1")
+  expect(netlist).toContain("- pin2(BIST_DONE1): NETS(U1_BIST_DONE1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for boundary-scan, BSCAN, scan-chain, BIST, ICT, and test-mode aliases before the generic digit fallback
- add regression coverage showing `BSCAN_TDI1`, `SCAN_CHAIN1`, and `BIST_DONE1` beat passive labels and appear in generated NET names / component pins

## Verification
- `npx.cmd --yes bun@latest test tests/boundary-scan-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/boundary-scan-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

/claim #4