### PR TITLE
Fix readable labels for chip pins and omit undefined footprints

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,9 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${[component.display_resistance, footprint].filter(Boolean).join(" ")})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${[component.display_capacitance, footprint].filter(Boolean).join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,21 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinLabel = (label: string | undefined, pinNumber?: number) => {
+  if (!label) return true
+  const normalized = label.toLowerCase()
+  return (
+    normalized === "pin" ||
+    normalized === `pin${pinNumber}` ||
+    normalized === String(pinNumber)
+  )
+}
+
+const getUniquePinHints = (port: SourcePort) =>
+  Array.from(new Set(port.port_hints ?? [])).filter(
+    (hint) => !isGenericPinLabel(hint, port.pin_number),
+  )
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +49,13 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const meaningfulHints = getUniquePinHints(port)
+  const mainPinName =
+    component.ftype === "simple_chip" &&
+    isGenericPinLabel(port.name, port.pin_number) &&
+    meaningfulHints.length > 0
+      ? meaningfulHints[0]
+      : port.name || `Pin${port.pin_number}`
 
   const additionalPinLabels: string[] = []
 
@@ -44,10 +65,10 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
-  for (const port_hint of port.port_hints ?? []) {
+  for (const port_hint of meaningfulHints) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (component.ftype === "simple_chip" || score > 1) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/test4-readable-pin-labels.test.ts
+++ b/tests/test4-readable-pin-labels.test.ts
@@ -1,0 +1,72 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses descriptive chip pin hints when the source port name is generic", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      resistance: 10000,
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      pin_number: 14,
+      name: "pin14",
+      port_hints: ["14", "pin14", "GP10", "SCLK"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 1,
+      name: "pin1",
+      port_hints: ["pin1", "anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: RP2040
+     - R1: 10k resistor
+
+    NET: U1_SCLK
+      - U1 GP10 (SCLK)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (RP2040)
+    - pin14(GP10, SCLK): NETS(U1_SCLK)
+
+    R1 (10k)
+    - pin1(anode, pos, left): NETS(U1_SCLK)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- prefer meaningful chip pin labels from port hints over generic names like pin14
- keep secondary useful labels such as SCLK in readable netlist output
- omit missing resistor/capacitor footprint values instead of rendering undefined

## Tests
- npx bun test tests\test4-readable-pin-labels.test.ts
- npx bun run build
- npx biome check lib\convertCircuitJsonToReadableNetlist.ts lib\getReadableNameForPin.ts tests\test4-readable-pin-labels.test.ts

Fixes #4