### PR TITLE
Fix generic pin labels in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = `${component.name} (${details})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = `${component.name} (${details})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,26 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinLabel = (label: string) => /^pin\d+$/i.test(label)
+
+const isLowInformationPinHint = (hint: string) => {
+  const normalizedHint = hint.toLowerCase()
+  return (
+    /^\d+$/.test(hint) ||
+    isGenericPinLabel(hint) ||
+    [
+      "anode",
+      "cathode",
+      "pos",
+      "neg",
+      "positive",
+      "negative",
+      "left",
+      "right",
+    ].includes(normalizedHint)
+  )
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -47,7 +67,10 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (
+      score > 1 ||
+      (isGenericPinLabel(mainPinName) && !isLowInformationPinHint(port_hint))
+    ) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/test4-generic-pin-labels.test.ts
+++ b/tests/test4-generic-pin-labels.test.ts
@@ -32,6 +32,7 @@ it("includes meaningful labels for generic pin names and omits missing footprint
       source_component_id: "source_component_1",
       ftype: "simple_resistor",
       name: "R1",
+      resistance: 1000,
       display_resistance: "1kΩ",
     },
     {

--- a/tests/test4-generic-pin-labels.test.ts
+++ b/tests/test4-generic-pin-labels.test.ts
@@ -1,0 +1,50 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("includes meaningful labels for generic pin names and omits missing footprint text", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GPIO13", "ADC1_CH4", "pin14", "14"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+      display_name: ".U1 .GPIO13 to .R1 .pin1",
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("  - U1 pin14 (GPIO13,ADC1_CH4)")
+  expect(netlist).not.toContain("undefined")
+})


### PR DESCRIPTION
/claim #4

Fixes #4

## Summary
- Include meaningful port hints for generic pin labels like `pin14` in net entries
- Avoid `undefined` in resistor/capacitor component pin headers when footprint data is absent
- Add regression coverage for generic pin labels and missing footprint text

## Verification
- `bun test`
- `bun run build`
- `bun run format:check`
- `bunx tsc --noEmit`