### PR TITLE
Score vending payment pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isVendingPaymentAlias = (phrase: string) => {
+  const normalized = phrase.toUpperCase()
+  return /(^|[_-])(MDB|CCTALK|CC_TALK|COIN|BILL|HOPPER|CASHLESS|VEND|VENDING|ESCROW|PAYOUT)([_-]|\d|$)/.test(
+    normalized,
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isVendingPaymentAlias(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-vending-payment-pin-labels.test.ts
+++ b/tests/test4-vending-payment-pin-labels.test.ts
@@ -1,0 +1,75 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves vending payment peripheral aliases on generic pin labels", () => {
+  const circuitJson: Parameters<typeof convertCircuitJsonToReadableNetlist>[0] =
+    [
+      {
+        type: "source_component",
+        ftype: "simple_chip",
+        source_component_id: "source_component_0",
+        name: "U1",
+        manufacturer_part_number: "VEND-CTRL",
+      },
+      {
+        type: "source_component",
+        ftype: "simple_chip",
+        source_component_id: "source_component_1",
+        name: "J1",
+        manufacturer_part_number: "PAYMENT_IO",
+      },
+      {
+        type: "source_port",
+        source_port_id: "source_port_0",
+        source_component_id: "source_component_0",
+        name: "pin14",
+        pin_number: 14,
+        port_hints: ["MDB_TX1"],
+      },
+      {
+        type: "source_port",
+        source_port_id: "source_port_1",
+        source_component_id: "source_component_1",
+        name: "pin1",
+        pin_number: 1,
+        port_hints: ["MDB_BUS"],
+      },
+      {
+        type: "source_port",
+        source_port_id: "source_port_2",
+        source_component_id: "source_component_0",
+        name: "pin15",
+        pin_number: 15,
+        port_hints: ["CCTALK_DATA1"],
+      },
+      {
+        type: "source_port",
+        source_port_id: "source_port_3",
+        source_component_id: "source_component_1",
+        name: "pin2",
+        pin_number: 2,
+        port_hints: ["COIN_PULSE1"],
+      },
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_0",
+        connected_source_port_ids: ["source_port_0", "source_port_1"],
+        connected_source_net_ids: [],
+      },
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_1",
+        connected_source_port_ids: ["source_port_2", "source_port_3"],
+        connected_source_net_ids: [],
+      },
+    ]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_MDB_TX1")
+  expect(readableNetlist).toContain("  - U1 pin14 (MDB_TX1)")
+  expect(readableNetlist).toContain("  - J1 pin1 (MDB_BUS)")
+  expect(readableNetlist).toContain("NET: U1_CCTALK_DATA1")
+  expect(readableNetlist).toContain("  - U1 pin15 (CCTALK_DATA1)")
+  expect(readableNetlist).toContain("  - J1 pin2 (COIN_PULSE1)")
+})


### PR DESCRIPTION
Addresses #4

## Summary
- Add focused scoring for vending/payment peripheral aliases before the generic digit fallback.
- Cover MDB, ccTalk, coin pulse, and vending payment connector labels with raw Circuit JSON regression coverage so generic physical pins keep useful payment-interface names in generated NET names and readable pin entries.

## Validation
- `npx -y bun@1.2.17 test tests/test4-vending-payment-pin-labels.test.ts`
- `npx -y bun@1.2.17 test`
- `npx -y node@22 node_modules/typescript/bin/tsc --noEmit --pretty false`
- `npx -y bun@1.2.17 run build`
- `npx -y bun@1.2.17 run format:check`
- `git diff --check`

/claim #4
