### PR TITLE
[codex] score gate driver pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -8,6 +8,16 @@
  * These unique port names are usually the best indicator of what the net is for
  */
 const wordQualityScore = {
+  DESAT: 1.25,
+  MILLER_CLAMP: 1.25,
+  GATE_HS: 1.25,
+  GATE_LS: 1.25,
+  VBOOT: 1.2,
+  BOOTSTRAP: 1.2,
+  IGBT: 1.2,
+  MOSFET: 1.2,
+  SIC: 1.2,
+  GAN: 1.2,
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
@@ -36,13 +46,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-gate-driver-pin-labels.test.tsx
+++ b/tests/test4-gate-driver-pin-labels.test.tsx
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("prefers isolated gate driver aliases over generic passive polarity hints", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        pinLabels={{
+          pin14: ["DESAT1"],
+          pin15: ["MILLER_CLAMP1"],
+          pin16: ["GATE_HS1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .DESAT1" to=".R1 .pin1" />
+      <trace from=".U1 .MILLER_CLAMP1" to=".R1 .pin2" />
+      <trace from=".U1 .GATE_HS1" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_DESAT1")
+  expect(readableNetlist).toContain("NET: U1_MILLER_CLAMP1")
+  expect(readableNetlist).toContain("NET: U1_GATE_HS1")
+  expect(readableNetlist).not.toContain("NET: R1_pos")
+  expect(readableNetlist).not.toContain("NET: R1_neg")
+  expect(readableNetlist).not.toContain("NET: C1_pos")
+})


### PR DESCRIPTION
/claim #4

## Summary
- Score isolated gate-driver and power-switch protection aliases such as `DESAT1`, `MILLER_CLAMP1`, and `GATE_HS1` as meaningful net-name candidates.
- Check known technical aliases before applying the generic digit-bearing fallback, so these labels do not lose to low-information passive hints like `pos` or `neg`.
- Add regression coverage for gate-driver aliases connected through passives.

## Verification
- `npx bun test`
- `npx biome check .`
- `npx tsc --noEmit`
- `npx bun run build`
- `git diff --check`
