### PR TITLE
Fix readable labels for generic pins

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,9 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const joinPresent = (...values: Array<string | undefined>) =>
+  values.filter(Boolean).join(" ")
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -145,9 +148,9 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${joinPresent(component.display_resistance, footprint)})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${joinPresent(component.display_capacitance, footprint)})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,16 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinLabel = (label: string) => /^pin\d+$/i.test(label)
+
+const hasLettersAndNumbers = (hint: string) =>
+  /[a-z]/i.test(hint) && /\d/.test(hint)
+
+const isMeaningfulPinHint = (hint: string, score: number) =>
+  !isGenericPinLabel(hint) &&
+  !/^\d+$/.test(hint) &&
+  (score >= 1 || hasLettersAndNumbers(hint))
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -35,6 +45,7 @@ export const getReadableNameForPin = ({
 
   // Format pin description
   const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinNameIsGeneric = isGenericPinLabel(mainPinName)
 
   const additionalPinLabels: string[] = []
 
@@ -47,7 +58,10 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (
+      score > 1 ||
+      (mainPinNameIsGeneric && isMeaningfulPinHint(port_hint, score))
+    ) {
       additionalPinLabels.push(port_hint)
     }
   }
@@ -55,5 +69,6 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  const uniquePinLabels = Array.from(new Set(additionalPinLabels))
+  return `${component.name} ${mainPinName}${uniquePinLabels.length > 0 ? ` (${uniquePinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/tests/test4-generic-pin-labels.test.ts
+++ b/tests/test4-generic-pin-labels.test.ts
@@ -1,0 +1,71 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("includes meaningful labels for generic pin names", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "14", "GP12", "SPI0_SCK"],
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "1kΩ",
+      resistance: 1000,
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: 
+     - R1: 1kΩ resistor
+
+    NET: R1_pos
+      - U1 pin14 (GP12,SPI0_SCK)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1
+    - pin14(GP12, SPI0_SCK): NETS(R1_pos)
+
+    R1 (1kΩ)
+    - pin1(anode, pos, left): NETS(R1_pos)
+    "
+  `)
+})


### PR DESCRIPTION
Fixes #4

/claim #4

## Summary
- include meaningful aliases like GP12 and SPI0_SCK when a source port only exposes a generic pin name such as pin14
- avoid duplicate pin aliases in readable pin labels
- omit missing footprint values from component pin headers instead of printing undefined

## Test plan
- bun test
- bun run format:check