### PR TITLE
Score digital isolator pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,8 +13,12 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  ADUM: 1.2,
+  SI86: 1.2,
+  ISOLATOR: 1.2,
   RX: 1.15,
   TX: 1.15,
+  ISO_CH: 1.15,
   GPIO: 1.1,
   cathode: 0.5,
   anode: 0.5,
@@ -35,7 +39,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) => ["ADUM", "SI86", "ISOLATOR", "ISO_CH"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/digital-isolator-pin-labels.test.tsx
+++ b/tests/digital-isolator-pin-labels.test.tsx
@@ -1,0 +1,40 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores digital-isolator aliases above passive labels", () => {
+  expect(scorePhrase("ADUM_IN1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("ADUM_OUT1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("SI86_CH1")).toBeGreaterThan(scorePhrase("pos"))
+})
+
+it("preserves digital-isolator labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="ADUM1401"
+        pinLabels={{
+          pin1: ["ADUM_IN1"],
+          pin2: ["SI86_CH1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .ADUM_IN1" to=".R1 > .pin1" />
+      <trace from=".U1 .SI86_CH1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ADUM_IN1")
+  expect(netlist).toContain("  - U1 ADUM_IN1")
+  expect(netlist).toContain("- pin1(ADUM_IN1): NETS(U1_ADUM_IN1)")
+  expect(netlist).toContain("NET: U1_SI86_CH1")
+  expect(netlist).toContain("  - U1 SI86_CH1")
+  expect(netlist).toContain("- pin2(SI86_CH1): NETS(U1_SI86_CH1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for ADuM, Si86xx, and generic digital-isolator channel aliases before the generic digit fallback
- add regression coverage showing `ADUM_IN1`, `ADUM_OUT1`, and `SI86_CH1` beat passive labels and appear in generated NET names / component pins

## Verification
- `npx.cmd --yes bun@latest test tests/digital-isolator-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/digital-isolator-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

/claim #4