### PR TITLE
Fix numbered chip pin labels in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,9 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${[component.display_resistance, footprint].filter(Boolean).join(" ")})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${[component.display_capacitance, footprint].filter(Boolean).join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,16 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isTrivialPinHint = (hint: string, mainPinName: string) => {
+  const normalizedHint = hint.toLowerCase()
+  return (
+    normalizedHint === mainPinName.toLowerCase() ||
+    normalizedHint === mainPinName.replace(/^pin/i, "").toLowerCase() ||
+    /^pin\d+$/i.test(hint) ||
+    /^\d+$/.test(hint)
+  )
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -45,9 +55,9 @@ export const getReadableNameForPin = ({
   }
 
   for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
+    if (isTrivialPinHint(port_hint, mainPinName)) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score > 1 || component.ftype === "simple_chip") {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/test4-numbered-chip-pin-labels.test.ts
+++ b/tests/test4-numbered-chip-pin-labels.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("includes meaningful labels for numbered chip pins", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GP10_SPI1SCK_I2C1SDA", "pin14", "14"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "PICO_W",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1k",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("  - U1 pin14 (GP10_SPI1SCK_I2C1SDA)")
+  expect(netlist).toContain("- pin14(GP10_SPI1SCK_I2C1SDA): NETS(R1_pos)")
+  expect(netlist).toContain("R1 (1k)")
+  expect(netlist).not.toContain("undefined")
+})


### PR DESCRIPTION
## Summary
- include meaningful chip pin hints such as `GP10_SPI1SCK_I2C1SDA` when a port display name is only `pin14`
- omit missing passive footprints from `COMPONENT_PINS` headers instead of rendering `undefined`
- add a regression test for the numbered chip pin case

Fixes #4.
/claim #4

## Bonus fix
This also fixes a related readable-netlist cleanup from the same issue: passive components without footprint metadata no longer render `undefined` in `COMPONENT_PINS` headers. The regression coverage keeps the numbered chip pin label fix and the missing-passive-footprint behavior visible in one focused test.

## Why this is low-risk
- keeps the existing `COMPONENT_PINS` primary label format (`pin14(...)`) instead of rewriting existing snapshots
- does not change `scorePhrase` or add domain-specific alias scoring
- touches only the concrete generic-chip-label path and passive header formatting from the original report
- keeps the patch to 3 files with one focused regression test

## Tests
- `npx --yes bun test`
- `npx --yes biome check .`
- `npx --yes bun run build`

GitHub CI is green for Bun Test, Dependency Check, Format Check, and Type Check.