### PR TITLE
Fix: include full pin label for generic pin names

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,21 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinName = (name: string) => /^pin\d+$/i.test(name)
+
+const hasLettersAndNumbers = (name: string) =>
+  /[a-z]/i.test(name) && /\d/.test(name)
+
+const isSamePinIdentifier = (hint: string, mainPinName: string) => {
+  const normalizedHint = hint.toLowerCase()
+  const normalizedMainPinName = mainPinName.toLowerCase()
+
+  return (
+    normalizedHint === normalizedMainPinName ||
+    normalizedHint === normalizedMainPinName.replace(/^pin/, "")
+  )
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -45,9 +60,12 @@ export const getReadableNameForPin = ({
   }
 
   for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
+    if (isSamePinIdentifier(port_hint, mainPinName)) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (
+      score > 1 ||
+      (isGenericPinName(mainPinName) && hasLettersAndNumbers(port_hint))
+    ) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/test4-generic-pin-labels.test.ts
+++ b/tests/test4-generic-pin-labels.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("includes full pin labels for generic pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "pin14", "GP28_ADC2"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (GP28_ADC2)")
+})


### PR DESCRIPTION
Fixes readable netlist output for generic pin names (e.g. pin14) by including the most informative alphanumeric pin hint (e.g. GP28_ADC2).

Changes:
- Keep alphanumeric hints for generic pin names in getReadableNameForPin
- Add regression test

Fixes #4