### PR TITLE
Score camera interface pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const cameraInterfaceAliasPattern =
+  /(^|[_-])(?:MIPI|CSI(?:2)?|CAM(?:ERA)?|MCLK|XCLK|PCLK|VSYNC|HSYNC|PWDN|STROBE)(?:[_-]|$)/i
+
 export const scorePhrase = (phrase: string) => {
+  if (cameraInterfaceAliasPattern.test(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-camera-interface-pin-labels.test.ts
+++ b/tests/test4-camera-interface-pin-labels.test.ts
@@ -1,0 +1,80 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves camera interface aliases in readable netlists", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_camera",
+      name: "CAM1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "IMX219",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_connector",
+      name: "J1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "FFC_22P",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_camera_d0p",
+      source_component_id: "source_component_camera",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["MIPI_CSI_D0P", "pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_connector_d0p",
+      source_component_id: "source_component_connector",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_camera_mclk",
+      source_component_id: "source_component_camera",
+      name: "pin6",
+      pin_number: 6,
+      port_hints: ["CAM_MCLK"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_connector_mclk",
+      source_component_id: "source_component_connector",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["right"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_camera_d0p",
+      connected_source_port_ids: [
+        "source_port_camera_d0p",
+        "source_port_connector_d0p",
+      ],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_camera_mclk",
+      connected_source_port_ids: [
+        "source_port_camera_mclk",
+        "source_port_connector_mclk",
+      ],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: CAM1_MIPI_CSI_D0P")
+  expect(netlist).toContain("  - CAM1 pin14 (+,MIPI_CSI_D0P)")
+  expect(netlist).toContain("NET: CAM1_CAM_MCLK")
+  expect(netlist).toContain("  - CAM1 pin6 (CAM_MCLK)")
+  expect(netlist).not.toContain("NET: CAM1_pos")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for camera/MIPI CSI aliases such as `MIPI_CSI_D0P` and `CAM_MCLK` before the generic digit fallback
- preserve those aliases in generated readable NET names and pin entries instead of falling back to low-information hints like `pos`
- add raw Circuit JSON regression coverage for camera data and clock pins

## Verification
- `npx --yes bun@latest test`
- `npx --yes bun@latest run build`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest x biome check lib/scorePhrase.ts tests/test4-camera-interface-pin-labels.test.ts`
- `git diff --check`

/claim #4

Transparency: AI-assisted with Codex; I reviewed the diff and verification output before opening this PR.