### PR TITLE
Fix numeric pin labels in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-pin-labels.test.ts
+++ b/tests/test4-pin-labels.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("includes numeric signal labels for generic pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GPIO14", "pin14", "14"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (GPIO14)")
+})


### PR DESCRIPTION
Fixes #4

## Summary
- Preserve numeric signal labels such as GPIO14 when a source port's main name is generic, e.g. pin14.
- Score known signal words before applying the generic digit penalty.
- Add regression coverage for pin14 rendering as pin14 (GPIO14).

## Verification
- npx --yes bun test
- npx --yes bun run format:check
- npx --yes bun run build

/claim #4