### PR TITLE
fix: include useful numeric pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -3,6 +3,7 @@ import type { AnyCircuitElement } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
 const hasSignalNameWithNumber = (phrase: string) => /[A-Za-z_]+\d+/.test(phrase)
+const isGenericPinHint = (phrase: string) => /^pin\d+$/i.test(phrase)
 
 export const getReadableNameForPin = ({
   circuitJson,
@@ -48,6 +49,7 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName || port_hint === String(port.pin_number))
       continue
+    if (isGenericPinHint(port_hint)) continue
     if (scorePhrase(port_hint) > 1 || hasSignalNameWithNumber(port_hint)) {
       additionalPinLabels.push(port_hint)
     }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -1,11 +1,8 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
+
+const hasSignalNameWithNumber = (phrase: string) => /[A-Za-z_]+\d+/.test(phrase)
 
 export const getReadableNameForPin = ({
   circuitJson,
@@ -34,7 +31,11 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = port.name
+    ? port.name
+    : port.pin_number !== undefined
+      ? `Pin${port.pin_number}`
+      : "Pin"
 
   const additionalPinLabels: string[] = []
 
@@ -45,9 +46,9 @@ export const getReadableNameForPin = ({
   }
 
   for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (port_hint === mainPinName || port_hint === String(port.pin_number))
+      continue
+    if (scorePhrase(port_hint) > 1 || hasSignalNameWithNumber(port_hint)) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/test4-pin-labels-and-undefined.test.tsx
+++ b/tests/test4-pin-labels-and-undefined.test.tsx
@@ -1,0 +1,53 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses full pin labels when the primary pin name is generic", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "ATMEGA328P",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GPIO14", "SCL"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (GPIO14,SCL)")
+})
+
+it("does not print undefined for passive components without footprints", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <resistor resistance="1k" name="R1" />
+      <capacitor capacitance="1nF" name="C1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("R1 (1k")
+  expect(netlist).toContain("C1 (1nF")
+})

--- a/tests/test4-pin-labels-and-undefined.test.tsx
+++ b/tests/test4-pin-labels-and-undefined.test.tsx
@@ -25,7 +25,7 @@ it("uses full pin labels when the primary pin name is generic", () => {
       source_component_id: "source_component_0",
       name: "pin14",
       pin_number: 14,
-      port_hints: ["GPIO14", "SCL"],
+      port_hints: ["pin14", "GPIO14", "SCL"],
     },
   ] as AnyCircuitElement[]
 


### PR DESCRIPTION
## Summary
- include useful numeric pin labels like `GPIO14` when readable netlist pins otherwise show generic names such as `pin14`
- keep the existing low-signal hint filter for positional/passive hints like `left`, `right`, `anode`, and `pos`
- avoid printing `undefined` in passive component pin headers when a footprint is unavailable
- add regression coverage for pin labels and missing passive footprints

## Bounty
/claim #4

## Test plan
- `npx.cmd biome check lib\convertCircuitJsonToReadableNetlist.ts lib\getReadableNameForPin.ts tests\test4-pin-labels-and-undefined.test.tsx`
- `npx.cmd tsc --noEmit`

## Notes
- `bun test` could not be run locally because Bun is not installed in this Windows environment.
- `npm.cmd run build` reached DTS generation but the ESM build failed in esbuild with the local Windows path/access error `Cannot read directory "../../../../..": Access is denied.`