### PR TITLE
[codex] score telecom line pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,26 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const telecomLineAliasPatterns = [
+  /^SLIC(?:_|$|\d)/,
+  /^FXS(?:_|$|\d)/,
+  /^FXO(?:_|$|\d)/,
+  /^POTS(?:_|$|\d)/,
+  /^TIP(?:_|$|\d)/,
+  /^RING(?:_|$|\d)/,
+  /^HOOKSW(?:_|$|\d)/,
+  /^OFFHOOK(?:_|$|\d)/,
+  /^ONHOOK(?:_|$|\d)/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    telecomLineAliasPatterns.some((pattern) => pattern.test(normalizedPhrase))
+  ) {
+    return 1.15
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/telecom-line-pin-labels.test.tsx
+++ b/tests/telecom-line-pin-labels.test.tsx
@@ -1,0 +1,38 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores telecom line-interface aliases above generic numbered pins", () => {
+  expect(scorePhrase("RING_DET1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("FXS_TIP")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("OFFHOOK")).toBeGreaterThan(1)
+})
+
+it("preserves telecom line-interface aliases in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="SI3210"
+        pinLabels={{
+          pin1: ["pin14", "RING_DET1"],
+          pin2: ["pin15", "FXS_TIP"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="2k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .pin14" to=".R1 > .pin1" />
+      <trace from=".U1 .pin15" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_RING_DET1")
+  expect(netlist).toContain("  - U1 pin14 (RING_DET1)")
+  expect(netlist).toContain("NET: U1_FXS_TIP")
+  expect(netlist).toContain("  - U1 pin15 (FXS_TIP)")
+})


### PR DESCRIPTION
## Issue

/claim #4

Part of #4.

## Summary

Adds a focused telecom line-interface scoring slice for SLIC/FXS/FXO/POTS aliases such as `RING_DET1`, `FXS_TIP`, `OFFHOOK`, and `HOOKSW`.

This lets generic physical chip pins like `pin14` keep useful phone-line/SLIC signal context in generated net names and readable pin labels, without changing unrelated alias families.

## Acceptance Criteria

- [x] Telecom line aliases score above generic numbered pins before the digit fallback
- [x] `RING_DET1` and `FXS_TIP` are preserved in generated `NET:` names
- [x] Readable NET pin entries include the useful telecom alias alongside the physical pin label
- [x] Regression coverage added

## Verification

- `npx.cmd --yes bun@latest test tests/telecom-line-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/telecom-line-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the scope and kept the patch limited to this alias family.