### PR TITLE
Score HyperBus pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,12 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  HYPERBUS: 1.2,
+  HYPERRAM: 1.2,
+  HYPERFLASH: 1.2,
+  OSPI: 1.2,
+  XSPI: 1.2,
+  RWDS: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +41,19 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) =>
+    ["HYPERBUS", "HYPERRAM", "HYPERFLASH", "OSPI", "XSPI", "RWDS"].includes(
+      word,
+    ),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/hyperbus-pin-labels.test.tsx
+++ b/tests/hyperbus-pin-labels.test.tsx
@@ -1,0 +1,42 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores HyperBus and xSPI aliases above passive labels", () => {
+  expect(scorePhrase("HYPERBUS_DQ0")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("HYPERRAM_RWDS1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("HYPERFLASH_CS1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("OSPI_DQS1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("XSPI_IO0")).toBeGreaterThan(scorePhrase("pos"))
+})
+
+it("preserves HyperBus and xSPI labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="bga64"
+        manufacturerPartNumber="HYPER-MEM"
+        pinLabels={{
+          pin1: ["HYPERBUS_DQ0"],
+          pin2: ["OSPI_DQS1"],
+        }}
+      />
+      <resistor resistance="33" footprint="0402" name="R1" />
+      <resistor resistance="33" footprint="0402" name="R2" />
+
+      <trace from=".U1 .HYPERBUS_DQ0" to=".R1 > .pin1" />
+      <trace from=".U1 .OSPI_DQS1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_HYPERBUS_DQ0")
+  expect(netlist).toContain("  - U1 HYPERBUS_DQ0")
+  expect(netlist).toContain("- pin1(HYPERBUS_DQ0): NETS(U1_HYPERBUS_DQ0)")
+  expect(netlist).toContain("NET: U1_OSPI_DQS1")
+  expect(netlist).toContain("  - U1 OSPI_DQS1")
+  expect(netlist).toContain("- pin2(OSPI_DQS1): NETS(U1_OSPI_DQS1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for HYPERBUS, HYPERRAM, HYPERFLASH, OSPI, XSPI, and RWDS aliases before the generic digit fallback.
- Add regression coverage proving `HYPERBUS_DQ0` and `OSPI_DQS1` are preserved in generated NET names and readable pin entries.

## Verification
- `npx.cmd --yes bun@latest test tests/hyperbus-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/hyperbus-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

/claim #4