### PR TITLE
fix: prefer full pin labels in readable netlists

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,20 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinName = (pinName?: string) => /^pin\d+$/i.test(pinName ?? "")
+
+const getMainPinName = (port: SourcePort) => {
+  if (!isGenericPinName(port.name)) return port.name ?? `Pin${port.pin_number}`
+
+  const bestHint = (port.port_hints ?? [])
+    .filter((hint) => !isGenericPinName(hint))
+    .map((hint) => ({ hint, score: scorePhrase(hint) }))
+    .filter(({ score }) => score >= 1)
+    .at(0)?.hint
+
+  return bestHint ?? port.name ?? `Pin${port.pin_number}`
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +48,7 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = getMainPinName(port)
 
   const additionalPinLabels: string[] = []
 
@@ -46,6 +60,7 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (isGenericPinName(port_hint)) continue
     const score = scorePhrase(port_hint)
     if (score > 1) {
       additionalPinLabels.push(port_hint)

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,7 +36,7 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
+  if (phrase.match(/^\d+$/)) {
     return 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {

--- a/tests/test4-pin-labels.test.ts
+++ b/tests/test4-pin-labels.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("uses full chip pin labels instead of generic pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GPIO10", "SCL", "pin14"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 GPIO10 (SCL)")
+})


### PR DESCRIPTION
## Summary
- prefer meaningful pin labels from port hints when the source port name is a generic pinN value
- keep generic passive pins such as pin1 when their hints are only polarity/position labels
- let alphanumeric signal names such as GPIO10 score as signal names instead of numeric-only phrases
- add a regression test for the pin14 -> GPIO10 (SCL) case

Closes #4

## Test plan
- npm.cmd run build
- npx.cmd bun test tests/test4-pin-labels.test.ts
- npx.cmd biome check lib/getReadableNameForPin.ts lib/scorePhrase.ts tests/test4-pin-labels.test.ts

Note: 
px.cmd bun test currently fails in existing unrelated tests because @tscircuit/circuit-json-util does not export distanceBetweenCircleAndPolygon in the installed dependency tree; the new regression test passes in isolation.
