### PR TITLE
Score wireless module control pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -16,6 +16,14 @@ const wordQualityScore = {
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  WL_REG_ON: 1.2,
+  BT_REG_ON: 1.2,
+  WLAN_RST: 1.15,
+  WIFI_EN: 1.15,
+  HOST_WAKE: 1.15,
+  DEV_WAKE: 1.15,
+  BT_WAKE: 1.15,
+  BT_RST: 1.15,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +44,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/wireless-module-control-pin-labels.test.tsx
+++ b/tests/wireless-module-control-pin-labels.test.tsx
@@ -1,0 +1,70 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores wireless module control aliases before the generic digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="CYW43439"
+        pinLabels={{
+          pin1: ["pin14", "WL_REG_ON1"],
+          pin2: ["pin15", "HOST_WAKE1"],
+          pin3: ["pin16", "BT_REG_ON1"],
+          pin4: ["pin17", "DEV_WAKE1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .pin14" to=".R1 .pin1" />
+      <trace from=".U1 .pin15" to=".C1 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: CYW43439, soic8
+     - R1: 10kΩ 0402 resistor
+     - C1: 100nF 0402 capacitor
+
+    NET: U1_WL_REG_ON1
+      - U1 pin14 (WL_REG_ON1)
+      - R1 pin1
+
+    NET: U1_HOST_WAKE1
+      - U1 pin15 (HOST_WAKE1)
+      - C1 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (CYW43439)
+    - pin1(pin14, WL_REG_ON1): NETS(U1_WL_REG_ON1)
+    - pin2(pin15, HOST_WAKE1): NETS(U1_HOST_WAKE1)
+    - pin3(pin16, BT_REG_ON1): NOT_CONNECTED
+    - pin4(pin17, DEV_WAKE1): NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_WL_REG_ON1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    C1 (100nF 0402)
+    - pin1(pos, anode, left): NETS(U1_HOST_WAKE1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- add focused scoring for wireless-module power, reset, and wake aliases before the generic digit fallback
- preserve labels like `WL_REG_ON1` and `HOST_WAKE1` in generated NET names and readable pin entries when the physical source port name is generic
- add regression coverage for wireless-module control aliases on a generic chip pin path

This scope is intentionally separate from the open wireless coexistence slice: it targets module-control aliases such as `WL_REG_ON`, `BT_REG_ON`, `HOST_WAKE`, `DEV_WAKE`, `BT_WAKE`, and reset/enable labels rather than arbitration labels like `WLAN_ACTIVE`, `BT_PRIORITY`, or `COEX_REQ`.

## Verification
- `bun test tests/wireless-module-control-pin-labels.test.tsx`
- `bunx biome check lib/scorePhrase.ts tests/wireless-module-control-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before submission.