### PR TITLE
Score touch controller pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,12 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  CTP: 1.2,
+  TOUCH: 1.2,
+  TCH: 1.2,
+  RESET: 1.2,
+  WAKE: 1.2,
+  INT: 1.15,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +41,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const touchControllerWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) => ["CTP", "TOUCH", "TCH", "RESET", "WAKE", "INT"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of touchControllerWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-touch-controller-pin-labels.test.tsx
+++ b/tests/test4-touch-controller-pin-labels.test.tsx
@@ -1,0 +1,36 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores numbered capacitive touch controller pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn24"
+        manufacturerPartNumber="FT6236"
+        pinLabels={{
+          pin1: ["CTP_INT1"],
+          pin2: ["TOUCH_RESET1"],
+          pin3: ["TOUCH_WAKE1"],
+          pin4: ["VDD"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .CTP_INT1" to=".R1 > .pin1" />
+      <trace from=".U1 .TOUCH_RESET1" to=".R1 > .pin2" />
+      <trace from=".U1 .TOUCH_WAKE1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_CTP_INT1")
+  expect(netlist).toContain("NET: U1_TOUCH_RESET1")
+  expect(netlist).toContain("NET: U1_TOUCH_WAKE1")
+  expect(netlist).toContain("- pin1(CTP_INT1): NETS(U1_CTP_INT1)")
+  expect(netlist).toContain("- pin2(TOUCH_RESET1): NETS(U1_TOUCH_RESET1)")
+  expect(netlist).toContain("- pin3(TOUCH_WAKE1): NETS(U1_TOUCH_WAKE1)")
+})


### PR DESCRIPTION
## Summary
- score capacitive touch controller labels such as `CTP_INT1`, `TOUCH_RESET1`, and `TOUCH_WAKE1` before the generic digit fallback
- add regression coverage showing those numbered labels now drive readable net names and component pin output

## Bounty
/claim #4

## Verification
- `npx --yes bun test tests/test4-touch-controller-pin-labels.test.tsx`
- `npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check lib\scorePhrase.ts tests\test4-touch-controller-pin-labels.test.tsx`
- `npx --yes bun run build`
- `git diff --check`