### PR TITLE
[codex] score OpenTherm HVAC pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,21 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const hvacThermostatAliasPatterns = [
+  /\bOPEN_?THERM(?:_?(?:BUS|TX|RX|IN|OUT|P|N|PLUS|MINUS))?\d?\b/i,
+  /\bOT_?(?:BUS|TX|RX|IN|OUT|P|N|PLUS|MINUS)\d?\b/i,
+  /\bTHERMOSTAT_?(?:W\d?|Y\d?|G\d?|C|R|RC|RH|O|B|AUX|E|FAN|HEAT|COOL)\b/i,
+  /\bHVAC_?(?:HEAT|COOL|FAN|AUX|EMHEAT|CALL)\d?\b/i,
+  /\b(?:HEAT|COOL|FAN|AUX|EM)_CALL\d?\b/i,
+  /\bBOILER_?(?:CALL|ENABLE|FIRE|TX|RX|BUS)\d?\b/i,
+  /\bFURNACE_?(?:W\d?|CALL|FAN|HEAT|FAULT)\b/i,
+  /\bHEATPUMP_?(?:O|B|REV|AUX|DEFROST|Y\d?)\b/i,
+]
+
 export const scorePhrase = (phrase: string) => {
+  if (hvacThermostatAliasPatterns.some((pattern) => pattern.test(phrase))) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/opentherm-hvac-pin-labels.test.tsx
+++ b/tests/opentherm-hvac-pin-labels.test.tsx
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores OpenTherm and HVAC thermostat pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="HVAC-CTRL"
+        pinLabels={{
+          pin1: ["pin14", "OPENTHERM_BUS1"],
+          pin2: ["pin15", "THERMOSTAT_W1"],
+          pin3: ["pin16", "BOILER_CALL1"],
+        }}
+      />
+      <resistor resistance="4.7k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .OPENTHERM_BUS1" to=".R1 > .pin1" />
+      <trace from=".U1 .THERMOSTAT_W1" to=".R1 > .pin2" />
+      <trace from=".U1 .BOILER_CALL1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_OPENTHERM_BUS1")
+  expect(netlist).toContain("  - U1 pin14 (OPENTHERM_BUS1)")
+  expect(netlist).toContain(
+    "- pin1(pin14, OPENTHERM_BUS1): NETS(U1_OPENTHERM_BUS1)",
+  )
+
+  expect(netlist).toContain("NET: U1_THERMOSTAT_W1")
+  expect(netlist).toContain("  - U1 pin15 (THERMOSTAT_W1)")
+
+  expect(netlist).toContain("NET: U1_BOILER_CALL1")
+  expect(netlist).toContain("  - U1 pin16 (BOILER_CALL1)")
+  expect(netlist).toContain(
+    "- pin3(pin16, BOILER_CALL1): NETS(U1_BOILER_CALL1)",
+  )
+})


### PR DESCRIPTION
## Issue

/claim #4

Part of #4.

## Summary

Adds focused scoring for OpenTherm and HVAC thermostat-control aliases such as `OPENTHERM_BUS1`, `THERMOSTAT_W1`, and `BOILER_CALL1`.

This lets generic physical chip pins like `pin14` keep useful thermostat/boiler control context in generated net names and readable pin labels, without changing unrelated alias families.

## Acceptance Criteria

- [x] OpenTherm/HVAC thermostat aliases score above generic numbered pins before the digit fallback
- [x] `OPENTHERM_BUS1`, `THERMOSTAT_W1`, and `BOILER_CALL1` are preserved in generated `NET:` names
- [x] Readable NET pin entries include the useful thermostat/boiler alias alongside the physical pin label
- [x] Regression coverage added

## Verification

- `npx.cmd --yes bun@latest test tests/opentherm-hvac-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/opentherm-hvac-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the scope and kept the patch limited to this alias family.