### PR TITLE
Score stepper driver pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,9 +13,18 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  MICROSTEP: 1.2,
+  STEP: 1.2,
+  DIR: 1.2,
   RX: 1.15,
   TX: 1.15,
+  SLEEP: 1.15,
+  RESET: 1.15,
+  FAULT: 1.15,
+  ENABLE: 1.15,
   GPIO: 1.1,
+  MS: 1.1,
+  DECAY: 1.1,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -35,7 +44,27 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const semanticNumberedWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) =>
+    [
+      "MICROSTEP",
+      "STEP",
+      "DIR",
+      "SLEEP",
+      "RESET",
+      "FAULT",
+      "ENABLE",
+      "MS",
+      "DECAY",
+    ].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of semanticNumberedWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/stepper-driver-pin-labels.test.tsx
+++ b/tests/stepper-driver-pin-labels.test.tsx
@@ -1,0 +1,40 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves stepper driver control pin labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="TMC2209"
+        pinLabels={{
+          pin1: ["STEP1"],
+          pin2: ["DIR1"],
+          pin3: ["MS1"],
+          pin4: ["MS2"],
+          pin5: ["FAULT1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .STEP1" to=".R1 > .pin1" />
+      <trace from=".U1 .DIR1" to=".C1 > .pin1" />
+      <trace from=".U1 .MS1" to=".R1 > .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_STEP1")
+  expect(netlist).toContain("  - U1 STEP1")
+  expect(netlist).toContain("- pin1(STEP1): NETS(U1_STEP1)")
+  expect(netlist).toContain("NET: U1_DIR1")
+  expect(netlist).toContain("  - U1 DIR1")
+  expect(netlist).toContain("- pin2(DIR1): NETS(U1_DIR1)")
+  expect(netlist).toContain("NET: U1_MS1")
+  expect(netlist).toContain("  - U1 MS1")
+  expect(netlist).toContain("- pin3(MS1): NETS(U1_MS1)")
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Summary
- score stepper motor driver aliases such as `STEP1`, `DIR1`, `MS1`, `MS2`, `FAULT1`, `MICROSTEP`, `ENABLE`, and `DECAY` before the generic digit fallback
- preserve useful stepper-control labels in generated readable NET names and component pin listings instead of falling back to passive endpoint names such as `R1_pos`
- add focused regression coverage for stepper driver control pin labels

## Verification
- `npx --yes bun test tests/stepper-driver-pin-labels.test.tsx`
- `npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check lib/scorePhrase.ts tests/stepper-driver-pin-labels.test.tsx`
- `npx --yes bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before submission.
