### PR TITLE
Score USB hub power pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  if (
+    /^(USB_?)?PWRON\d*$/i.test(phrase) ||
+    /^(USB_?)?PORT_?PWR_?EN\d*$/i.test(phrase) ||
+    /^(USB_?)?(OC|OVERCURRENT)\d*$/i.test(phrase) ||
+    /^HUB_(RESET|PWRON|OC|OVERCURRENT)\d*$/i.test(phrase)
+  ) {
+    return 1.15
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/usb-hub-power-pin-labels.test.ts
+++ b/tests/usb-hub-power-pin-labels.test.ts
@@ -1,0 +1,76 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves USB hub power and overcurrent pin labels", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "USB2514B",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 10000,
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["PWRON1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["USB_OC1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["neg"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_4"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_PWRON1")
+  expect(netlist).toContain("  - U1 pin14 (PWRON1)")
+  expect(netlist).toContain("NET: U1_USB_OC1")
+  expect(netlist).toContain("  - U1 pin15 (USB_OC1)")
+  expect(netlist).toContain("- pin14(PWRON1): NETS(U1_PWRON1)")
+  expect(netlist).toContain("- pin15(USB_OC1): NETS(U1_USB_OC1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for USB hub port-power, overcurrent, and hub-reset aliases before the generic digit fallback.
- Add raw Circuit JSON regression coverage proving `PWRON1` and `USB_OC1` are preserved in generated NET names and readable pin entries.

/claim #4

## Verification
- `npx --yes bun@latest test tests/usb-hub-power-pin-labels.test.ts`
- `npx --yes bun@latest x biome check lib/scorePhrase.ts tests/usb-hub-power-pin-labels.test.ts`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest run build`
- `git diff --check`

## Note
- Full `npx --yes bun@latest test` still fails in this local environment only on the existing JSX-renderer tests with `TypeError: Attempting to define property on object that is not extensible` from `@tscircuit/core`; the new raw Circuit JSON regression test passes and avoids that renderer path.