### PR TITLE
Score retimer pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,12 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  RETIMER: 1.2,
+  REDRIVER: 1.2,
+  EQUALIZER: 1.2,
+  CDR: 1.2,
+  CTLE: 1.2,
+  DFE: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +41,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) =>
+    ["RETIMER", "REDRIVER", "EQUALIZER", "CDR", "CTLE", "DFE"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/retimer-pin-labels.test.tsx
+++ b/tests/retimer-pin-labels.test.tsx
@@ -1,0 +1,41 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores high-speed signal-conditioning aliases above passive labels", () => {
+  expect(scorePhrase("RETIMER_RX1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("REDRIVER_TX1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("CTLE_OUT1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("DFE_TAP1")).toBeGreaterThan(scorePhrase("pos"))
+})
+
+it("preserves high-speed signal-conditioning labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="HS-RETIMER"
+        pinLabels={{
+          pin1: ["RETIMER_RX1"],
+          pin2: ["REDRIVER_TX1"],
+        }}
+      />
+      <resistor resistance="100" footprint="0402" name="R1" />
+      <resistor resistance="100" footprint="0402" name="R2" />
+
+      <trace from=".U1 .RETIMER_RX1" to=".R1 > .pin1" />
+      <trace from=".U1 .REDRIVER_TX1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_RETIMER_RX1")
+  expect(netlist).toContain("  - U1 RETIMER_RX1")
+  expect(netlist).toContain("- pin1(RETIMER_RX1): NETS(U1_RETIMER_RX1)")
+  expect(netlist).toContain("NET: U1_REDRIVER_TX1")
+  expect(netlist).toContain("  - U1 REDRIVER_TX1")
+  expect(netlist).toContain("- pin2(REDRIVER_TX1): NETS(U1_REDRIVER_TX1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for retimer, redriver, equalizer, CDR, CTLE, and DFE aliases before the generic digit fallback.
- Add regression coverage proving `RETIMER_RX1` and `REDRIVER_TX1` are preserved in generated NET names and readable pin entries.

## Verification
- `npx.cmd --yes bun@latest test tests/retimer-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/retimer-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

/claim #4