### PR TITLE
Score magstripe reader pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isMagstripeReaderAlias = (phrase: string) => {
+  const normalized = phrase.toUpperCase()
+  return /(^|[_-])(MAGSTRIPE|MAG_STRIPE|MSR|MAGTEK|TRACK[123]|TK[123]|F2F|SWIPE)([_-]|$)/.test(
+    normalized,
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isMagstripeReaderAlias(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-magstripe-pin-labels.test.ts
+++ b/tests/test4-magstripe-pin-labels.test.ts
@@ -1,0 +1,75 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves magstripe reader aliases on generic pin labels", () => {
+  const circuitJson: Parameters<typeof convertCircuitJsonToReadableNetlist>[0] =
+    [
+      {
+        type: "source_component",
+        ftype: "simple_chip",
+        source_component_id: "source_component_0",
+        name: "U1",
+        manufacturer_part_number: "MSR-CTRL",
+      },
+      {
+        type: "source_component",
+        ftype: "simple_chip",
+        source_component_id: "source_component_1",
+        name: "J1",
+        manufacturer_part_number: "MAGSTRIPE_HEAD",
+      },
+      {
+        type: "source_port",
+        source_port_id: "source_port_0",
+        source_component_id: "source_component_0",
+        name: "pin14",
+        pin_number: 14,
+        port_hints: ["MSR_TRACK1_DATA"],
+      },
+      {
+        type: "source_port",
+        source_port_id: "source_port_1",
+        source_component_id: "source_component_1",
+        name: "pin1",
+        pin_number: 1,
+        port_hints: ["TRACK1"],
+      },
+      {
+        type: "source_port",
+        source_port_id: "source_port_2",
+        source_component_id: "source_component_0",
+        name: "pin15",
+        pin_number: 15,
+        port_hints: ["MAGSTRIPE_STROBE1"],
+      },
+      {
+        type: "source_port",
+        source_port_id: "source_port_3",
+        source_component_id: "source_component_1",
+        name: "pin2",
+        pin_number: 2,
+        port_hints: ["F2F_DATA"],
+      },
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_0",
+        connected_source_port_ids: ["source_port_0", "source_port_1"],
+        connected_source_net_ids: [],
+      },
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_1",
+        connected_source_port_ids: ["source_port_2", "source_port_3"],
+        connected_source_net_ids: [],
+      },
+    ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_MSR_TRACK1_DATA")
+  expect(readableNetlist).toContain("  - U1 pin14 (MSR_TRACK1_DATA)")
+  expect(readableNetlist).toContain("  - J1 pin1 (TRACK1)")
+  expect(readableNetlist).toContain("NET: U1_MAGSTRIPE_STROBE1")
+  expect(readableNetlist).toContain("  - U1 pin15 (MAGSTRIPE_STROBE1)")
+  expect(readableNetlist).toContain("  - J1 pin2 (F2F_DATA)")
+})


### PR DESCRIPTION
Addresses #4

## Summary
- Add focused scoring for magstripe/MSR reader aliases before the generic digit fallback.
- Cover `MSR_TRACK1_DATA`, `MAGSTRIPE_STROBE1`, `TRACK1`, and `F2F_DATA` with raw Circuit JSON regression coverage so generic physical pins keep useful reader labels in generated NET names and readable pin entries.

## Validation
- `bun test tests/test4-magstripe-pin-labels.test.ts`
- `npx -y bun@1.2.17 test`
- `npx -y node@22 node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npx -y bun@1.2.17 run build`
- `npx -y bun@1.2.17 run format:check`
- `git diff --check`

/claim #4
