### PR TITLE
[codex] score LPC eSPI TPM pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,22 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const platformManagementAliasPatterns = [
+  /\bLPC_?(?:AD|LAD)\d\b/i,
+  /\bLAD\d\b/i,
+  /\bLPC_?(?:CLK|FRAME|RESET|RST|DRQ\d?|PD)\b/i,
+  /\bLFRAME(?:_N)?\b/i,
+  /\b(?:SERIRQ|CLKRUN)\b/i,
+  /\bESPI_?(?:CLK|CS\d?|IO\d|RESET|RST|ALERT|OOB|SAFS|VWIRE)\b/i,
+  /\bTPM_?(?:CS\d?|CLK|RST|RESET|IRQ|PIRQ|PP|GPIO\d?|LAD\d|AD\d)\b/i,
+  /\b(?:PLTRST|RSMRST|SLP_S[345]|PCH_PWROK|SUSCLK|SUS_STAT)\b/i,
+  /\bEC_(?:SCI|SMI)\b/i,
+]
+
 export const scorePhrase = (phrase: string) => {
+  if (platformManagementAliasPatterns.some((pattern) => pattern.test(phrase))) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/platform-management-pin-labels.test.tsx
+++ b/tests/platform-management-pin-labels.test.tsx
@@ -1,0 +1,39 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores LPC eSPI and TPM platform-management pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="TPM9670"
+        pinLabels={{
+          pin1: ["pin14", "LPC_AD0"],
+          pin2: ["pin15", "ESPI_CLK"],
+          pin3: ["pin16", "TPM_PIRQ"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .LPC_AD0" to=".R1 > .pin1" />
+      <trace from=".U1 .ESPI_CLK" to=".R1 > .pin2" />
+      <trace from=".U1 .TPM_PIRQ" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_LPC_AD0")
+  expect(netlist).toContain("  - U1 pin14 (LPC_AD0)")
+  expect(netlist).toContain("- pin1(pin14, LPC_AD0): NETS(U1_LPC_AD0)")
+
+  expect(netlist).toContain("NET: U1_ESPI_CLK")
+  expect(netlist).toContain("  - U1 pin15 (ESPI_CLK)")
+
+  expect(netlist).toContain("NET: U1_TPM_PIRQ")
+  expect(netlist).toContain("  - U1 pin16 (TPM_PIRQ)")
+  expect(netlist).toContain("- pin3(pin16, TPM_PIRQ): NETS(U1_TPM_PIRQ)")
+})


### PR DESCRIPTION
## Issue

/claim #4

Part of #4.

## Summary

Adds focused scoring for LPC/eSPI/TPM platform-management aliases such as `LPC_AD0`, `ESPI_CLK`, and `TPM_PIRQ`.

This lets generic physical chip pins like `pin14` keep useful platform-bus signal context in generated net names and readable pin labels, without changing unrelated alias families.

## Acceptance Criteria

- [x] LPC/eSPI/TPM platform-management aliases score above generic numbered pins before the digit fallback
- [x] `LPC_AD0`, `ESPI_CLK`, and `TPM_PIRQ` are preserved in generated `NET:` names
- [x] Readable NET pin entries include the useful platform-management alias alongside the physical pin label
- [x] Regression coverage added

## Verification

- `npx.cmd --yes bun@latest test tests/platform-management-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/platform-management-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the scope and kept the patch limited to this alias family.