### PR TITLE
[codex] score motion network pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const motionNetworkAliasPatterns = [
+  /\bSERCOS_?(?:III|TX|RX|DATA|P|N|CLK|SYNC)?\d?\b/i,
+  /\bMECHATROLINK_?(?:I|II|III|TX|RX|DATA|P|N|SYNC)?\d?\b/i,
+  /\bPOWERLINK_?(?:TX|RX|DATA|P|N|SYNC|MN|CN)?\d?\b/i,
+  /\bETHERNET_POWERLINK_?(?:TX|RX|DATA|P|N|SYNC)?\d?\b/i,
+]
+
 export const scorePhrase = (phrase: string) => {
+  if (motionNetworkAliasPatterns.some((pattern) => pattern.test(phrase))) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/motion-network-pin-labels.test.tsx
+++ b/tests/motion-network-pin-labels.test.tsx
@@ -1,0 +1,41 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores industrial motion network pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="MOTION-NET"
+        pinLabels={{
+          pin1: ["pin14", "SERCOS_TX1"],
+          pin2: ["pin15", "MECHATROLINK_DATA1"],
+          pin3: ["pin16", "POWERLINK_SYNC1"],
+        }}
+      />
+      <resistor resistance="100" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .SERCOS_TX1" to=".R1 > .pin1" />
+      <trace from=".U1 .MECHATROLINK_DATA1" to=".R1 > .pin2" />
+      <trace from=".U1 .POWERLINK_SYNC1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_SERCOS_TX1")
+  expect(netlist).toContain("  - U1 pin14 (SERCOS_TX1)")
+  expect(netlist).toContain("- pin1(pin14, SERCOS_TX1): NETS(U1_SERCOS_TX1)")
+
+  expect(netlist).toContain("NET: U1_MECHATROLINK_DATA1")
+  expect(netlist).toContain("  - U1 pin15 (MECHATROLINK_DATA1)")
+
+  expect(netlist).toContain("NET: U1_POWERLINK_SYNC1")
+  expect(netlist).toContain("  - U1 pin16 (POWERLINK_SYNC1)")
+  expect(netlist).toContain(
+    "- pin3(pin16, POWERLINK_SYNC1): NETS(U1_POWERLINK_SYNC1)",
+  )
+})


### PR DESCRIPTION
## Issue

/claim #4

Part of #4.

## Summary

Adds focused scoring for industrial motion-network aliases such as `SERCOS_TX1`, `MECHATROLINK_DATA1`, and `POWERLINK_SYNC1`.

This lets generic physical chip pins like `pin14` keep useful motion-network signal context in generated net names and readable pin labels, without changing unrelated alias families.

## Acceptance Criteria

- [x] SERCOS/MECHATROLINK/POWERLINK aliases score above generic numbered pins before the digit fallback
- [x] `SERCOS_TX1`, `MECHATROLINK_DATA1`, and `POWERLINK_SYNC1` are preserved in generated `NET:` names
- [x] Readable NET pin entries include the useful motion-network alias alongside the physical pin label
- [x] Regression coverage added

## Verification

- `npx.cmd --yes bun@latest test tests/motion-network-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/motion-network-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the scope and kept the patch limited to this alias family.