### PR TITLE
Fix readable labels for generic chip pins

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -7,7 +7,11 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
-import { getReadableNameForPin } from "./getReadableNameForPin"
+import {
+  getBestReadablePinLabel,
+  getReadableNameForPin,
+  getReadablePinAliases,
+} from "./getReadableNameForPin"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -145,9 +149,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }
@@ -156,18 +166,9 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
-        const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
-        for (const hint of port.port_hints ?? []) {
-          if (hint === String(port.pin_number)) continue
-          if (hint !== mainPin && hint !== port.name) aliases.push(hint)
-        }
-        const aliasPart =
-          aliases.length > 0
-            ? `(${Array.from(new Set(aliases)).join(", ")})`
-            : ""
+        const mainPin = getBestReadablePinLabel(port)
+        const aliases = getReadablePinAliases(port, mainPin)
+        const aliasPart = aliases.length > 0 ? `(${aliases.join(", ")})` : ""
         const nets = portIdToNetNames[port.source_port_id] ?? []
         const netsPart =
           nets.length > 0 ? `NETS(${nets.join(", ")})` : "NOT_CONNECTED"

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,48 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinName = (name?: string) => /^pin\d+$/i.test(name ?? "")
+
+const isPinNumberHint = (hint: string, port: SourcePort) =>
+  port.pin_number !== undefined && hint === String(port.pin_number)
+
+const uniqueLabels = (labels: string[]) => Array.from(new Set(labels))
+
+export const getBestReadablePinLabel = (port: SourcePort): string => {
+  const fallback =
+    port.name || (port.pin_number !== undefined ? `pin${port.pin_number}` : "")
+
+  if (port.name && !isGenericPinName(port.name)) return port.name
+
+  const bestHint = (port.port_hints ?? []).find(
+    (hint) =>
+      !isGenericPinName(hint) &&
+      !isPinNumberHint(hint, port) &&
+      scorePhrase(hint) >= 1,
+  )
+
+  return bestHint ?? fallback
+}
+
+export const getReadablePinAliases = (port: SourcePort, mainPin: string) => {
+  const aliases: string[] = []
+  const numberedPin =
+    port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+  const addAlias = (label?: string) => {
+    if (!label || label === mainPin) return
+    aliases.push(label)
+  }
+
+  addAlias(numberedPin)
+  addAlias(port.name)
+  for (const hint of port.port_hints ?? []) {
+    if (isPinNumberHint(hint, port)) continue
+    addAlias(hint)
+  }
+
+  return uniqueLabels(aliases)
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +76,7 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = getBestReadablePinLabel(port)
 
   const additionalPinLabels: string[] = []
 
@@ -44,10 +86,15 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
+  if (port.name && isGenericPinName(port.name) && port.name !== mainPinName) {
+    additionalPinLabels.push(port.name)
+  }
+
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (isPinNumberHint(port_hint, port)) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score >= 1) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/^pin\d+$/i)) {
+    return 0.5
+  }
+  if (phrase.match(/^\d+$/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)

--- a/tests/test4-generic-chip-pin-labels.test.ts
+++ b/tests/test4-generic-chip-pin-labels.test.ts
@@ -1,0 +1,50 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("prefers descriptive pin hints over generic pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "PICO-W",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GPIO1", "MATRIX_COL_3"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("U1 GPIO1 (pin14,MATRIX_COL_3)")
+  expect(netlist).toContain("- GPIO1(pin14, MATRIX_COL_3):")
+})


### PR DESCRIPTION
Fixes #4.
/claim #4

Summary:
- Prefer descriptive source port hints over generic `pinN` labels for chip pins.
- Keep `pinN` and other useful hints as aliases.
- Avoid `undefined` in resistor/capacitor component headers when footprints are missing.
- Add direct regression coverage for a `pin14`/`GPIO1` chip port.

Tests:
- `npx.cmd bun test tests\test4-generic-chip-pin-labels.test.ts`
- `npx.cmd tsc --noEmit`
- `npx.cmd biome check lib\convertCircuitJsonToReadableNetlist.ts lib\getReadableNameForPin.ts lib\scorePhrase.ts tests\test2-chip.test.tsx tests\test4-generic-chip-pin-labels.test.ts`
- GitHub Actions: Format Check, Dependency Check, Type Check, and Bun Test passed.