### PR TITLE
Score known digit-bearing pin labels before numeric fallback

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.toLowerCase()
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toLowerCase())) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/score-phrase.test.ts
+++ b/tests/score-phrase.test.ts
@@ -1,0 +1,8 @@
+import { expect, it } from "bun:test"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores known digit-bearing pin labels before the generic digit fallback", () => {
+  expect(scorePhrase("GPIO1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("gpio1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("UART_TX1")).toBeGreaterThan(scorePhrase("pin14"))
+})

--- a/tests/test4-digit-bearing-pin-labels.test.tsx
+++ b/tests/test4-digit-bearing-pin-labels.test.tsx
@@ -1,0 +1,68 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("prefers known digit-bearing chip pin labels over passive aliases", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="MCU"
+        pinLabels={{
+          pin1: ["GPIO1"],
+          pin2: ["UART_TX1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .GPIO1" to=".R1 .pin1" />
+      <trace from=".U1 .UART_TX1" to=".C1 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: MCU, soic8
+     - R1: 1kΩ 0402 resistor
+     - C1: 1nF 0402 capacitor
+
+    NET: U1_GPIO1
+      - U1 GPIO1
+      - R1 pin1
+
+    NET: U1_UART_TX1
+      - U1 UART_TX1
+      - C1 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (MCU)
+    - pin1(GPIO1): NETS(U1_GPIO1)
+    - pin2(UART_TX1): NETS(U1_UART_TX1)
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_GPIO1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    C1 (1nF 0402)
+    - pin1(pos, anode, left): NETS(U1_UART_TX1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- Scores known useful pin-label vocabulary before applying the generic digit-bearing fallback
- Makes the known-word match case-insensitive so labels like `gpio1` still rank as useful
- Adds focused scoring and readable-netlist regressions showing `GPIO1` / `UART_TX1` are preferred over passive aliases like `pos`

/claim #4

## Proof
Before this change, `scorePhrase("GPIO1")` returned the generic digit score `0.5`, so generated net names could prefer lower-information aliases such as `pos`. The new regression proves the generated net names are `U1_GPIO1` and `U1_UART_TX1`.

## Validation
- `bun test`
- `bun run format:check`
- `bun run build`
- `git diff --check`

AI-assisted with OpenAI Codex; I reviewed the diff and local verification before submitting.