### PR TITLE
Score backplane connector pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const upperPhrase = phrase.toUpperCase()
+  if (
+    upperPhrase.match(
+      /(^|[_-])(VPX|FMC|COMPACTPCI|CPCI|VME|PC[-_]?104)(?=[_+\-\d]|$)/,
+    )
+  ) {
+    return 1.1
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/backplane-pin-labels.test.tsx
+++ b/tests/backplane-pin-labels.test.tsx
@@ -1,0 +1,88 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores VPX and FMC backplane pin aliases", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn16"
+        manufacturerPartNumber="VPX_FMC_BACKPLANE"
+        pinLabels={{
+          pin1: ["VPX_LA01_P"],
+          pin2: ["FMC_LA01_N"],
+          pin3: ["CPCI_REQ1"],
+        }}
+      />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C2" />
+      <capacitor capacitance="1nF" footprint="0402" name="C3" />
+
+      <trace from=".U1 .VPX_LA01_P" to=".C1 .pin1" />
+      <trace from=".U1 .FMC_LA01_N" to=".C2 .pin1" />
+      <trace from=".U1 .CPCI_REQ1" to=".C3 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: VPX_FMC_BACKPLANE, qfn16
+     - C1: 1nF 0402 capacitor
+     - C2: 1nF 0402 capacitor
+     - C3: 1nF 0402 capacitor
+
+    NET: U1_VPX_LA01_P
+      - U1 VPX_LA01_P
+      - C1 pin1 (+)
+
+    NET: U1_FMC_LA01_N
+      - U1 FMC_LA01_N
+      - C2 pin1 (+)
+
+    NET: U1_CPCI_REQ1
+      - U1 CPCI_REQ1
+      - C3 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (VPX_FMC_BACKPLANE)
+    - pin1(VPX_LA01_P): NETS(U1_VPX_LA01_P)
+    - pin2(FMC_LA01_N): NETS(U1_FMC_LA01_N)
+    - pin3(CPCI_REQ1): NETS(U1_CPCI_REQ1)
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+    - pin9: NOT_CONNECTED
+    - pin10: NOT_CONNECTED
+    - pin11: NOT_CONNECTED
+    - pin12: NOT_CONNECTED
+    - pin13: NOT_CONNECTED
+    - pin14: NOT_CONNECTED
+    - pin15: NOT_CONNECTED
+    - pin16: NOT_CONNECTED
+
+    C1 (1nF 0402)
+    - pin1(pos, anode, left): NETS(U1_VPX_LA01_P)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+
+    C2 (1nF 0402)
+    - pin1(pos, anode, left): NETS(U1_FMC_LA01_N)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+
+    C3 (1nF 0402)
+    - pin1(pos, anode, left): NETS(U1_CPCI_REQ1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- prioritize VPX/FMC/CompactPCI/VME/PC104 backplane connector aliases before the generic digit fallback
- add a regression netlist snapshot for VPX/FMC/CPCI-style pin labels

## Verification
- bun test tests/backplane-pin-labels.test.tsx
- bun test
- bun x biome check lib/scorePhrase.ts tests/backplane-pin-labels.test.tsx
- bun run build
- git diff --check

/claim #4
