### PR TITLE
Score Hall BLDC pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,10 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  HALL: 1.2,
+  BLDC: 1.2,
+  TACH: 1.2,
+  FG: 1.15,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +39,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const hallBldcWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) => ["HALL", "BLDC", "TACH", "FG"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of hallBldcWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-hall-bldc-pin-labels.test.tsx
+++ b/tests/test4-hall-bldc-pin-labels.test.tsx
@@ -1,0 +1,36 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores numbered Hall and BLDC feedback pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="DRV10983"
+        pinLabels={{
+          pin1: ["HALL_U1"],
+          pin2: ["HALL_V1"],
+          pin3: ["BLDC_TACH1"],
+          pin4: ["FG1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .HALL_U1" to=".R1 > .pin1" />
+      <trace from=".U1 .HALL_V1" to=".R1 > .pin2" />
+      <trace from=".U1 .BLDC_TACH1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_HALL_U1")
+  expect(netlist).toContain("NET: U1_HALL_V1")
+  expect(netlist).toContain("NET: U1_BLDC_TACH1")
+  expect(netlist).toContain("- pin1(HALL_U1): NETS(U1_HALL_U1)")
+  expect(netlist).toContain("- pin2(HALL_V1): NETS(U1_HALL_V1)")
+  expect(netlist).toContain("- pin3(BLDC_TACH1): NETS(U1_BLDC_TACH1)")
+})


### PR DESCRIPTION
## Summary
- score Hall and BLDC feedback labels such as `HALL_U1`, `HALL_V1`, and `BLDC_TACH1` before the generic digit fallback
- add regression coverage showing those numbered feedback labels now drive readable net names and component pin output

## Bounty
/claim #4

## Verification
- `npx --yes bun test tests/test4-hall-bldc-pin-labels.test.tsx`
- `npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check lib\scorePhrase.ts tests\test4-hall-bldc-pin-labels.test.tsx`
- `npx --yes bun run build`
- `git diff --check`