### PR TITLE
Prefer readable labels in component pin summaries

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,8 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const isGenericPinName = (name: string) => /^pin\d+$/i.test(name)
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -156,9 +158,16 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
+        const pinNumberName =
+          port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.name && !isGenericPinName(port.name)
+            ? port.name
+            : (pinNumberName ?? port.name ?? port.source_port_id)
         const aliases: string[] = []
+        if (pinNumberName && pinNumberName !== mainPin) {
+          aliases.push(pinNumberName)
+        }
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)


### PR DESCRIPTION
/claim #4

## Summary
- Prefer named chip pin labels in COMPONENT_PINS output instead of using only physical pin numbers as the primary label
- Preserve physical pin numbers as aliases, e.g. GPIO1(pin3, SCL), so the netlist keeps both readable labels and pin identity
- Update the chip snapshot to cover the new output shape

## Verification
- GitHub Actions: dependency-check, format-check, test, and type-check all pass
- Locally checked: npx biome check .
- Locally checked: npx -p typescript@5.6.3 tsc --noEmit
- Locally checked: npm run build after installing the TypeScript peer compiler