### PR TITLE
Score supercap pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,9 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  SUPERCAP: 1.2,
+  ULTRACAP: 1.2,
+  BACKUP_CAP: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +38,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) => ["SUPERCAP", "ULTRACAP", "BACKUP_CAP"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/supercap-pin-labels.test.tsx
+++ b/tests/supercap-pin-labels.test.tsx
@@ -1,0 +1,40 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores supercapacitor backup aliases above passive labels", () => {
+  expect(scorePhrase("SUPERCAP_P1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("ULTRACAP_N1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("BACKUP_CAP1")).toBeGreaterThan(scorePhrase("pos"))
+})
+
+it("preserves supercapacitor backup labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn24"
+        manufacturerPartNumber="BACKUP-PMU"
+        pinLabels={{
+          pin1: ["SUPERCAP_P1"],
+          pin2: ["ULTRACAP_N1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .SUPERCAP_P1" to=".R1 > .pin1" />
+      <trace from=".U1 .ULTRACAP_N1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_SUPERCAP_P1")
+  expect(netlist).toContain("  - U1 SUPERCAP_P1")
+  expect(netlist).toContain("- pin1(SUPERCAP_P1): NETS(U1_SUPERCAP_P1)")
+  expect(netlist).toContain("NET: U1_ULTRACAP_N1")
+  expect(netlist).toContain("  - U1 ULTRACAP_N1")
+  expect(netlist).toContain("- pin2(ULTRACAP_N1): NETS(U1_ULTRACAP_N1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for supercap, ultracap, and backup-capacitor aliases before the generic digit fallback
- add regression coverage showing `SUPERCAP_P1`, `ULTRACAP_N1`, and `BACKUP_CAP1` beat passive labels and appear in generated NET names / component pins

## Verification
- `npx.cmd --yes bun@latest test tests/supercap-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/supercap-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

/claim #4