### PR TITLE
fix(netlist): omit undefined fields in resistor/capacitor descriptors

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -36,13 +36,17 @@ export const convertCircuitJsonToReadableNetlist = (
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
+      // Filter out undefined fields so a resistor without a stated resistance
+      // doesn't render as "undefined 0402 resistor" (see issue #4).
+      const parts = [component.display_resistance, footprint].filter(Boolean)
+      componentDescription = parts.length
+        ? `${parts.join(" ")} resistor`
+        : "resistor"
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
+      const parts = [component.display_capacitance, footprint].filter(Boolean)
+      componentDescription = parts.length
+        ? `${parts.join(" ")} capacitor`
+        : "capacitor"
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -144,10 +148,18 @@ export const convertCircuitJsonToReadableNetlist = (
       })
       const footprint = cadComponent?.footprinter_string
       let header = component.name
+      // Build the parenthetical descriptor from non-empty fields so a resistor
+      // or capacitor without a value doesn't render "R1 (undefined 0402)".
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const parts = [component.display_resistance, footprint].filter(Boolean)
+        header = parts.length
+          ? `${component.name} (${parts.join(" ")})`
+          : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const parts = [component.display_capacitance, footprint].filter(Boolean)
+        header = parts.length
+          ? `${component.name} (${parts.join(" ")})`
+          : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/tests/test4-no-undefined-on-missing-values.test.tsx
+++ b/tests/test4-no-undefined-on-missing-values.test.tsx
@@ -1,0 +1,40 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+// Regression for issue #4: a resistor or capacitor whose `display_resistance`
+// or `display_capacitance` is missing must not leak the literal string
+// "undefined" into the readable netlist output.
+it("resistor without display_resistance does not output 'undefined'", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "src_R1",
+      name: "R1",
+      ftype: "simple_resistor",
+      // display_resistance intentionally omitted
+    } as any,
+  ]
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+  expect(netlist).not.toContain("undefined")
+})
+
+it("capacitor without display_capacitance does not output 'undefined'", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "src_C1",
+      name: "C1",
+      ftype: "simple_capacitor",
+      // display_capacitance intentionally omitted
+    } as any,
+  ]
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+  expect(netlist).not.toContain("undefined")
+})


### PR DESCRIPTION
## Summary

fix(netlist): omit undefined fields in resistor/capacitor descriptors




## Diff

```
 lib/convertCircuitJsonToReadableNetlist.ts         | 28 ++++++++++-----
 .../test4-no-undefined-on-missing-values.test.tsx  | 40 ++++++++++++++++++++++
 2 files changed, 60 insertions(+), 8 deletions(-)
```

## Claim

/claim #4
