### PR TITLE
Fix readable chip pin hints that contain digits

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,10 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const joinComponentDetails = (
+  ...parts: Array<string | number | undefined>
+): string => parts.filter(Boolean).join(" ")
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -36,13 +40,15 @@ export const convertCircuitJsonToReadableNetlist = (
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
+      componentDescription = `${joinComponentDetails(
+        component.display_resistance,
+        footprint,
+      )} resistor`.trim()
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
+      componentDescription = `${joinComponentDetails(
+        component.display_capacitance,
+        footprint,
+      )} capacitor`.trim()
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -145,9 +151,17 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = joinComponentDetails(
+          component.display_resistance,
+          footprint,
+        )
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = joinComponentDetails(
+          component.display_capacitance,
+          footprint,
+        )
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,11 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinHint = (hint: string, pinNumber?: number): boolean => {
+  if (hint === String(pinNumber)) return true
+  return /^pin\d+$/i.test(hint)
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -46,6 +51,11 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (isGenericPinHint(port_hint, port.pin_number)) continue
+    if (component.ftype === "simple_chip") {
+      additionalPinLabels.push(port_hint)
+      continue
+    }
     const score = scorePhrase(port_hint)
     if (score > 1) {
       additionalPinLabels.push(port_hint)
@@ -55,5 +65,6 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  const uniqueAdditionalPinLabels = Array.from(new Set(additionalPinLabels))
+  return `${component.name} ${mainPinName}${uniqueAdditionalPinLabels.length > 0 ? ` (${uniqueAdditionalPinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/tests/test4-readable-pin-hints.test.ts
+++ b/tests/test4-readable-pin-hints.test.ts
@@ -1,0 +1,30 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("includes useful chip pin hints that contain digits", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "PICO_W",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_13",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GP10_SPI1SCK_I2C1SDA", "pin14", "14"],
+      source_component_id: "source_component_0",
+    },
+  ]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_13",
+    }),
+  ).toBe("U1 pin14 (GP10_SPI1SCK_I2C1SDA)")
+})

--- a/tests/test4-readable-pin-hints.test.ts
+++ b/tests/test4-readable-pin-hints.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "bun:test"
 import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
 import { getReadableNameForPin } from "lib/getReadableNameForPin"
 
 it("includes useful chip pin hints that contain digits", () => {
@@ -27,4 +28,50 @@ it("includes useful chip pin hints that contain digits", () => {
       source_port_id: "source_port_13",
     }),
   ).toBe("U1 pin14 (GP10_SPI1SCK_I2C1SDA)")
+})
+
+it("renders useful digit-containing chip pin hints in readable netlists", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "PICO_W",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_13",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GP10_SPI1SCK_I2C1SDA", "pin14", "14"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_13", "source_port_r1_1"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  expect(convertCircuitJsonToReadableNetlist(circuitJson)).toContain(
+    "U1 pin14 (GP10_SPI1SCK_I2C1SDA)",
+  )
 })

--- a/tests/test4-readable-pin-hints.test.ts
+++ b/tests/test4-readable-pin-hints.test.ts
@@ -71,7 +71,8 @@ it("renders useful digit-containing chip pin hints in readable netlists", () => 
     },
   ]
 
-  expect(convertCircuitJsonToReadableNetlist(circuitJson)).toContain(
-    "U1 pin14 (GP10_SPI1SCK_I2C1SDA)",
-  )
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("U1 pin14 (GP10_SPI1SCK_I2C1SDA)")
+  expect(netlist).not.toContain("undefined")
 })


### PR DESCRIPTION
Fixes #4

## Summary
- Preserve useful `simple_chip` pin hints even when the hint contains digits, such as `GP10_SPI1SCK_I2C1SDA`.
- Filter generic numeric pin aliases like `pin14` and `14` from the extra label list.
- Deduplicate additional labels before rendering.
- Omit missing passive component details instead of rendering `undefined`, e.g. `R1 (1k)` instead of `R1 (1k undefined)` when a footprint is unavailable.
- Add regression coverage for both `getReadableNameForPin` and the full readable netlist output so the original symptoms stay covered.

## Test plan
- `bun test` (5 pass)
- `tsc --noEmit`
- `biome check lib/convertCircuitJsonToReadableNetlist.ts lib/getReadableNameForPin.ts tests/test4-readable-pin-hints.test.ts`
- `tsup ./lib/index.ts --format esm --dts`

Regression checks:
- The pin-label test fails on the unmodified baseline with `Received: "U1 pin14"`.
- The netlist regression also fails before the passive-detail fix with `R1 (1k undefined)`, and passes after this change.

/claim #4