### PR TITLE
Score power path ideal diode pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -16,6 +16,11 @@ const wordQualityScore = {
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  IDEAL_DIODE: 1.2,
+  REVERSE_BAT: 1.2,
+  POWER_PATH: 1.15,
+  LOAD_SHARE: 1.15,
+  CURRENT_SHARE: 1.15,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +41,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/power-path-ideal-diode-pin-labels.test.tsx
+++ b/tests/power-path-ideal-diode-pin-labels.test.tsx
@@ -1,0 +1,70 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores power-path and ideal-diode aliases before the generic digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="LTC4412"
+        pinLabels={{
+          pin1: ["pin14", "IDEAL_DIODE1"],
+          pin2: ["pin15", "POWER_PATH_EN1"],
+          pin3: ["pin16", "REVERSE_BAT1"],
+          pin4: ["pin17", "LOAD_SHARE1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .pin14" to=".R1 .pin1" />
+      <trace from=".U1 .pin15" to=".C1 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: LTC4412, soic8
+     - R1: 10kΩ 0402 resistor
+     - C1: 100nF 0402 capacitor
+
+    NET: U1_IDEAL_DIODE1
+      - U1 pin14 (IDEAL_DIODE1)
+      - R1 pin1
+
+    NET: U1_POWER_PATH_EN1
+      - U1 pin15 (POWER_PATH_EN1)
+      - C1 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (LTC4412)
+    - pin1(pin14, IDEAL_DIODE1): NETS(U1_IDEAL_DIODE1)
+    - pin2(pin15, POWER_PATH_EN1): NETS(U1_POWER_PATH_EN1)
+    - pin3(pin16, REVERSE_BAT1): NOT_CONNECTED
+    - pin4(pin17, LOAD_SHARE1): NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_IDEAL_DIODE1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    C1 (100nF 0402)
+    - pin1(pos, anode, left): NETS(U1_POWER_PATH_EN1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- add focused scoring for ideal-diode, reverse-battery, power-path, and load/current-share aliases before the generic digit fallback
- preserve labels like `IDEAL_DIODE1` and `POWER_PATH_EN1` in generated NET names and readable pin entries when the physical source port name is generic
- add regression coverage for power-path aliases on a generic chip pin path

This scope is intentionally separate from the open charger/fuel-gauge, PMIC control/status, regulator-topology, connector-power, and generic control slices: it targets `IDEAL_DIODE`, `REVERSE_BAT`, `POWER_PATH`, `LOAD_SHARE`, and `CURRENT_SHARE` labels specifically.

## Verification
- `bun test tests/power-path-ideal-diode-pin-labels.test.tsx`
- `bunx biome check lib/scorePhrase.ts tests/power-path-ideal-diode-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before submission.