### PR TITLE
Add thermal printer pin label scoring

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -29,6 +29,13 @@ const wordQualityScore = {
   pin: 0.5,
   left: 0.3,
   right: 0.3,
+  PAPER: 1.2,
+  PAPER_OUT: 1.2,
+  HEAD_STB: 1.2,
+  CUTTER: 1.2,
+  CUTTER_HOME: 1.2,
+  PRINTER: 1.15,
+  THERMAL: 1.15,
 }
 
 const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
@@ -36,13 +43,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/thermal-printer-pin-labels.test.tsx
+++ b/tests/thermal-printer-pin-labels.test.tsx
@@ -1,0 +1,80 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves thermal printer controller pin aliases", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="THERMAL-PRINTER-CTRL"
+        pinLabels={{
+          pin1: ["pin14", "PAPER_OUT1"],
+          pin2: ["pin15", "HEAD_STB1"],
+          pin3: ["pin16", "CUTTER_HOME1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+
+      <trace from=".U1 .pin14" to=".R1 .pin1" />
+      <trace from=".U1 .pin15" to=".R2 .pin1" />
+      <trace from=".U1 .pin16" to=".R3 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: THERMAL-PRINTER-CTRL, soic8
+     - R1: 1kΩ 0402 resistor
+     - R2: 1kΩ 0402 resistor
+     - R3: 1kΩ 0402 resistor
+
+    NET: U1_PAPER_OUT1
+      - U1 pin14 (PAPER_OUT1)
+      - R1 pin1
+
+    NET: U1_HEAD_STB1
+      - U1 pin15 (HEAD_STB1)
+      - R2 pin1
+
+    NET: U1_CUTTER_HOME1
+      - U1 pin16 (CUTTER_HOME1)
+      - R3 pin1
+
+
+    COMPONENT_PINS:
+    U1 (THERMAL-PRINTER-CTRL)
+    - pin1(pin14, PAPER_OUT1): NETS(U1_PAPER_OUT1)
+    - pin2(pin15, HEAD_STB1): NETS(U1_HEAD_STB1)
+    - pin3(pin16, CUTTER_HOME1): NETS(U1_CUTTER_HOME1)
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_PAPER_OUT1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R2 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_HEAD_STB1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R3 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_CUTTER_HOME1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

Contributes to #4

Summary:
- score thermal/receipt-printer pin aliases before the generic digit fallback
- preserve PAPER_OUT1, HEAD_STB1, and CUTTER_HOME1 in readable net names and pin output
- add a regression test covering a thermal printer controller pin-label slice

Demo:
https://github.com/digzrow-coder/circuit-json-to-readable-netlist/releases/download/pr-433-demo-v2-20260515/pr-433-thermal-printer-netlist-demo-v2.mp4

Tests:
- bun test tests/thermal-printer-pin-labels.test.tsx
- bun test
- bun x tsc --noEmit
- bun x biome check lib/scorePhrase.ts tests/thermal-printer-pin-labels.test.tsx
- bun run build
- git diff --check

Claim refresh: /claim #4

AI-assisted with OpenAI Codex; I reviewed the diff, reran the focused/full tests, and verified the demo video before posting.
