### PR TITLE
Score ultrasonic pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -8,6 +8,10 @@
  * These unique port names are usually the best indicator of what the net is for
  */
 const wordQualityScore = {
+  ULTRASONIC: 1.2,
+  SONAR: 1.2,
+  ECHO: 1.15,
+  TRIG: 1.15,
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
@@ -36,13 +40,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-ultrasonic-pin-labels.test.tsx
+++ b/tests/test4-ultrasonic-pin-labels.test.tsx
@@ -1,0 +1,68 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("prefers ultrasonic sensor aliases over passive labels", () => {
+  expect(scorePhrase("ULTRASONIC_ECHO1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("TRIG1")).toBeGreaterThan(scorePhrase("pos"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="HC-SR04"
+        pinLabels={{
+          pin1: ["VCC"],
+          pin2: ["TRIG1"],
+          pin3: ["ULTRASONIC_ECHO1"],
+          pin4: ["GND"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .TRIG1" to=".R1 > .pin1" />
+      <trace from=".U1 .ULTRASONIC_ECHO1" to=".R1 > .pin2" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: HC-SR04, soic8
+     - R1: 1kΩ 0402 resistor
+
+    NET: U1_TRIG1
+      - U1 TRIG1
+      - R1 pin1
+
+    NET: U1_ULTRASONIC_ECHO1
+      - U1 ULTRASONIC_ECHO1
+      - R1 pin2
+
+
+    COMPONENT_PINS:
+    U1 (HC-SR04)
+    - pin1(VCC): NOT_CONNECTED
+    - pin2(TRIG1): NETS(U1_TRIG1)
+    - pin3(ULTRASONIC_ECHO1): NETS(U1_ULTRASONIC_ECHO1)
+    - pin4(GND): NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_TRIG1)
+    - pin2(cathode, neg, right): NETS(U1_ULTRASONIC_ECHO1)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- score ultrasonic/sonar trigger and echo aliases before the generic digit fallback
- add a regression test showing `TRIG1` and `ULTRASONIC_ECHO1` win over passive labels in generated readable NET names

## Verification
- `npx --yes bun@latest test`
- `npx --yes bun@latest run build`
- `npx --yes @biomejs/biome@1.9.4 check .`

AI-assisted with Codex; I reviewed the diff and kept the change scoped.

/claim #4