### PR TITLE
Score weather station pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -31,11 +31,31 @@ const wordQualityScore = {
   right: 0.3,
 }
 
+const digitBearingWordQualityScore = {
+  ANEMOMETER: 1.15,
+  GUST: 1.15,
+  RAIN: 1.15,
+  VANE: 1.15,
+  WIND: 1.15,
+}
+
 const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = Object.entries(
+  digitBearingWordQualityScore,
+).sort((a, b) => b[1] - a[1])
+
+const containsSignalWord = (phrase: string, word: string) =>
+  new RegExp(`(^|[^A-Za-z])${word}($|[^A-Za-z])`).test(phrase)
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (containsSignalWord(phrase, word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-weather-station-pin-labels.test.ts
+++ b/tests/test4-weather-station-pin-labels.test.ts
@@ -1,0 +1,66 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("keeps weather station pin labels with digits readable", () => {
+  expect(scorePhrase("RAIN_COUNT1")).toBeGreaterThan(1)
+  expect(scorePhrase("WIND_SPEED1")).toBeGreaterThan(1)
+  expect(scorePhrase("WINDOW1")).toBe(0.5)
+
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "WX1000",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      source_component_id: "source_component_0",
+      footprinter_string: "soic16",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "1k",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["RAIN_COUNT1", "pin14", "14"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "anode", "left", "pin1", "1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson as any)
+
+  expect(netlist).toContain("NET: U1_RAIN_COUNT1")
+  expect(netlist).toContain("  - U1 pin14 (RAIN_COUNT1)")
+  expect(netlist).toContain("- pin14(RAIN_COUNT1): NETS(U1_RAIN_COUNT1)")
+})


### PR DESCRIPTION
/claim #4

Summary:
- Adds focused pre-digit scoring for weather-station aliases such as `RAIN_COUNT1` and `WIND_SPEED1`.
- Keeps matching token-aware so unrelated labels such as `WINDOW1` still use the generic digit fallback.
- Adds a regression covering generated readable NET names and pin entries for a generic `pin14` weather-controller label.

Tests:
- `bun test`
- `bunx biome check lib/scorePhrase.ts tests/test4-weather-station-pin-labels.test.ts`
- `git diff --check`
- `bun run build`

AI-assisted with Codex; I reviewed the diff and ran local verification.