### PR TITLE
Score differential interface pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -16,6 +16,11 @@ const wordQualityScore = {
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  LVPECL: 1.2,
+  CML: 1.15,
+  SLVS: 1.15,
+  SUBLVDS: 1.15,
+  OPENLDI: 1.15,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +41,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/differential-interface-pin-labels.test.tsx
+++ b/tests/differential-interface-pin-labels.test.tsx
@@ -1,0 +1,70 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores differential interface aliases before the generic digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="SN65LVPECL"
+        pinLabels={{
+          pin1: ["pin14", "LVPECL_CLK1"],
+          pin2: ["pin15", "CML_RX1"],
+          pin3: ["pin16", "SLVS_TX1"],
+          pin4: ["pin17", "OPENLDI_CLK1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .pin14" to=".R1 .pin1" />
+      <trace from=".U1 .pin15" to=".C1 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: SN65LVPECL, soic8
+     - R1: 10kΩ 0402 resistor
+     - C1: 100nF 0402 capacitor
+
+    NET: U1_LVPECL_CLK1
+      - U1 pin14 (LVPECL_CLK1)
+      - R1 pin1
+
+    NET: U1_CML_RX1
+      - U1 pin15 (CML_RX1)
+      - C1 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (SN65LVPECL)
+    - pin1(pin14, LVPECL_CLK1): NETS(U1_LVPECL_CLK1)
+    - pin2(pin15, CML_RX1): NETS(U1_CML_RX1)
+    - pin3(pin16, SLVS_TX1): NOT_CONNECTED
+    - pin4(pin17, OPENLDI_CLK1): NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_LVPECL_CLK1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    C1 (100nF 0402)
+    - pin1(pos, anode, left): NETS(U1_CML_RX1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- add focused scoring for LVPECL, CML, SLVS, SubLVDS, and OpenLDI aliases before the generic digit fallback
- preserve labels like `LVPECL_CLK1` and `CML_RX1` in generated NET names and readable pin entries when the physical source port name is generic
- add regression coverage for differential interface aliases on a generic chip pin path

This scope is intentionally separate from the open LVDS/eDP, HDMI/DisplayPort, JESD204, automotive camera SerDes, and high-speed retimer/link slices: it targets LVPECL/CML/SLVS/SubLVDS/OpenLDI labels specifically.

## Verification
- `bun test tests/differential-interface-pin-labels.test.tsx`
- `bunx biome check lib/scorePhrase.ts tests/differential-interface-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before submission.