### PR TITLE
Fix scoring for digit-bearing pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -16,6 +16,8 @@ const wordQualityScore = {
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  PWM: 1.1,
+  ADC: 1.1,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +38,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -87,3 +87,59 @@ it("test2 chip", () => {
     "
   `)
 })
+
+it("keeps digit-bearing descriptive pin labels readable", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U2"
+        footprint="soic16"
+        manufacturerPartNumber="RP2040"
+        pinLabels={{
+          pin14: ["GPIO17"],
+          pin15: ["GPIO18"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U2 .GPIO17" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U2: RP2040, soic16
+     - R2: 10kΩ 0402 resistor
+
+    NET: U2_GPIO17
+      - U2 GPIO17
+      - R2 pin1
+
+
+    COMPONENT_PINS:
+    U2 (RP2040)
+    - pin1: NOT_CONNECTED
+    - pin2: NOT_CONNECTED
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+    - pin9: NOT_CONNECTED
+    - pin10: NOT_CONNECTED
+    - pin11: NOT_CONNECTED
+    - pin12: NOT_CONNECTED
+    - pin13: NOT_CONNECTED
+    - pin14(GPIO17): NETS(U2_GPIO17)
+    - pin15(GPIO18): NOT_CONNECTED
+    - pin16: NOT_CONNECTED
+
+    R2 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U2_GPIO17)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
Relates to #4.

## Summary
- Score known semantic pin-label words before applying the digit fallback.
- Preserve digit-bearing labels such as GPIO17, PWM2, and ADC3 as readable labels.
- Add regression coverage for a pin14/GPIO17 case.

## Testing
- bun test
- bun run format:check
- bun run build
- git diff --check