### PR TITLE
Guard missing source net names in net generation

### DIFF
--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -61,6 +61,7 @@ export const generateNetName = ({
       ),
     )
     .concat(nets.map((n) => n.name))
+    .filter((name): name is string => typeof name === "string")
 
   const phrases = possibleNames.map((name) => ({
     name,

--- a/tests/test4-missing-source-net-name.test.ts
+++ b/tests/test4-missing-source-net-name.test.ts
@@ -1,0 +1,52 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("ignores source nets with missing names while generating readable net names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_chip",
+      name: "U1",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "1k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["SCL"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_1",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: ["source_net_1"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(() => convertCircuitJsonToReadableNetlist(circuitJson)).not.toThrow()
+  expect(convertCircuitJsonToReadableNetlist(circuitJson)).toContain(
+    "NET: U1_SCL",
+  )
+})


### PR DESCRIPTION
## Summary
- ignore non-string `source_net.name` candidates while generating fallback readable net names
- add a raw Circuit JSON regression test for a connected source net whose name is missing
- keep this scoped away from blank-name trimming, source-port fallback labels, and alias scoring PRs

## Validation
- `npx -y bun@1.2.17 test tests/test4-missing-source-net-name.test.ts`
- `npx -y bun@1.2.17 test`
- `npx -y tsc --noEmit`
- `npx -y bun@1.2.17 run build`
- `npx -y @biomejs/biome@1.9.4 check lib/generateNetName.ts tests/test4-missing-source-net-name.test.ts`
- `git diff --check`

## Duplicate check
- Reviewed issue #4 latest comments and open PRs before patching. Recent open work covers generic pin aliases, blank/whitespace source-net labels, missing source-port fallbacks, custom source-port ids, component metadata, and many alias-family scoring slices.
- I did not find an open PR specifically for the current-main crash from a missing/non-string `source_net.name` being passed into `scorePhrase` during generated net naming.

/claim #4

AI-assisted with Codex but manually reviewed.