### PR TITLE
fix: use full pin labels in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = `${component.name} (${details})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = `${component.name} (${details})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }
@@ -156,17 +162,21 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const pinNumberLabel =
+          port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+        const mainPin = port.name ?? pinNumberLabel ?? "unnamed_pin"
         const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
+        if (pinNumberLabel && pinNumberLabel !== mainPin)
+          aliases.push(pinNumberLabel)
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)
         }
+        const aliasSeparator =
+          pinNumberLabel && pinNumberLabel !== mainPin ? " " : ""
         const aliasPart =
           aliases.length > 0
-            ? `(${Array.from(new Set(aliases)).join(", ")})`
+            ? `${aliasSeparator}(${Array.from(new Set(aliases)).join(", ")})`
             : ""
         const nets = portIdToNetNames[port.source_port_id] ?? []
         const netsPart =

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND (pin1): NETS(GND)
+    - AGND (pin2): NETS(GND)
+    - GPIO1 (pin3, SCL): NETS(GND)
+    - GPIO2 (pin4, SDA): NETS(U1_SDA)
+    - GPIO3 (pin5): NETS(GPIO4)
+    - GPIO4 (pin6, UART_TX): NOT_CONNECTED
+    - GPIO5 (pin7, UART_RX): NOT_CONNECTED
+    - VDD (pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)


### PR DESCRIPTION
## Summary
- Use source port names as the primary label in the COMPONENT_PINS section, keeping pin numbers as aliases
- Keep full alternate pin labels in the output, e.g. `GPIO1 (pin3, SCL)` instead of `pin3(GPIO1, SCL)`
- Avoid emitting `undefined` in resistor/capacitor component headers when footprint data is missing

Closes #4
/claim #4

## Test plan
- `npx --yes bun@latest run format:check`
- `npx --yes bun@latest test`