### PR TITLE
Score heater pin aliases in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const heaterAliasPattern =
+  /(?:^|_)(?:HEATER|HEAT|BED_HEATER|HOTEND|HEATING|RESISTIVE_LOAD)(?:_|$)/
+
 export const scorePhrase = (phrase: string) => {
+  if (heaterAliasPattern.test(phrase.toUpperCase())) {
+    return 1.15
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/heater-pin-labels.test.tsx
+++ b/tests/heater-pin-labels.test.tsx
@@ -1,0 +1,37 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves heater control aliases in readable labels", () => {
+  expect(scorePhrase("HEATER_EN1")).toBeGreaterThan(1)
+  expect(scorePhrase("HEAT_PWM1")).toBeGreaterThan(1)
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="HEATER_CTRL"
+        pinLabels={{
+          pin1: ["pin1", "HEATER_EN1"],
+          pin2: ["pin2", "HEAT_PWM1"],
+          pin3: ["GND"],
+          pin4: ["VDD"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <trace from=".U1 .HEATER_EN1" to=".R1 .pin1" />
+      <trace from=".U1 .HEAT_PWM1" to=".R1 .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_HEATER_EN1")
+  expect(netlist).toContain("  - U1 pin1 (HEATER_EN1)")
+  expect(netlist).toContain("NET: U1_HEAT_PWM1")
+  expect(netlist).toContain("  - U1 pin2 (HEAT_PWM1)")
+  expect(netlist).toContain("- pin1(HEATER_EN1): NETS(U1_HEATER_EN1)")
+  expect(netlist).toContain("- pin2(HEAT_PWM1): NETS(U1_HEAT_PWM1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for heater and resistive-load control aliases before the generic digit fallback
- add regression coverage for HEATER_EN1 and HEAT_PWM1 so generated NET names and readable pin entries keep useful heater labels

/claim #4

## Validation
- npm.cmd exec --yes bun@latest -- test tests/heater-pin-labels.test.tsx
- npm.cmd exec --yes bun@latest -- test
- npm.cmd exec --yes bun@latest -- run build
- npm.cmd exec --yes @biomejs/biome@1.9.4 -- check lib/scorePhrase.ts tests/heater-pin-labels.test.tsx
- git diff --check