### PR TITLE
Score i2c mux switch pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -16,6 +16,10 @@ const wordQualityScore = {
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  I2C_MUX: 1.2,
+  I2C_SWITCH: 1.2,
+  TCA9548: 1.15,
+  PCA954: 1.15,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +40,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/i2c-mux-switch-pin-labels.test.tsx
+++ b/tests/i2c-mux-switch-pin-labels.test.tsx
@@ -1,0 +1,70 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores i2c mux and switch aliases before the generic digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="TCA9548A"
+        pinLabels={{
+          pin1: ["pin14", "I2C_MUX_SEL1"],
+          pin2: ["pin15", "TCA9548A_INT1"],
+          pin3: ["pin16", "PCA9545_RESET1"],
+          pin4: ["pin17", "I2C_SWITCH_EN1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .pin14" to=".R1 .pin1" />
+      <trace from=".U1 .pin15" to=".C1 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: TCA9548A, soic8
+     - R1: 10kΩ 0402 resistor
+     - C1: 100nF 0402 capacitor
+
+    NET: U1_I2C_MUX_SEL1
+      - U1 pin14 (I2C_MUX_SEL1)
+      - R1 pin1
+
+    NET: U1_TCA9548A_INT1
+      - U1 pin15 (TCA9548A_INT1)
+      - C1 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (TCA9548A)
+    - pin1(pin14, I2C_MUX_SEL1): NETS(U1_I2C_MUX_SEL1)
+    - pin2(pin15, TCA9548A_INT1): NETS(U1_TCA9548A_INT1)
+    - pin3(pin16, PCA9545_RESET1): NOT_CONNECTED
+    - pin4(pin17, I2C_SWITCH_EN1): NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_I2C_MUX_SEL1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    C1 (100nF 0402)
+    - pin1(pos, anode, left): NETS(U1_TCA9548A_INT1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- add focused scoring for I2C mux / switch aliases before the generic digit fallback
- preserve labels like `I2C_MUX_SEL1` and `TCA9548A_INT1` in generated NET names and readable pin entries when the physical source port name is generic
- add regression coverage for I2C mux and switch aliases on a generic chip pin path

This scope is intentionally separate from the open I3C, SMBus/PMBus, and generic control/status slices: it targets `I2C_MUX`, `I2C_SWITCH`, `TCA9548`, and `PCA954x`-style labels specifically.

## Verification
- `bun test tests/i2c-mux-switch-pin-labels.test.tsx`
- `bunx biome check lib/scorePhrase.ts tests/i2c-mux-switch-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before submission.