### PR TITLE
Score semantic numbered pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/semantic-numbered-pin-labels.test.tsx
+++ b/tests/semantic-numbered-pin-labels.test.tsx
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("keeps semantic numbered chip labels ahead of generic physical pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="ATMEGA328P"
+        pinLabels={{
+          pin1: ["GPIO1", "SCL"],
+          pin2: ["GPIO2", "SDA"],
+          pin3: ["GPIO3"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .GPIO1" to=".R1 > .pin1" />
+      <trace from=".U1 .GPIO2" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_SCL")
+  expect(netlist).toContain("  - U1 GPIO1 (SCL)")
+  expect(netlist).toContain("- pin1(GPIO1, SCL): NETS(U1_SCL)")
+  expect(netlist).toContain("NET: U1_SDA")
+  expect(netlist).toContain("  - U1 GPIO2 (SDA)")
+  expect(netlist).toContain("- pin2(GPIO2, SDA): NETS(U1_SDA)")
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Summary
- score known semantic labels before the generic digit fallback so labels like `GPIO1` keep their documented quality score
- preserve numbered semantic labels such as `GPIO1/SCL` and `GPIO2/SDA` in generated readable NET names and component pin listings
- add focused regression coverage for numbered semantic chip labels

## Verification
- `npx --yes bun test tests/semantic-numbered-pin-labels.test.tsx`
- `npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check lib/scorePhrase.ts tests/semantic-numbered-pin-labels.test.tsx`
- `npx --yes bun run build`
- `git diff --check`

Transparency: AI-assisted with Codex; I reviewed the diff and local verification before submission.
