### PR TITLE
[codex] score substation automation pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const substationAutomationAliasPatterns = [
+  /\bDNP3_?(?:TX|RX|RTS|CTS|DE|RE|DATA|P|N)?\d?\b/i,
+  /\bIEC_?61850_?(?:GOOSE|MMS|SV|SMV|TRIP|PUBLISH|SUBSCRIBE)\d?\b/i,
+  /\bGOOSE_?(?:TX|RX|TRIP|PUBLISH|SUBSCRIBE|DATA)\d?\b/i,
+  /\bSAMPLED_?VALUE_?(?:TX|RX|DATA)?\d?\b/i,
+  /\bSMV_?(?:TX|RX|DATA)\d?\b/i,
+]
+
 export const scorePhrase = (phrase: string) => {
+  if (
+    substationAutomationAliasPatterns.some((pattern) => pattern.test(phrase))
+  ) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/substation-automation-pin-labels.test.tsx
+++ b/tests/substation-automation-pin-labels.test.tsx
@@ -1,0 +1,39 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores substation automation pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="SUBSTATION-CTRL"
+        pinLabels={{
+          pin1: ["pin14", "DNP3_TX1"],
+          pin2: ["pin15", "IEC61850_GOOSE1"],
+          pin3: ["pin16", "GOOSE_TRIP1"],
+        }}
+      />
+      <resistor resistance="100" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .DNP3_TX1" to=".R1 > .pin1" />
+      <trace from=".U1 .IEC61850_GOOSE1" to=".R1 > .pin2" />
+      <trace from=".U1 .GOOSE_TRIP1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_DNP3_TX1")
+  expect(netlist).toContain("  - U1 pin14 (DNP3_TX1)")
+  expect(netlist).toContain("- pin1(pin14, DNP3_TX1): NETS(U1_DNP3_TX1)")
+
+  expect(netlist).toContain("NET: U1_IEC61850_GOOSE1")
+  expect(netlist).toContain("  - U1 pin15 (IEC61850_GOOSE1)")
+
+  expect(netlist).toContain("NET: U1_GOOSE_TRIP1")
+  expect(netlist).toContain("  - U1 pin16 (GOOSE_TRIP1)")
+  expect(netlist).toContain("- pin3(pin16, GOOSE_TRIP1): NETS(U1_GOOSE_TRIP1)")
+})


### PR DESCRIPTION
## Issue

/claim #4

Part of #4.

## Summary

Adds focused scoring for substation automation aliases such as `DNP3_TX1`, `IEC61850_GOOSE1`, and `GOOSE_TRIP1`.

This lets generic physical chip pins like `pin14` keep useful substation-protocol signal context in generated net names and readable pin labels, without changing unrelated alias families.

## Acceptance Criteria

- [x] DNP3/IEC 61850/GOOSE aliases score above generic numbered pins before the digit fallback
- [x] `DNP3_TX1`, `IEC61850_GOOSE1`, and `GOOSE_TRIP1` are preserved in generated `NET:` names
- [x] Readable NET pin entries include the useful substation alias alongside the physical pin label
- [x] Regression coverage added

## Verification

- `npx.cmd --yes bun@latest test tests/substation-automation-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest test`
- `npx.cmd --yes bun@latest x biome check lib/scorePhrase.ts tests/substation-automation-pin-labels.test.tsx`
- `npx.cmd --yes bun@latest x tsc --noEmit`
- `npx.cmd --yes bun@latest run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the scope and kept the patch limited to this alias family.