### PR TITLE
Score fingerprint sensor pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -31,11 +31,33 @@ const wordQualityScore = {
   right: 0.3,
 }
 
+const digitBearingWordQualityScore = {
+  FINGERPRINT: 1.35,
+  FINGER_DETECT: 1.35,
+  FINGER_DET: 1.35,
+  FP_IRQ: 1.3,
+  FP_INT: 1.3,
+  IMG_RDY: 1.25,
+  IMAGE_READY: 1.25,
+}
+
 const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = Object.entries(
+  digitBearingWordQualityScore,
+).sort((a, b) => b[1] - a[1])
+
 export const scorePhrase = (phrase: string) => {
+  const upperPhrase = phrase.toUpperCase()
+
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (upperPhrase.includes(word)) {
+      return score
+    }
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/fingerprint-pin-labels.test.tsx
+++ b/tests/fingerprint-pin-labels.test.tsx
@@ -1,0 +1,41 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores digit-bearing fingerprint sensor pin aliases", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="FPM10A"
+        pinLabels={{
+          pin1: ["VCC"],
+          pin2: ["GND"],
+          pin3: ["FINGER_DETECT1"],
+          pin4: ["FP_IRQ1"],
+          pin5: ["IMG_RDY1"],
+          pin6: ["UART_TX"],
+          pin7: ["UART_RX"],
+          pin8: ["RST"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+      <resistor resistance="10k" footprint="0402" name="R3" />
+
+      <trace from=".U1 .FINGER_DETECT1" to=".R1 > .pin1" />
+      <trace from=".U1 .FP_IRQ1" to=".R2 > .pin1" />
+      <trace from=".U1 .IMG_RDY1" to=".R3 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_FINGER_DETECT1")
+  expect(netlist).toContain("NET: U1_FP_IRQ1")
+  expect(netlist).toContain("NET: U1_IMG_RDY1")
+  expect(netlist).toContain("- U1 FINGER_DETECT1")
+  expect(netlist).toContain("- U1 FP_IRQ1")
+  expect(netlist).toContain("- U1 IMG_RDY1")
+})


### PR DESCRIPTION
## Summary
- add a small digit-bearing alias score table for fingerprint / biometric sensor labels
- preserve useful labels such as FINGER_DETECT1, FP_IRQ1, and IMG_RDY1 in generated net names and readable pin entries
- add focused regression coverage for fingerprint sensor aliases

## Proof
- bun test
- bun run build
- bunx tsc --noEmit
- git diff --check

## Scope note
I searched existing PRs/issues for fingerprint and biometric label slices before opening this. This is separate from the existing security, NFC/RFID, keypad, optical, barcode, and generic digit-label PRs.

/claim #4