### PR TITLE
Improve readable component pin names

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -156,9 +156,15 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const pinNumberName =
+          port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+        const readablePortName = port.name && !/^pin\d+$/i.test(port.name)
+        const mainPin = readablePortName
+          ? port.name
+          : (pinNumberName ?? port.name)
         const aliases: string[] = []
+        if (pinNumberName && pinNumberName !== mainPin)
+          aliases.push(pinNumberName)
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue

--- a/tests/test4-readable-component-pin-names.test.tsx
+++ b/tests/test4-readable-component-pin-names.test.tsx
@@ -1,0 +1,60 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses readable chip pin labels before pin numbers in component pins", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "TEST_CHIP",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      pcb_component_id: "pcb_component_0",
+      source_component_id: "source_component_0",
+      footprinter_string: "soic16",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "GPIO12",
+      pin_number: 13,
+      port_hints: ["pin13", "GPIO12"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "GPIO13",
+      pin_number: 14,
+      port_hints: ["pin14", "GPIO13"],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: TEST_CHIP, soic16
+
+
+    COMPONENT_PINS:
+    U1 (TEST_CHIP)
+    - GPIO12(pin13): NOT_CONNECTED
+    - GPIO13(pin14): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
Fixes #4

## Summary
- Prefer readable port names like `GPIO13` over raw pin numbers in the `COMPONENT_PINS` section.
- Preserve the physical pin number as an alias, e.g. `GPIO13(pin14)`.
- Add a regression test using minimal circuit JSON so it does not depend on the renderer fixture.

## Verification
- `npm exec tsc -- --noEmit`
- `npm exec biome -- check .`
- `npm run build`
- `bun test tests/test4-readable-component-pin-names.test.tsx`

Note: the full `bun test` suite still has existing failures in renderer-based tests with `TypeError: Attempting to define property on object that is not extensible`; the new targeted test passes.
