### PR TITLE
Score SATA connector pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const upperPhrase = phrase.toUpperCase()
+  if (
+    upperPhrase.match(
+      /(^|[_-])(SATA|TXP|TXN|RXP|RXN|P3V3|3V3|P5V|5V|P12V|12V|DEVSLP|PWDIS|PWR_?DIS)(?=[_+\-\d]|$)/,
+    )
+  ) {
+    return 1.1
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/sata-power-pin-labels.test.tsx
+++ b/tests/sata-power-pin-labels.test.tsx
@@ -1,0 +1,41 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores SATA data and power pin aliases", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="J1"
+        footprint="qfn16"
+        manufacturerPartNumber="SATA-22"
+        pinLabels={{
+          pin1: ["SATA_TXP1"],
+          pin2: ["SATA_RXN1"],
+          pin3: ["P3V3_1"],
+          pin4: ["P12V_1"],
+          pin5: ["DEVSLP"],
+        }}
+      />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C2" />
+      <capacitor capacitance="1nF" footprint="0402" name="C3" />
+      <capacitor capacitance="1nF" footprint="0402" name="C4" />
+      <capacitor capacitance="1nF" footprint="0402" name="C5" />
+
+      <trace from=".J1 .SATA_TXP1" to=".C1 .pin1" />
+      <trace from=".J1 .SATA_RXN1" to=".C2 .pin1" />
+      <trace from=".J1 .P3V3_1" to=".C3 .pin1" />
+      <trace from=".J1 .P12V_1" to=".C4 .pin1" />
+      <trace from=".J1 .DEVSLP" to=".C5 .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: J1_SATA_TXP1")
+  expect(readableNetlist).toContain("NET: J1_SATA_RXN1")
+  expect(readableNetlist).toContain("NET: J1_P3V3_1")
+  expect(readableNetlist).toContain("NET: J1_P12V_1")
+  expect(readableNetlist).toContain("NET: J1_DEVSLP")
+})


### PR DESCRIPTION
/attempt #4
/claim #4

## Summary
- score SATA data aliases such as `SATA_TXP1` and `SATA_RXN1` before the generic digit downgrade
- score SATA power/control aliases such as `P3V3_1`, `P12V_1`, `DEVSLP`, and power-disable names
- add a focused test proving readable net names use those SATA aliases

## Verification
- `bun test tests/sata-power-pin-labels.test.tsx`
- `bun test`
- `bun run format:check lib/scorePhrase.ts tests/sata-power-pin-labels.test.tsx`
- `git diff --check`

AI-assisted with OpenAI Codex.