### PR TITLE
Score BLDC back-EMF pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,21 +35,11 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
-const motorControlAliases = [
-  "PHASE_U",
-  "PHASE_V",
-  "PHASE_W",
-  "BEMF_U",
-  "BEMF_V",
-  "BEMF_W",
-  "HALL_A",
-  "HALL_B",
-  "HALL_C",
-]
+const bemfAliases = ["BEMF_U", "BEMF_V", "BEMF_W"]
 
 export const scorePhrase = (phrase: string) => {
   const normalizedPhrase = phrase.toUpperCase()
-  for (const alias of motorControlAliases) {
+  for (const alias of bemfAliases) {
     if (normalizedPhrase.includes(alias)) {
       return 1.2
     }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,25 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const motorControlAliases = [
+  "PHASE_U",
+  "PHASE_V",
+  "PHASE_W",
+  "BEMF_U",
+  "BEMF_V",
+  "BEMF_W",
+  "HALL_A",
+  "HALL_B",
+  "HALL_C",
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  for (const alias of motorControlAliases) {
+    if (normalizedPhrase.includes(alias)) {
+      return 1.2
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-motor-control-pin-labels.test.ts
+++ b/tests/test4-motor-control-pin-labels.test.ts
@@ -2,7 +2,7 @@ import { expect, it } from "bun:test"
 import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
 
-it("keeps BLDC motor-control aliases readable on generic physical pins", () => {
+it("keeps BLDC back-EMF aliases readable on generic physical pins", () => {
   const circuitJson: AnyCircuitElement[] = [
     {
       type: "source_component",
@@ -19,94 +19,51 @@ it("keeps BLDC motor-control aliases readable on generic physical pins", () => {
     },
     {
       type: "source_port",
-      source_port_id: "source_port_phase_u_driver",
+      source_port_id: "source_port_bemf_u_driver",
       source_component_id: "source_component_driver",
       name: "pin14",
       pin_number: 14,
-      port_hints: ["14", "pin14", "PHASE_U1"],
-    },
-    {
-      type: "source_port",
-      source_port_id: "source_port_phase_u_motor",
-      source_component_id: "source_component_motor",
-      name: "pin1",
-      pin_number: 1,
-      port_hints: ["1", "pin1", "PHASE_U1"],
-    },
-    {
-      type: "source_port",
-      source_port_id: "source_port_phase_v_driver",
-      source_component_id: "source_component_driver",
-      name: "pin15",
-      pin_number: 15,
-      port_hints: ["15", "pin15", "PHASE_V1"],
-    },
-    {
-      type: "source_port",
-      source_port_id: "source_port_phase_v_motor",
-      source_component_id: "source_component_motor",
-      name: "pin2",
-      pin_number: 2,
-      port_hints: ["2", "pin2", "PHASE_V1"],
-    },
-    {
-      type: "source_port",
-      source_port_id: "source_port_hall_a_driver",
-      source_component_id: "source_component_driver",
-      name: "pin16",
-      pin_number: 16,
-      port_hints: ["16", "pin16", "HALL_A1"],
-    },
-    {
-      type: "source_port",
-      source_port_id: "source_port_hall_a_motor",
-      source_component_id: "source_component_motor",
-      name: "pin3",
-      pin_number: 3,
-      port_hints: ["3", "pin3", "HALL_A1"],
-    },
-    {
-      type: "source_port",
-      source_port_id: "source_port_bemf_u_driver",
-      source_component_id: "source_component_driver",
-      name: "pin17",
-      pin_number: 17,
-      port_hints: ["17", "pin17", "BEMF_U1"],
+      port_hints: ["14", "pin14", "BEMF_U1"],
     },
     {
       type: "source_port",
       source_port_id: "source_port_bemf_u_sense",
       source_component_id: "source_component_motor",
-      name: "pin4",
-      pin_number: 4,
-      port_hints: ["4", "pin4", "BEMF_U1"],
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["1", "pin1", "BEMF_U1"],
     },
     {
-      type: "source_trace",
-      source_trace_id: "source_trace_phase_u",
-      connected_source_port_ids: [
-        "source_port_phase_u_driver",
-        "source_port_phase_u_motor",
-      ],
-      connected_source_net_ids: [],
+      type: "source_port",
+      source_port_id: "source_port_bemf_v_driver",
+      source_component_id: "source_component_driver",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["15", "pin15", "BEMF_V1"],
     },
     {
-      type: "source_trace",
-      source_trace_id: "source_trace_phase_v",
-      connected_source_port_ids: [
-        "source_port_phase_v_driver",
-        "source_port_phase_v_motor",
-      ],
-      connected_source_net_ids: [],
+      type: "source_port",
+      source_port_id: "source_port_bemf_v_sense",
+      source_component_id: "source_component_motor",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["2", "pin2", "BEMF_V1"],
     },
     {
-      type: "source_trace",
-      source_trace_id: "source_trace_hall_a",
-      connected_source_port_ids: [
-        "source_port_hall_a_driver",
-        "source_port_hall_a_motor",
-      ],
-      connected_source_net_ids: [],
+      type: "source_port",
+      source_port_id: "source_port_bemf_w_driver",
+      source_component_id: "source_component_driver",
+      name: "pin16",
+      pin_number: 16,
+      port_hints: ["16", "pin16", "BEMF_W1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_bemf_w_sense",
+      source_component_id: "source_component_motor",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["3", "pin3", "BEMF_W1"],
     },
     {
       type: "source_trace",
@@ -117,21 +74,36 @@ it("keeps BLDC motor-control aliases readable on generic physical pins", () => {
       ],
       connected_source_net_ids: [],
     },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_bemf_v",
+      connected_source_port_ids: [
+        "source_port_bemf_v_driver",
+        "source_port_bemf_v_sense",
+      ],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_bemf_w",
+      connected_source_port_ids: [
+        "source_port_bemf_w_driver",
+        "source_port_bemf_w_sense",
+      ],
+      connected_source_net_ids: [],
+    },
   ]
 
   const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
 
-  expect(netlist).toContain("NET: U1_PHASE_U1")
-  expect(netlist).toContain("  - U1 pin14 (PHASE_U1)")
-  expect(netlist).toContain("NET: U1_PHASE_V1")
-  expect(netlist).toContain("  - U1 pin15 (PHASE_V1)")
-  expect(netlist).toContain("NET: U1_HALL_A1")
-  expect(netlist).toContain("  - U1 pin16 (HALL_A1)")
   expect(netlist).toContain("NET: U1_BEMF_U1")
-  expect(netlist).toContain("  - U1 pin17 (BEMF_U1)")
-  expect(netlist).toContain("- pin14(PHASE_U1): NETS(U1_PHASE_U1)")
-  expect(netlist).toContain("- pin15(PHASE_V1): NETS(U1_PHASE_V1)")
-  expect(netlist).toContain("- pin16(HALL_A1): NETS(U1_HALL_A1)")
-  expect(netlist).toContain("- pin17(BEMF_U1): NETS(U1_BEMF_U1)")
+  expect(netlist).toContain("  - U1 pin14 (BEMF_U1)")
+  expect(netlist).toContain("NET: U1_BEMF_V1")
+  expect(netlist).toContain("  - U1 pin15 (BEMF_V1)")
+  expect(netlist).toContain("NET: U1_BEMF_W1")
+  expect(netlist).toContain("  - U1 pin16 (BEMF_W1)")
+  expect(netlist).toContain("- pin14(BEMF_U1): NETS(U1_BEMF_U1)")
+  expect(netlist).toContain("- pin15(BEMF_V1): NETS(U1_BEMF_V1)")
+  expect(netlist).toContain("- pin16(BEMF_W1): NETS(U1_BEMF_W1)")
   expect(netlist).not.toContain("undefined")
 })

--- a/tests/test4-motor-control-pin-labels.test.ts
+++ b/tests/test4-motor-control-pin-labels.test.ts
@@ -1,0 +1,137 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("keeps BLDC motor-control aliases readable on generic physical pins", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_driver",
+      name: "U1",
+      manufacturer_part_number: "DRV8313",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_motor",
+      name: "M1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_phase_u_driver",
+      source_component_id: "source_component_driver",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "pin14", "PHASE_U1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_phase_u_motor",
+      source_component_id: "source_component_motor",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["1", "pin1", "PHASE_U1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_phase_v_driver",
+      source_component_id: "source_component_driver",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["15", "pin15", "PHASE_V1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_phase_v_motor",
+      source_component_id: "source_component_motor",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["2", "pin2", "PHASE_V1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_hall_a_driver",
+      source_component_id: "source_component_driver",
+      name: "pin16",
+      pin_number: 16,
+      port_hints: ["16", "pin16", "HALL_A1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_hall_a_motor",
+      source_component_id: "source_component_motor",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["3", "pin3", "HALL_A1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_bemf_u_driver",
+      source_component_id: "source_component_driver",
+      name: "pin17",
+      pin_number: 17,
+      port_hints: ["17", "pin17", "BEMF_U1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_bemf_u_sense",
+      source_component_id: "source_component_motor",
+      name: "pin4",
+      pin_number: 4,
+      port_hints: ["4", "pin4", "BEMF_U1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_phase_u",
+      connected_source_port_ids: [
+        "source_port_phase_u_driver",
+        "source_port_phase_u_motor",
+      ],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_phase_v",
+      connected_source_port_ids: [
+        "source_port_phase_v_driver",
+        "source_port_phase_v_motor",
+      ],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_hall_a",
+      connected_source_port_ids: [
+        "source_port_hall_a_driver",
+        "source_port_hall_a_motor",
+      ],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_bemf_u",
+      connected_source_port_ids: [
+        "source_port_bemf_u_driver",
+        "source_port_bemf_u_sense",
+      ],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_PHASE_U1")
+  expect(netlist).toContain("  - U1 pin14 (PHASE_U1)")
+  expect(netlist).toContain("NET: U1_PHASE_V1")
+  expect(netlist).toContain("  - U1 pin15 (PHASE_V1)")
+  expect(netlist).toContain("NET: U1_HALL_A1")
+  expect(netlist).toContain("  - U1 pin16 (HALL_A1)")
+  expect(netlist).toContain("NET: U1_BEMF_U1")
+  expect(netlist).toContain("  - U1 pin17 (BEMF_U1)")
+  expect(netlist).toContain("- pin14(PHASE_U1): NETS(U1_PHASE_U1)")
+  expect(netlist).toContain("- pin15(PHASE_V1): NETS(U1_PHASE_V1)")
+  expect(netlist).toContain("- pin16(HALL_A1): NETS(U1_HALL_A1)")
+  expect(netlist).toContain("- pin17(BEMF_U1): NETS(U1_BEMF_U1)")
+  expect(netlist).not.toContain("undefined")
+})


### PR DESCRIPTION
## Summary
- Narrow this bounty slice to BLDC back-EMF aliases so it does not overlap the older open motor-control PR #132.
- Score `BEMF_U`, `BEMF_V`, and `BEMF_W` aliases before the generic digit fallback so labels like `BEMF_U1` stay readable instead of losing to `pin14`-style labels.
- Add raw Circuit JSON regression coverage for generic physical pins carrying those back-EMF aliases.

## Validation
- `npx --yes bun@latest test tests/test4-motor-control-pin-labels.test.ts` - passed
- `npx --yes bun@latest test` - passed
- `npx --yes bun@latest run build` - passed
- `npx --yes bun@latest x tsc --noEmit` - passed
- `npx --yes bun@latest x biome check lib/scorePhrase.ts tests/test4-motor-control-pin-labels.test.ts` - passed
- `git diff --check` - passed

AI-assisted with Codex; diff and validation reviewed locally before initial submission, then scope narrowed after duplicate-PR review. Post-narrowing validation was rerun on the current branch.

Fixes #4
/claim #4