### PR TITLE
Score QSPI memory pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,13 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  QSPI: 1.2,
+  PSRAM: 1.2,
+  FLASH: 1.2,
+  DQ: 1.2,
+  IO: 1.15,
+  HOLD: 1.15,
+  WP: 1.15,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +42,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const qspiMemoryWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) =>
+    ["QSPI", "PSRAM", "FLASH", "DQ", "IO", "HOLD", "WP"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of qspiMemoryWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-qspi-memory-pin-labels.test.tsx
+++ b/tests/test4-qspi-memory-pin-labels.test.tsx
@@ -1,0 +1,36 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores numbered QSPI flash and PSRAM pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="W25Q128"
+        pinLabels={{
+          pin1: ["QSPI_IO0"],
+          pin2: ["QSPI_IO1"],
+          pin3: ["FLASH_WP2"],
+          pin4: ["PSRAM_DQ3"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .QSPI_IO0" to=".R1 > .pin1" />
+      <trace from=".U1 .QSPI_IO1" to=".R1 > .pin2" />
+      <trace from=".U1 .PSRAM_DQ3" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_QSPI_IO0")
+  expect(netlist).toContain("NET: U1_QSPI_IO1")
+  expect(netlist).toContain("NET: U1_PSRAM_DQ3")
+  expect(netlist).toContain("- pin1(QSPI_IO0): NETS(U1_QSPI_IO0)")
+  expect(netlist).toContain("- pin2(QSPI_IO1): NETS(U1_QSPI_IO1)")
+  expect(netlist).toContain("- pin4(PSRAM_DQ3): NETS(U1_PSRAM_DQ3)")
+})


### PR DESCRIPTION
## Summary
- score QSPI flash and PSRAM labels such as `QSPI_IO0`, `QSPI_IO1`, and `PSRAM_DQ3` before the generic digit fallback
- add regression coverage showing these numbered external-memory labels are used for readable net names and component pin output

## Bounty
/claim #4

## Verification
- `npx --yes bun test tests/test4-qspi-memory-pin-labels.test.tsx`
- `npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check lib\scorePhrase.ts tests\test4-qspi-memory-pin-labels.test.tsx`
- `npx --yes bun run build`
- `git diff --check`