### PR TITLE
Score battery pack cell balancer pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -16,6 +16,16 @@ const wordQualityScore = {
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  CELL_BAL: 1.2,
+  BAL_SNS: 1.2,
+  JEITA: 1.15,
+  NTC_BAT: 1.15,
+  SHIP_MODE: 1.15,
+  BATT_PROT: 1.15,
+  PACK_SNS: 1.15,
+  BATFET: 1.15,
+  DSG: 1.15,
+  CHG_FET: 1.15,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +46,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/battery-pack-cell-balancer-pin-labels.test.tsx
+++ b/tests/battery-pack-cell-balancer-pin-labels.test.tsx
@@ -1,0 +1,70 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores battery-pack and cell-balancer aliases before the generic digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="BQ40Z50"
+        pinLabels={{
+          pin1: ["pin14", "CELL_BAL1"],
+          pin2: ["pin15", "SHIP_MODE1"],
+          pin3: ["pin16", "JEITA_HOT1"],
+          pin4: ["pin17", "NTC_BAT1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .pin14" to=".R1 .pin1" />
+      <trace from=".U1 .pin15" to=".C1 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: BQ40Z50, soic8
+     - R1: 10kΩ 0402 resistor
+     - C1: 100nF 0402 capacitor
+
+    NET: U1_CELL_BAL1
+      - U1 pin14 (CELL_BAL1)
+      - R1 pin1
+
+    NET: U1_SHIP_MODE1
+      - U1 pin15 (SHIP_MODE1)
+      - C1 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (BQ40Z50)
+    - pin1(pin14, CELL_BAL1): NETS(U1_CELL_BAL1)
+    - pin2(pin15, SHIP_MODE1): NETS(U1_SHIP_MODE1)
+    - pin3(pin16, JEITA_HOT1): NOT_CONNECTED
+    - pin4(pin17, NTC_BAT1): NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_CELL_BAL1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    C1 (100nF 0402)
+    - pin1(pos, anode, left): NETS(U1_SHIP_MODE1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- add focused scoring for battery-pack protection, cell-balancer, JEITA thermistor, and ship-mode aliases before the generic digit fallback
- preserve labels like `CELL_BAL1` and `SHIP_MODE1` in generated NET names and readable pin entries when the physical source port name is generic
- add regression coverage for battery-pack and cell-balancer aliases on a generic chip pin path

This scope is intentionally separate from the open charger/fuel-gauge and broad power-management slices: it targets battery-pack/BMS control aliases such as `CELL_BAL`, `BAL_SNS`, `JEITA`, `NTC_BAT`, `SHIP_MODE`, `BATT_PROT`, `PACK_SNS`, `BATFET`, `DSG`, and `CHG_FET`.

## Verification
- `bun test tests/battery-pack-cell-balancer-pin-labels.test.tsx`
- `bunx biome check lib/scorePhrase.ts tests/battery-pack-cell-balancer-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before submission.