### PR TITLE
Fix: Use full pin labels instead of pin numbers in readable netlist

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -157,7 +157,7 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.name || (port.pin_number !== undefined ? `pin${port.pin_number}` : "")
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -34,7 +34,7 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = port.name || (port.pin_number !== undefined ? `pin${port.pin_number}` : "")
 
   const additionalPinLabels: string[] = []
 

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(SCL, pin3): NETS(GND)
+    - GPIO2(SDA, pin4): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(UART_TX, pin6): NOT_CONNECTED
+    - GPIO5(UART_RX, pin7): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)


### PR DESCRIPTION
## Summary
Fixes issue #4 where pin labels were displaying shortened versions like `pin14` instead of full descriptive labels like `GPIO1`.

## Changes
- Modified `lib/convertCircuitJsonToReadableNetlist.ts` to prioritize `port.name` over `pin_number`
- Modified `lib/getReadableNameForPin.ts` with same logic
- Updated test snapshots to reflect correct behavior (e.g., `GND(pin1)` instead of `pin1(GND)`)

## Testing
All tests pass:
```
✓ test1 should render a basic circuit
✓ test2 chip
✓ chip without footprint doesn't output undefined
```

## Before
```
- pin1(GND): NETS(GND)
- pin2(AGND): NETS(GND)
```

## After
```
- GND(pin1): NETS(GND)
- AGND(pin2): NETS(GND)
```

Resolves #4

/claim