### PR TITLE
fix: keep numeric pin labels in readable netlist

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/get-readable-name-for-pin.test.ts
+++ b/tests/get-readable-name-for-pin.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+import type { AnyCircuitElement } from "circuit-json"
+
+it("keeps useful numeric pin labels in readable pin names", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+    } as any,
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "GPIO1", "SCL"],
+    } as any,
+  ]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (GPIO1,SCL)")
+})


### PR DESCRIPTION
## Summary
- Keep useful numeric labels like `GPIO1` from being filtered out of readable pin names.
- Add a regression test covering a `pin14` source port with `GPIO1` and `SCL` labels.

## Testing
- `git diff --check`

Note: I could not run `bun test` locally because `bun` is not installed in this environment.

Closes #4