### PR TITLE
Score audio amplifier and headset pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,12 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  SPK_OUT: 1.15,
+  HPOUT: 1.15,
+  LINEOUT: 1.15,
+  HP_DET: 1.15,
+  MIC_BIAS: 1.15,
+  CLASSD: 1.1,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -36,6 +42,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  for (const [word, score] of wordQualityScoreEntries) {
+    if (
+      ["SPK_OUT", "HPOUT", "LINEOUT", "HP_DET", "MIC_BIAS", "CLASSD"].includes(
+        word,
+      ) &&
+      normalizedPhrase.includes(word)
+    ) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-audio-amplifier-pin-labels.test.ts
+++ b/tests/test4-audio-amplifier-pin-labels.test.ts
@@ -1,0 +1,68 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("prefers digit-bearing audio amplifier aliases over passive labels", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "AMP1",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_r1",
+      name: "R1",
+      ftype: "simple_resistor",
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1",
+      source_component_id: "source_component_u1",
+      pin_number: 14,
+      port_hints: ["SPK_OUT1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1",
+      source_component_id: "source_component_r1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_u1", "source_port_r1"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: AMP1
+     - R1: 10kΩ resistor
+
+    NET: U1_SPK_OUT1
+      - U1 Pin14 (SPK_OUT1)
+      - R1 Pin1
+
+
+    COMPONENT_PINS:
+    U1 (AMP1)
+    - pin14(SPK_OUT1): NETS(U1_SPK_OUT1)
+
+    R1 (10kΩ undefined)
+    - pin1(pos): NETS(U1_SPK_OUT1)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
This keeps the scope narrow to a remaining readable-label gap for digit-bearing audio amplifier / headset aliases. Hints such as `SPK_OUT1`, `HP_DET1`, and `MIC_BIAS1` currently hit the generic numeric fallback before they can act like useful signal labels, so generated net names can prefer low-information labels such as `pos`.

## What changed
- add focused scorer entries for audio amplifier / headset aliases
- apply those aliases before the generic digit fallback
- add a regression test proving `SPK_OUT1` wins over a passive `pos` endpoint in generated net output

## Validation
- `bun test tests/test4-audio-amplifier-pin-labels.test.ts`
- `bun test`
- `bunx @biomejs/biome check lib/scorePhrase.ts tests/test4-audio-amplifier-pin-labels.test.ts`
- `bun run build`

## Notes
This patch is intentionally scorer-only plus regression coverage so it stays separate from the existing display, RF, storage, power, and generic numbered-pin slices already open on issue #4.