### PR TITLE
Score soil moisture pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,24 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const agricultureSensorWordQualityScore = {
+  SOIL_MOIST: 1.2,
+  TENSIOMETER: 1.2,
+  WATERMARK: 1.2,
+  IRRIG: 1.15,
+  VWC: 1.15,
+}
+
+const agricultureSensorWordQualityScoreEntries = Object.entries(
+  agricultureSensorWordQualityScore,
+).sort((a, b) => b[1] - a[1])
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of agricultureSensorWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/soil-moisture-pin-labels.test.ts
+++ b/tests/soil-moisture-pin-labels.test.ts
@@ -1,0 +1,68 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves soil moisture sensor pin labels", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      manufacturer_part_number: "AGRO_SENSOR_MCU",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u2",
+      name: "U2",
+      manufacturer_part_number: "ADC_FRONTEND",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_soil",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "pos", "SOIL_MOIST1", "VWC1", "TENSIOMETER1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u2_input",
+      source_component_id: "source_component_u2",
+      name: "SENSOR_IN",
+      pin_number: 1,
+      port_hints: ["SENSOR_IN"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_soil",
+      connected_source_port_ids: [
+        "source_port_u1_soil",
+        "source_port_u2_input",
+      ],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+      "COMPONENTS:
+       - U1: AGRO_SENSOR_MCU
+       - U2: ADC_FRONTEND
+
+      NET: U1_SOIL_MOIST1
+        - U1 pin14 (+,SOIL_MOIST1,VWC1,TENSIOMETER1)
+        - U2 SENSOR_IN
+
+
+      COMPONENT_PINS:
+      U1 (AGRO_SENSOR_MCU)
+      - pin14(pos, SOIL_MOIST1, VWC1, TENSIOMETER1): NETS(U1_SOIL_MOIST1)
+
+      U2 (ADC_FRONTEND)
+      - pin1(SENSOR_IN): NETS(U1_SOIL_MOIST1)
+      "
+    `)
+})


### PR DESCRIPTION
## Summary

- add focused scoring for soil-moisture / irrigation sensor aliases before the generic digit fallback
- preserve labels such as `SOIL_MOIST1`, `VWC1`, and `TENSIOMETER1` in generated net names and readable pin entries
- add raw Circuit JSON regression coverage for the agriculture-sensor pin-label slice

Closes #4
/claim #4

## Duplicate-scope check

Searched open PRs for `soil`, `moisture`, `irrigation`, `VWC`, `tensiometer`, and `watermark`; did not find an active matching slice.

## Verification

- `npx bun test tests/soil-moisture-pin-labels.test.ts`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/soil-moisture-pin-labels.test.ts`
- `./node_modules/.bin/tsc --noEmit`
- `npx bun run build`

## Note

- Full `npx bun test` currently fails in existing JSX/renderCircuit tests because the installed `@tscircuit/circuit-json-util` package does not export `distanceBetweenCircleAndPolygon`; the new regression passes.
