### PR TITLE
[codex] score industrial fieldbus pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,19 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const industrialFieldbusAliasPatterns = [
+  /\bPROFIBUS_?(?:DP|PA|FMS|A|B|TX|RX|DE|RE|RTS|CTS|DATA|P|N)?\d?\b/i,
+  /\bCC_?LINK_?(?:A|B|TX|RX|DATA|P|N)?\d?\b/i,
+  /\bCCLINK_?(?:A|B|TX|RX|DATA|P|N)?\d?\b/i,
+  /\bINTERBUS_?(?:DI|DO|CLK|DATA|TX|RX|P|N)?\d?\b/i,
+  /\bMVB_?(?:A|B|TX|RX|DATA|P|N)\d?\b/i,
+  /\bWTB_?(?:A|B|TX|RX|DATA|P|N)\d?\b/i,
+]
+
 export const scorePhrase = (phrase: string) => {
+  if (industrialFieldbusAliasPatterns.some((pattern) => pattern.test(phrase))) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/industrial-fieldbus-pin-labels.test.tsx
+++ b/tests/industrial-fieldbus-pin-labels.test.tsx
@@ -1,0 +1,39 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores industrial fieldbus pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="FIELDBUS-CTRL"
+        pinLabels={{
+          pin1: ["pin14", "PROFIBUS_A1"],
+          pin2: ["pin15", "CC_LINK_DATA1"],
+          pin3: ["pin16", "MVB_A1"],
+        }}
+      />
+      <resistor resistance="120" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .PROFIBUS_A1" to=".R1 > .pin1" />
+      <trace from=".U1 .CC_LINK_DATA1" to=".R1 > .pin2" />
+      <trace from=".U1 .MVB_A1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_PROFIBUS_A1")
+  expect(netlist).toContain("  - U1 pin14 (PROFIBUS_A1)")
+  expect(netlist).toContain("- pin1(pin14, PROFIBUS_A1): NETS(U1_PROFIBUS_A1)")
+
+  expect(netlist).toContain("NET: U1_CC_LINK_DATA1")
+  expect(netlist).toContain("  - U1 pin15 (CC_LINK_DATA1)")
+
+  expect(netlist).toContain("NET: U1_MVB_A1")
+  expect(netlist).toContain("  - U1 pin16 (MVB_A1)")
+  expect(netlist).toContain("- pin3(pin16, MVB_A1): NETS(U1_MVB_A1)")
+})


### PR DESCRIPTION
## Issue

/claim #4

Part of #4.

## Summary

Adds focused scoring for non-CAN industrial fieldbus aliases such as `PROFIBUS_A1`, `CC_LINK_DATA1`, and `MVB_A1`.

This lets generic physical chip pins like `pin14` keep useful fieldbus signal context in generated net names and readable pin labels, without changing unrelated alias families.

## Acceptance Criteria

- [x] PROFIBUS/CC-Link/MVB-style aliases score above generic numbered pins before the digit fallback
- [x] `PROFIBUS_A1`, `CC_LINK_DATA1`, and `MVB_A1` are preserved in generated `NET:` names
- [x] Readable NET pin entries include the useful fieldbus alias alongside the physical pin label
- [x] Regression coverage added

## Verification

- `npx.cmd --yes bun@latest test tests/industrial-fieldbus-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/industrial-fieldbus-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the scope and kept the patch limited to this alias family.