### PR TITLE
Score gate driver pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,33 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const gateDriverAliasPatterns = [
+  /^DESAT(?:_|$|\d)/,
+  /^MILLER_CLAMP(?:_|$|\d)/,
+  /^MILLER(?:_|$|\d)/,
+  /^GATE_HS(?:_|$|\d)/,
+  /^GATE_LS(?:_|$|\d)/,
+  /^GATE_HI(?:_|$|\d)/,
+  /^GATE_LO(?:_|$|\d)/,
+  /^GH(?:_|$|\d)/,
+  /^GL(?:_|$|\d)/,
+  /^HO(?:_|$|\d)/,
+  /^LO(?:_|$|\d)/,
+  /^VBST(?:_|$|\d)/,
+  /^VBOOT(?:_|$|\d)/,
+  /^BOOTSTRAP(?:_|$|\d)/,
+  /^SIC_GATE(?:_|$|\d)/,
+  /^GAN_GATE(?:_|$|\d)/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    gateDriverAliasPatterns.some((pattern) => pattern.test(normalizedPhrase))
+  ) {
+    return 1.15
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/gate-driver-power-switch-pin-labels.test.tsx
+++ b/tests/gate-driver-power-switch-pin-labels.test.tsx
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores isolated gate-driver aliases above generic numbered pins", () => {
+  expect(scorePhrase("DESAT1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("MILLER_CLAMP1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("GATE_HS1")).toBeGreaterThan(1)
+})
+
+it("preserves isolated gate-driver aliases in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="UCC21750"
+        pinLabels={{
+          pin1: ["pin14", "DESAT1"],
+          pin2: ["pin15", "MILLER_CLAMP1"],
+          pin3: ["pin16", "GATE_HS1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="2k" footprint="0402" name="R2" />
+      <resistor resistance="3k" footprint="0402" name="R3" />
+
+      <trace from=".U1 .pin14" to=".R1 > .pin1" />
+      <trace from=".U1 .pin15" to=".R2 > .pin1" />
+      <trace from=".U1 .pin16" to=".R3 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_DESAT1")
+  expect(netlist).toContain("  - U1 pin14 (DESAT1)")
+  expect(netlist).toContain("NET: U1_MILLER_CLAMP1")
+  expect(netlist).toContain("  - U1 pin15 (MILLER_CLAMP1)")
+  expect(netlist).toContain("NET: U1_GATE_HS1")
+  expect(netlist).toContain("  - U1 pin16 (GATE_HS1)")
+})


### PR DESCRIPTION
Summary
- Score focused isolated gate-driver / power-switch aliases (DESAT, MILLER_CLAMP, GATE_HS/GATE_LS, GH/GL, HO/LO, bootstrap, SiC/GaN gate labels) before the generic digit fallback.
- Add regression coverage proving DESAT1, MILLER_CLAMP1, and GATE_HS1 appear in generated NET names and readable pin entries.
- Keep this scoped to scoring plus test coverage, separate from discrete transistor, motor driver, power-management, reset/control, and general numbered-pin fixes.

Verification
- bun test tests/gate-driver-power-switch-pin-labels.test.tsx
- bun test
- bunx tsc --noEmit
- bunx biome check lib/scorePhrase.ts tests/gate-driver-power-switch-pin-labels.test.tsx
- bun run build
- git diff --check

/claim #4

Transparency note: AI-assisted with Codex; I reviewed the diff and verified it locally before submission.