### PR TITLE
Score CXL memory link pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const cxlMemoryLinkLabelPattern =
+  /^(CXL|CCIX|NVLINK)([_-]?(TX|RX)?[PN]?\d*|[_-]?(CLK|REFCLK|WAKE|RST|RESET|PERST|READY|LINK|PRSNT|PWR|VDD|VSS))$|^HBM([_-]?(CK|CKE|RESET|TEMP|ALERT|DBI|DQ|DQS|CA|WCK|RDQS)\d*)?$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (cxlMemoryLinkLabelPattern.test(phrase)) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/cxl-memory-link-pin-labels.test.ts
+++ b/tests/cxl-memory-link-pin-labels.test.ts
@@ -1,0 +1,78 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "../lib"
+
+it("preserves CXL and HBM memory-link pin labels", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_3",
+      name: "R2",
+      ftype: "simple_resistor",
+      resistance: 1000,
+      display_resistance: "1kohm",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      port_hints: ["CXL_TXP0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      port_hints: ["HBM_DQ0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_3",
+      pin_number: 1,
+      name: "pos",
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_4"],
+    },
+  ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_CXL_TXP0")
+  expect(readableNetlist).toContain("NET: U1_HBM_DQ0")
+  expect(readableNetlist).toContain("- U1 Pin14 (CXL_TXP0)")
+  expect(readableNetlist).toContain("- U1 Pin15 (HBM_DQ0)")
+  expect(readableNetlist).toContain("- pin14(CXL_TXP0): NETS(U1_CXL_TXP0)")
+  expect(readableNetlist).toContain("- pin15(HBM_DQ0): NETS(U1_HBM_DQ0)")
+})


### PR DESCRIPTION
## Summary

@algora-pbc /claim #4

Adds focused scoring for CXL / CCIX / NVLink / HBM memory-link aliases so generated readable net names and pin entries keep useful labels like `CXL_TXP0` and `HBM_DQ0` instead of falling back to generic numbered pins or passive endpoints.

- scores CXL, CCIX, NVLink lane/control labels before the generic digit fallback
- scores HBM data/clock/control labels before the generic digit fallback
- adds raw Circuit JSON regression coverage for generated `NET:` names, readable NET entries, and COMPONENT_PINS output

## Verification

- `npx --yes bun test tests/cxl-memory-link-pin-labels.test.ts`
- `npx --yes bun x biome check lib/scorePhrase.ts tests/cxl-memory-link-pin-labels.test.ts`
