### PR TITLE
[codex] score digital carrier framer pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,23 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitalCarrierFramerAliasPatterns = [
+  /^(?:DS[13]|T[13]|E[13])_(?:RX|TX|RCLK|TCLK|CLK|LOS|LOF|AIS|RAI|SYNC|FRAME|FRAMER)(?:_|$|\d)/,
+  /^FRAMER_(?:CLK|SYNC|RESET|INT|LOS|LOF|AIS|RAI)(?:_|$|\d)/,
+  /^(?:B8ZS|HDB3|AMI|HDLC_FLAG)(?:_|$|\d)/,
+  /^HDLC_(?:FLAG|CLK|RX|TX)(?:_|$|\d)/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    digitalCarrierFramerAliasPatterns.some((pattern) =>
+      pattern.test(normalizedPhrase),
+    )
+  ) {
+    return 1.15
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/digital-carrier-framer-pin-labels.test.tsx
+++ b/tests/digital-carrier-framer-pin-labels.test.tsx
@@ -1,0 +1,61 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores digital carrier framer aliases above generic numbered pins", () => {
+  expect(scorePhrase("DS1_RCLK")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("E1_LOS1")).toBeGreaterThan(scorePhrase("pin15"))
+  expect(scorePhrase("T1_AIS")).toBeGreaterThan(1)
+  expect(scorePhrase("HDLC_FLAG")).toBeGreaterThan(1)
+})
+
+it("preserves digital carrier framer aliases in readable netlists", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_framer",
+      name: "FR1",
+      manufacturer_part_number: "DS2155",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_monitor",
+      name: "MON1",
+      manufacturer_part_number: "TEST_MONITOR",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_framer_rclk",
+      source_component_id: "source_component_framer",
+      pin_number: 14,
+      name: "pin14",
+      port_hints: ["DS1_RCLK"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_monitor_pos",
+      source_component_id: "source_component_monitor",
+      pin_number: 1,
+      name: "pin1",
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_rclk",
+      connected_source_port_ids: [
+        "source_port_framer_rclk",
+        "source_port_monitor_pos",
+      ],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: FR1_DS1_RCLK")
+  expect(netlist).toContain("  - FR1 pin14 (DS1_RCLK)")
+  expect(netlist).toContain("- pin14(DS1_RCLK): NETS(FR1_DS1_RCLK)")
+})


### PR DESCRIPTION
## What changed
- Added focused scoring for digital carrier/framer aliases before the generic digit fallback.
- Covered DS1/DS3, T1/T3, E1/E3, framer alarm/clock labels, B8ZS/HDB3/AMI, and HDLC flag labels.
- Added raw Circuit JSON regression coverage showing `DS1_RCLK` is preserved in generated NET names and readable pin entries.

## Why
Generic chip pins with hints like `DS1_RCLK`, `E1_LOS1`, `T1_AIS`, or `HDLC_FLAG` can otherwise lose to low-information labels such as `pos` because the generic digit fallback runs first.

## Verification
- `npx.cmd --yes bun@latest test tests/digital-carrier-framer-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/digital-carrier-framer-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

/claim #4