### PR TITLE
fix: resolve undefined values and improve pin labels in readable netlist

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "circuit-json-to-readable-netlist",

--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -36,11 +36,11 @@ export const convertCircuitJsonToReadableNetlist = (
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
+      componentDescription = `${component.display_resistance ?? "?"}${
         footprint ? ` ${footprint}` : ""
       } resistor`
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
+      componentDescription = `${component.display_capacitance ?? "?"}${
         footprint ? ` ${footprint}` : ""
       } capacitor`
     } else if (component.ftype === "simple_chip") {
@@ -145,9 +145,9 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${component.display_resistance ?? "?"} ${footprint ?? ""})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${component.display_capacitance ?? "?"} ${footprint ?? ""})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }
@@ -157,7 +157,7 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.name ?? (port.pin_number !== undefined ? `pin${port.pin_number}` : "?")
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -60,14 +60,14 @@ export const generateNetName = ({
         new Set([...(p.name ? [p.name] : []), ...(p.port_hints ?? [])]),
       ),
     )
-    .concat(nets.map((n) => n.name))
+    .concat(nets.flatMap((n) => (n.name ? [n.name] : [])))
 
   const phrases = possibleNames.map((name) => ({
     name,
     score: scorePhrase(name),
   }))
 
-  const bestPortName = phrases.sort((a, b) => b.score - a.score)[0].name
+  const bestPortName = phrases.sort((a, b) => b.score - a.score)[0]?.name ?? "Net"
 
   // Find the component that has the best port name
   const bestPort = ports.find(

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -34,7 +34,7 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = port.name ? port.name : `pin${port.pin_number}`
 
   const additionalPinLabels: string[] = []
 

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(SCL, pin3): NETS(GND)
+    - GPIO2(SDA, pin4): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(UART_TX, pin6): NOT_CONNECTED
+    - GPIO5(UART_RX, pin7): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)


### PR DESCRIPTION
## Summary

Fixes undefined values appearing in readable netlists and improves pin label formatting.

## Changes

1. **Fix undefined values** — Handle missing `display_resistance`, `display_capacitance`, and `footprint` with `??` operator instead of stringifying `undefined`
2. **Fix undefined net names** — Filter out undefined entries from `nets.map(n => n.name)`
3. **Fix crash on empty possibleNames** — Use optional chaining `phrases[0]?.name` with fallback
4. **Improve pin labels** — Prefer `port.name` over pin number, only fall back to `pin{N}` when no name exists
5. **Consistent casing** — Use lowercase `pin` prefix everywhere

## Test Plan

- [x] All 3 existing tests pass (snapshots updated)

Fixes #4

/claim #4