### PR TITLE
Score H-bridge motor pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,12 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  PWMA: 1.2,
+  PWMB: 1.2,
+  AIN: 1.2,
+  BIN: 1.2,
+  STBY: 1.2,
+  FAULT: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +41,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const hbridgeMotorWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) => ["PWMA", "PWMB", "AIN", "BIN", "STBY", "FAULT"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of hbridgeMotorWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-hbridge-motor-pin-labels.test.tsx
+++ b/tests/test4-hbridge-motor-pin-labels.test.tsx
@@ -1,0 +1,36 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores numbered H-bridge motor driver pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="TB6612FNG"
+        pinLabels={{
+          pin1: ["AIN1"],
+          pin2: ["BIN1"],
+          pin3: ["PWMA1"],
+          pin4: ["STBY1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .AIN1" to=".R1 > .pin1" />
+      <trace from=".U1 .BIN1" to=".R1 > .pin2" />
+      <trace from=".U1 .PWMA1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_AIN1")
+  expect(netlist).toContain("NET: U1_BIN1")
+  expect(netlist).toContain("NET: U1_PWMA1")
+  expect(netlist).toContain("- pin1(AIN1): NETS(U1_AIN1)")
+  expect(netlist).toContain("- pin2(BIN1): NETS(U1_BIN1)")
+  expect(netlist).toContain("- pin3(PWMA1): NETS(U1_PWMA1)")
+})


### PR DESCRIPTION
## Summary
- score H-bridge motor driver labels such as `AIN1`, `BIN1`, and `PWMA1` before the generic digit fallback
- add regression coverage showing those numbered motor-driver labels now drive readable net names and component pin output

## Bounty
/claim #4

## Verification
- `npx --yes bun test tests/test4-hbridge-motor-pin-labels.test.tsx`
- `npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check lib\scorePhrase.ts tests\test4-hbridge-motor-pin-labels.test.tsx`
- `npx --yes bun run build`
- `git diff --check`