### PR TITLE
Fix readable labels for generic chip pin names

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,28 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinName = (name: string) => /^pin\d+$/i.test(name)
+
+const isLowValuePinHint = (hint: string, mainPinName: string) => {
+  const normalizedHint = hint.toLowerCase()
+  const normalizedMainPinName = mainPinName.toLowerCase()
+
+  return (
+    normalizedHint === normalizedMainPinName ||
+    normalizedHint === normalizedMainPinName.replace("pin", "") ||
+    [
+      "left",
+      "right",
+      "top",
+      "bottom",
+      "pos",
+      "neg",
+      "anode",
+      "cathode",
+    ].includes(normalizedHint)
+  )
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -47,7 +69,12 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (
+      score > 1 ||
+      (isGenericPinName(mainPinName) &&
+        component.ftype === "simple_chip" &&
+        !isLowValuePinHint(port_hint, mainPinName))
+    ) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/get-readable-name-for-pin.test.ts
+++ b/tests/get-readable-name-for-pin.test.ts
@@ -1,0 +1,30 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("includes chip pin hints when the source port name is generic", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "14", "GPIO10", "UART_TX"],
+    },
+  ]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (GPIO10,UART_TX)")
+})


### PR DESCRIPTION
Fixes #4.

This updates readable pin naming so chip ports with generic names like `pin14` still include useful label hints such as `GPIO10` and `UART_TX`. Low-value duplicate/position/polarity hints are filtered out.

Verification:
- bunx biome check lib/getReadableNameForPin.ts tests/get-readable-name-for-pin.test.ts
- bun test
- bun run build