### PR TITLE
Prefer readable labels for generic pins

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -161,7 +161,10 @@ export const convertCircuitJsonToReadableNetlist = (
       for (const port of ports) {
         const fallbackPin =
           port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
-        const mainPin = getReadableMainPinName(port) ?? fallbackPin
+        const mainPin =
+          getReadableMainPinName(port, {
+            preferPortHints: component.ftype === "simple_chip",
+          }) ?? fallbackPin
         const aliases: string[] = []
         if (fallbackPin && fallbackPin !== mainPin) aliases.push(fallbackPin)
         if (port.name && port.name !== mainPin) aliases.push(port.name)

--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -7,7 +7,10 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
-import { getReadableNameForPin } from "./getReadableNameForPin"
+import {
+  getReadableMainPinName,
+  getReadableNameForPin,
+} from "./getReadableNameForPin"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -156,9 +159,11 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
+        const fallbackPin =
           port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const mainPin = getReadableMainPinName(port) ?? fallbackPin
         const aliases: string[] = []
+        if (fallbackPin && fallbackPin !== mainPin) aliases.push(fallbackPin)
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -11,7 +11,9 @@ const isGenericPinName = (name?: string) => /^pin\d+$/i.test(name ?? "")
 
 export const getReadableMainPinName = (
   port: SourcePort,
+  options?: { preferPortHints?: boolean },
 ): string | undefined => {
+  if (!options?.preferPortHints) return port.name
   if (!isGenericPinName(port.name)) return port.name
 
   const bestHint = (port.port_hints ?? []).filter(
@@ -49,7 +51,10 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = getReadableMainPinName(port) ?? `Pin${port.pin_number}`
+  const mainPinName =
+    getReadableMainPinName(port, {
+      preferPortHints: component.ftype === "simple_chip",
+    }) ?? `Pin${port.pin_number}`
 
   const additionalPinLabels: string[] = []
 

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,21 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinName = (name?: string) => /^pin\d+$/i.test(name ?? "")
+
+export const getReadableMainPinName = (
+  port: SourcePort,
+): string | undefined => {
+  if (!isGenericPinName(port.name)) return port.name
+
+  const bestHint = (port.port_hints ?? []).filter(
+    (hint) =>
+      hint !== port.name && !/^\d+$/.test(hint) && !isGenericPinName(hint),
+  )[0]
+
+  return bestHint ?? port.name
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +49,7 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = getReadableMainPinName(port) ?? `Pin${port.pin_number}`
 
   const additionalPinLabels: string[] = []
 

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)

--- a/tests/test4-generic-pin-labels.test.ts
+++ b/tests/test4-generic-pin-labels.test.ts
@@ -1,0 +1,15 @@
+import { expect, it } from "bun:test"
+import { getReadableMainPinName } from "lib/getReadableNameForPin"
+
+it("prefers useful pin hints over generic pin names", () => {
+  expect(
+    getReadableMainPinName({
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "GPIO16", "UART_RX"],
+    }),
+  ).toBe("GPIO16")
+})

--- a/tests/test4-generic-pin-labels.test.ts
+++ b/tests/test4-generic-pin-labels.test.ts
@@ -3,13 +3,16 @@ import { getReadableMainPinName } from "lib/getReadableNameForPin"
 
 it("prefers useful pin hints over generic pin names", () => {
   expect(
-    getReadableMainPinName({
-      type: "source_port",
-      source_port_id: "source_port_1",
-      source_component_id: "source_component_1",
-      name: "pin14",
-      pin_number: 14,
-      port_hints: ["14", "GPIO16", "UART_RX"],
-    }),
+    getReadableMainPinName(
+      {
+        type: "source_port",
+        source_port_id: "source_port_1",
+        source_component_id: "source_component_1",
+        name: "pin14",
+        pin_number: 14,
+        port_hints: ["14", "GPIO16", "UART_RX"],
+      },
+      { preferPortHints: true },
+    ),
   ).toBe("GPIO16")
 })


### PR DESCRIPTION
## Summary
- prefer meaningful source port hints when a port name is only a generic `pinN`
- keep the original `pinN` value as an alias in the component pin list
- add a focused regression test for generic chip pin labels

## Verification
- `npm run build`
- `npx tsc --noEmit`

Bun is not installed in this local environment, so I could not run `bun test` here.

Fixes #4