### PR TITLE
Score magnetic sensor pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,10 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  MAGNETOMETER: 1.2,
+  HALL: 1.2,
+  TMR: 1.2,
+  AMR: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +39,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) => ["MAGNETOMETER", "HALL", "TMR", "AMR"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/magnetic-sensor-pin-labels.test.tsx
+++ b/tests/magnetic-sensor-pin-labels.test.tsx
@@ -1,0 +1,41 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores solid-state magnetic sensor aliases above passive labels", () => {
+  expect(scorePhrase("HALL_OUT1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("TMR_SENSE1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("AMR_BRIDGE1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("MAGNETOMETER_DRDY1")).toBeGreaterThan(scorePhrase("pos"))
+})
+
+it("preserves solid-state magnetic sensor labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="HALL-SENSOR"
+        pinLabels={{
+          pin1: ["HALL_OUT1"],
+          pin2: ["TMR_SENSE1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .HALL_OUT1" to=".R1 > .pin1" />
+      <trace from=".U1 .TMR_SENSE1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_HALL_OUT1")
+  expect(netlist).toContain("  - U1 HALL_OUT1")
+  expect(netlist).toContain("- pin1(HALL_OUT1): NETS(U1_HALL_OUT1)")
+  expect(netlist).toContain("NET: U1_TMR_SENSE1")
+  expect(netlist).toContain("  - U1 TMR_SENSE1")
+  expect(netlist).toContain("- pin2(TMR_SENSE1): NETS(U1_TMR_SENSE1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for HALL, TMR, AMR, and MAGNETOMETER aliases before the generic digit fallback.
- Add regression coverage proving `HALL_OUT1` and `TMR_SENSE1` are preserved in generated NET names and readable pin entries.

## Verification
- `npx.cmd --yes bun@latest test tests/magnetic-sensor-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/magnetic-sensor-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

/claim #4