### PR TITLE
fix: include full chip pin labels in netlist output

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -1,13 +1,11 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
-import { getReadableNameForPin } from "./getReadableNameForPin"
+import {
+  getReadableNameForPin,
+  getReadablePinLabel,
+} from "./getReadableNameForPin"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -156,22 +154,10 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
-        const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
-        for (const hint of port.port_hints ?? []) {
-          if (hint === String(port.pin_number)) continue
-          if (hint !== mainPin && hint !== port.name) aliases.push(hint)
-        }
-        const aliasPart =
-          aliases.length > 0
-            ? `(${Array.from(new Set(aliases)).join(", ")})`
-            : ""
         const nets = portIdToNetNames[port.source_port_id] ?? []
         const netsPart =
           nets.length > 0 ? `NETS(${nets.join(", ")})` : "NOT_CONNECTED"
-        netlist.push(`- ${mainPin}${aliasPart}: ${netsPart}`)
+        netlist.push(`- ${getReadablePinLabel(port)}: ${netsPart}`)
       }
       netlist.push("")
     }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -1,11 +1,28 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
-import { scorePhrase } from "./scorePhrase"
+import type { AnyCircuitElement, SourcePort } from "circuit-json"
+
+export const getReadablePinLabel = (port: SourcePort): string => {
+  const mainPinName =
+    port.pin_number !== undefined
+      ? `pin${port.pin_number}`
+      : (port.name ?? "pin")
+
+  const aliases: string[] = []
+  if (port.name && port.name !== mainPinName) aliases.push(port.name)
+
+  for (const portHint of port.port_hints ?? []) {
+    if (portHint === String(port.pin_number)) continue
+    if (portHint !== mainPinName && portHint !== port.name) {
+      aliases.push(portHint)
+    }
+  }
+
+  const uniqueAliases = Array.from(new Set(aliases))
+  const aliasPart =
+    uniqueAliases.length > 0 ? `(${uniqueAliases.join(", ")})` : ""
+
+  return `${mainPinName}${aliasPart}`
+}
 
 export const getReadableNameForPin = ({
   circuitJson,
@@ -25,35 +42,23 @@ export const getReadableNameForPin = ({
   )
   if (!component) return ""
 
-  // Determine pin polarity from hints
-  const isPositive = port.port_hints?.some((hint) =>
-    ["anode", "pos", "positive"].includes(hint.toLowerCase()),
-  )
-  const isNegative = port.port_hints?.some((hint) =>
-    ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
-  )
-
-  // Format pin description
   const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  let pinLabel = getReadablePinLabel(port)
 
-  const additionalPinLabels: string[] = []
-
-  if (isPositive && component.ftype !== "simple_resistor") {
-    additionalPinLabels.push("+")
-  } else if (isNegative && component.ftype !== "simple_resistor") {
-    additionalPinLabels.push("-")
-  }
-
-  for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
-      additionalPinLabels.push(port_hint)
-    }
+  if (component.ftype === "simple_resistor") {
+    pinLabel = mainPinName
+  } else if (component.ftype === "simple_capacitor") {
+    const isPositive = port.port_hints?.some((hint) =>
+      ["anode", "pos", "positive"].includes(hint.toLowerCase()),
+    )
+    const isNegative = port.port_hints?.some((hint) =>
+      ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
+    )
+    pinLabel = `${mainPinName}${isPositive ? " (+)" : isNegative ? " (-)" : ""}`
   }
 
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  return `${component.name} ${pinLabel}${displayValue}`
 }

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -53,18 +53,18 @@ it("test2 chip", () => {
       - C1 pin1 (+)
 
     NET: GND
-      - U1 GPIO1 (SCL)
-      - U1 AGND
-      - U1 GND
+      - U1 pin3(GPIO1, SCL)
+      - U1 pin2(AGND)
+      - U1 pin1(GND)
 
     NET: U1_SDA
-      - U1 GPIO2 (SDA)
+      - U1 pin4(GPIO2, SDA)
       - R1 pin2
 
 
     EMPTY NET PINS:
-      - U1 GPIO3
-      - U1 VDD
+      - U1 pin5(GPIO3)
+      - U1 pin8(VDD)
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)


### PR DESCRIPTION
## Summary

- Adds a shared pin-label formatter that keeps the physical pin number and appends aliases/hints, so chip nets now render labels like `pin3(GPIO1, SCL)` instead of only the short signal label.
- Reuses the formatter in `COMPONENT_PINS` so pin labels stay consistent while preserving the existing compact resistor/capacitor net output.
- Updates the chip snapshot to cover full pin labels in connected nets and empty pins.

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `bun run format:check`
- `PATH=/opt/homebrew/bin:$PATH bun run build`

Closes #4