### PR TITLE
Score clock buffer pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,10 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  CLKBUF: 1.2,
+  FANOUT: 1.2,
+  ZERO_DELAY: 1.2,
+  ZDB: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +39,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) => ["CLKBUF", "FANOUT", "ZERO_DELAY", "ZDB"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/clock-buffer-pin-labels.test.tsx
+++ b/tests/clock-buffer-pin-labels.test.tsx
@@ -1,0 +1,41 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores clock-buffer fanout aliases above passive labels", () => {
+  expect(scorePhrase("CLKBUF_OUT1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("FANOUT_CLK1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("ZERO_DELAY_OUT1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("ZDB_OUT1")).toBeGreaterThan(scorePhrase("pos"))
+})
+
+it("preserves clock-buffer fanout labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn24"
+        manufacturerPartNumber="CLK-FANOUT"
+        pinLabels={{
+          pin1: ["CLKBUF_OUT1"],
+          pin2: ["FANOUT_CLK1"],
+        }}
+      />
+      <resistor resistance="49.9" footprint="0402" name="R1" />
+      <resistor resistance="49.9" footprint="0402" name="R2" />
+
+      <trace from=".U1 .CLKBUF_OUT1" to=".R1 > .pin1" />
+      <trace from=".U1 .FANOUT_CLK1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_CLKBUF_OUT1")
+  expect(netlist).toContain("  - U1 CLKBUF_OUT1")
+  expect(netlist).toContain("- pin1(CLKBUF_OUT1): NETS(U1_CLKBUF_OUT1)")
+  expect(netlist).toContain("NET: U1_FANOUT_CLK1")
+  expect(netlist).toContain("  - U1 FANOUT_CLK1")
+  expect(netlist).toContain("- pin2(FANOUT_CLK1): NETS(U1_FANOUT_CLK1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for CLKBUF, FANOUT, ZERO_DELAY, and ZDB aliases before the generic digit fallback.
- Add regression coverage proving `CLKBUF_OUT1` and `FANOUT_CLK1` are preserved in generated NET names and readable pin entries.

## Verification
- `npx.cmd --yes bun@latest test tests/clock-buffer-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/clock-buffer-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

/claim #4