### PR TITLE
Score RF detector pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,18 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const rfDetectorAliasPatterns = [
+  /RSSI/i,
+  /RF_?DET/i,
+  /LOG_?DET/i,
+  /PWR_?DET/i,
+  /POWER_?DET/i,
+]
+
 export const scorePhrase = (phrase: string) => {
+  if (rfDetectorAliasPatterns.some((pattern) => pattern.test(phrase))) {
+    return 1.15
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/rf-detector-pin-labels.test.ts
+++ b/tests/rf-detector-pin-labels.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+test("RF detector aliases win over passive pin labels", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "AD8318",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 10000,
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["RSSI1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_RSSI1")
+  expect(netlist).toContain("  - U1 pin14 (RSSI1)")
+  expect(netlist).not.toContain("NET: R1_pos")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for RF detector / logarithmic detector aliases such as `RSSI1`, `RFDET`, `LOGDET`, and `PWRDET` before the generic digit fallback
- add raw Circuit JSON regression coverage proving `RSSI1` wins over passive endpoint labels in generated NET names and readable pin entries

## Verification
- `bun test tests/rf-detector-pin-labels.test.ts`
- `bun test`
- `bun x tsc --noEmit`
- `bun x biome check lib/scorePhrase.ts tests/rf-detector-pin-labels.test.ts`
- `bun run build`
- `git diff --check`

Refs #4
/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before submission.