### PR TITLE
fix: prefer meaningful readable pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -7,6 +7,7 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
+import { getDisplayPinLabel } from "./getDisplayPinLabel"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
 export const convertCircuitJsonToReadableNetlist = (
@@ -156,9 +157,10 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const { mainPinName, fallbackPinName } = getDisplayPinLabel(port)
+        const mainPin = mainPinName
         const aliases: string[] = []
+        if (fallbackPinName !== mainPin) aliases.push(fallbackPinName)
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue

--- a/lib/getDisplayPinLabel.ts
+++ b/lib/getDisplayPinLabel.ts
@@ -1,0 +1,44 @@
+import type { SourcePort } from "circuit-json"
+import { scorePhrase } from "./scorePhrase"
+
+const genericPortHints = new Set([
+  "anode",
+  "cathode",
+  "left",
+  "right",
+  "pos",
+  "neg",
+  "positive",
+  "negative",
+])
+
+export const getDisplayPinLabel = (port: SourcePort) => {
+  const fallbackPinName =
+    port.pin_number !== undefined
+      ? `pin${port.pin_number}`
+      : (port.name ?? "pin")
+
+  if (port.name) {
+    return {
+      mainPinName: port.name,
+      fallbackPinName,
+    }
+  }
+
+  const candidateHints = (port.port_hints ?? []).filter((hint) => {
+    const normalizedHint = hint.toLowerCase()
+    if (genericPortHints.has(normalizedHint)) return false
+    if (hint === String(port.pin_number)) return false
+    if (normalizedHint === fallbackPinName.toLowerCase()) return false
+    return true
+  })
+
+  const mainPinName =
+    candidateHints.sort((a, b) => scorePhrase(b) - scorePhrase(a))[0] ??
+    fallbackPinName
+
+  return {
+    mainPinName,
+    fallbackPinName,
+  }
+}

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -5,6 +5,7 @@ import type {
   SourceNet,
   SourcePort,
 } from "circuit-json"
+import { getDisplayPinLabel } from "./getDisplayPinLabel"
 import { scorePhrase } from "./scorePhrase"
 
 export const getReadableNameForPin = ({
@@ -33,8 +34,7 @@ export const getReadableNameForPin = ({
     ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
   )
 
-  // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const { mainPinName } = getDisplayPinLabel(port)
 
   const additionalPinLabels: string[] = []
 

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)

--- a/tests/test4-hint-only-pin-labels.test.ts
+++ b/tests/test4-hint-only-pin-labels.test.ts
@@ -1,0 +1,74 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("prefers meaningful port hints when a port name is missing", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "74HC14",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      port_hints: ["VCC", "right"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 7,
+      port_hints: ["GND", "left"],
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_1",
+      name: "VCC",
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_2",
+      name: "GND",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1"],
+      connected_source_net_ids: ["source_net_1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2"],
+      connected_source_net_ids: ["source_net_2"],
+    },
+  ] as any
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: 74HC14
+
+
+    EMPTY NET PINS:
+      - U1 VCC
+      - U1 GND
+
+    COMPONENT_PINS:
+    U1 (74HC14)
+    - GND(pin7, left): NETS(GND)
+    - VCC(pin14, right): NETS(VCC)
+    "
+  `)
+})


### PR DESCRIPTION
Fixes #4.

## Summary
When a `source_port` had no `port.name`, the readable netlist fell back to `Pin<number>` even if the port already had a meaningful label in `port_hints` such as `VCC` or `GND`.

This patch adds a small shared helper to choose a better display label:
- prefer `port.name` when present
- otherwise prefer the best non-generic `port_hints` value
- fall back to `pin<number>` only when no meaningful label exists

## What changed
- use the shared display-label helper in net pin rendering
- use the same helper in `COMPONENT_PINS`
- keep the numeric pin number as an alias for hint-only ports
- add a regression test covering hint-only labels like `VCC` on `pin14`

## Validation
- `bunx @biomejs/biome check lib tests`
- `bun test`
- `bun run build`