### PR TITLE
Score RTC backup pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,11 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  VBAT: 1.2,
+  RTC: 1.2,
+  CLKOUT: 1.2,
+  INTB: 1.15,
+  SQW: 1.15,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +40,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const rtcBackupWordQualityScoreEntries = wordQualityScoreEntries.filter(
+  ([word]) => ["VBAT", "RTC", "CLKOUT", "INTB", "SQW"].includes(word),
+)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of rtcBackupWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-rtc-backup-pin-labels.test.tsx
+++ b/tests/test4-rtc-backup-pin-labels.test.tsx
@@ -1,0 +1,36 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores numbered RTC backup-domain pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="DS3231M"
+        pinLabels={{
+          pin1: ["VBAT1"],
+          pin2: ["RTC_INTB1"],
+          pin3: ["CLKOUT1"],
+          pin4: ["SQW1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .VBAT1" to=".R1 > .pin1" />
+      <trace from=".U1 .RTC_INTB1" to=".R1 > .pin2" />
+      <trace from=".U1 .CLKOUT1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_VBAT1")
+  expect(netlist).toContain("NET: U1_RTC_INTB1")
+  expect(netlist).toContain("NET: U1_CLKOUT1")
+  expect(netlist).toContain("- pin1(VBAT1): NETS(U1_VBAT1)")
+  expect(netlist).toContain("- pin2(RTC_INTB1): NETS(U1_RTC_INTB1)")
+  expect(netlist).toContain("- pin3(CLKOUT1): NETS(U1_CLKOUT1)")
+})


### PR DESCRIPTION
## Summary
- score RTC backup-domain labels such as `VBAT1`, `RTC_INTB1`, and `CLKOUT1` before the generic digit fallback
- add regression coverage showing those numbered RTC labels now drive readable net names and component pin output

## Bounty
/claim #4

## Verification
- `npx --yes bun test tests/test4-rtc-backup-pin-labels.test.tsx`
- `npx --yes bun test`
- `npx --yes bun x tsc --noEmit`
- `npx --yes bun x biome check lib\scorePhrase.ts tests\test4-rtc-backup-pin-labels.test.tsx`
- `npx --yes bun run build`
- `git diff --check`