### PR TITLE
Score ham radio pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,19 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const focusedTechnicalLabelScores: Array<[RegExp, number]> = [
+  [
+    /(^|_)(PTT|SQUELCH|SQL|CW|MORSE|APRS|RIG|TXEN|RXEN|KEYER|KEY)(?=\d|_|$)/i,
+    1.18,
+  ],
+]
+
 export const scorePhrase = (phrase: string) => {
+  for (const [pattern, score] of focusedTechnicalLabelScores) {
+    if (pattern.test(phrase)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/ham-radio-pin-labels.test.tsx
+++ b/tests/ham-radio-pin-labels.test.tsx
@@ -1,0 +1,35 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves ham radio control aliases on generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        pinLabels={{
+          pin1: ["pin14", "PTT_OUT1"],
+          pin2: ["pin15", "SQUELCH1"],
+          pin3: ["pin16", "CW_KEY1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+
+      <trace from=".U1 .PTT_OUT1" to=".R1 .pin1" />
+      <trace from=".U1 .SQUELCH1" to=".R2 .pin1" />
+      <trace from=".U1 .CW_KEY1" to=".R3 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_PTT_OUT1")
+  expect(netlist).toContain("NET: U1_SQUELCH1")
+  expect(netlist).toContain("NET: U1_CW_KEY1")
+  expect(netlist).toContain("U1 pin14 (PTT_OUT1)")
+  expect(netlist).toContain("U1 pin15 (SQUELCH1)")
+  expect(netlist).toContain("U1 pin16 (CW_KEY1)")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for ham-radio / transceiver control aliases such as `PTT_OUT1`, `SQUELCH1`, and `CW_KEY1` before the generic digit fallback
- add regression coverage proving those aliases are preserved in generated NET names and readable pin entries on generic chip pins

## Verification
- `bun x biome check lib/scorePhrase.ts tests/ham-radio-pin-labels.test.tsx --write`
- `bun test tests/ham-radio-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #4