### PR TITLE
Score fuel-cell pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const fuelCellAliasPattern =
+  /FUEL_?CELL|HYDROGEN|H2_|STACK_?VOLT|ELECTROLY[ZS]ER|PEMFC/
+
 export const scorePhrase = (phrase: string) => {
+  if (fuelCellAliasPattern.test(phrase.toUpperCase())) {
+    return 1.15
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-fuel-cell-pin-labels.test.ts
+++ b/tests/test4-fuel-cell-pin-labels.test.ts
@@ -1,0 +1,111 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves fuel-cell and hydrogen controller aliases on generic pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      manufacturer_part_number: "H2CTRL",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_1",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["FUEL_CELL1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_2",
+      source_component_id: "source_component_u1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["H2_SENSOR1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_3",
+      source_component_id: "source_component_u1",
+      name: "pin16",
+      pin_number: 16,
+      port_hints: ["STACK_VOLT1"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r1",
+      name: "R1",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r2",
+      name: "R2",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r2_1",
+      source_component_id: "source_component_r2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r3",
+      name: "R3",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r3_1",
+      source_component_id: "source_component_r3",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_u1_1", "source_port_r1_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_u1_2", "source_port_r2_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_3",
+      connected_source_port_ids: ["source_port_u1_3", "source_port_r3_1"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_FUEL_CELL1")
+  expect(readableNetlist).toContain("  - U1 pin14 (FUEL_CELL1)")
+  expect(readableNetlist).toContain("NET: U1_H2_SENSOR1")
+  expect(readableNetlist).toContain("  - U1 pin15 (H2_SENSOR1)")
+  expect(readableNetlist).toContain("NET: U1_STACK_VOLT1")
+  expect(readableNetlist).toContain("  - U1 pin16 (STACK_VOLT1)")
+})


### PR DESCRIPTION
## Summary
- Add focused scoring for fuel-cell and hydrogen-stack aliases before the generic digit fallback.
- Add raw Circuit JSON regression coverage for `FUEL_CELL1`, `H2_SENSOR1`, and `STACK_VOLT1` on generic physical pins.

## Why
Generic pins carrying fuel-cell controller aliases were scored as low-value numeric labels, so readable netlists could prefer passive labels like `pos` and omit useful aliases from NET entries.

## Validation
- `npm_config_cache=/Users/johnchen/Documents/playground/make_5_bucks/.npm-cache npx bun test tests/test4-fuel-cell-pin-labels.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/test4-fuel-cell-pin-labels.test.ts`
- `npm_config_cache=/Users/johnchen/Documents/playground/make_5_bucks/.npm-cache npx bun run build`
- `git diff --check`

Note: full `npx bun test` was attempted locally, but the existing JSX-renderer tests fail in `@tscircuit/core` with `TypeError: Attempting to define property on object that is not extensible`; the focused raw Circuit JSON regression avoids that unrelated renderer path.

/claim #4