### PR TITLE
Fix numbered pin label scoring

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -44,7 +44,7 @@ export const scorePhrase = (phrase: string) => {
       return score
     }
   }
-  if (/[a-zA-Z].*\d|\d.*[a-zA-Z]/.test(phrase)) {
+  if (/^GP\d+$/i.test(phrase)) {
     return 1.05
   }
   return 1

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
+  if (/^(?:pin)?\d+$/i.test(phrase)) {
     return 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (/[a-zA-Z].*\d|\d.*[a-zA-Z]/.test(phrase)) {
+    return 1.05
   }
   return 1
 }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,7 +36,7 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (/^(?:pin)?\d+$/i.test(phrase)) {
+  if (/^(?:pin[-_ ]?|p)?\d+$/i.test(phrase)) {
     return 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -47,5 +47,8 @@ export const scorePhrase = (phrase: string) => {
   if (/^GP\d+$/i.test(phrase)) {
     return 1.05
   }
+  if (/^[A-Z]{1,2}\d+$/i.test(phrase)) {
+    return 0.5
+  }
   return 1
 }

--- a/tests/test4-numbered-pin-labels.test.ts
+++ b/tests/test4-numbered-pin-labels.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("keeps useful numbered pin labels for generic pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "GP14", "GPIO14"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    getReadableNameForPin({ circuitJson, source_port_id: "source_port_0" }),
+  ).toBe("U1 pin14 (GP14,GPIO14)")
+})

--- a/tests/test4-numbered-pin-labels.test.ts
+++ b/tests/test4-numbered-pin-labels.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "bun:test"
 import type { AnyCircuitElement } from "circuit-json"
+import { generateNetName } from "lib/generateNetName"
 import { getReadableNameForPin } from "lib/getReadableNameForPin"
 import { scorePhrase } from "lib/scorePhrase"
 
@@ -8,9 +9,36 @@ it("scores useful GPIO-style numbered labels without promoting generic coordinat
   expect(scorePhrase("pin14")).toBe(0.5)
   expect(scorePhrase("GP14")).toBeGreaterThan(scorePhrase("CLK"))
   expect(scorePhrase("GPIO14")).toBeGreaterThan(scorePhrase("CLK"))
-  expect(scorePhrase("A1")).toBeLessThanOrEqual(scorePhrase("CLK"))
-  expect(scorePhrase("B2")).toBeLessThanOrEqual(scorePhrase("RST"))
-  expect(scorePhrase("IO3")).toBeLessThanOrEqual(scorePhrase("CS"))
+  expect(scorePhrase("A1")).toBeLessThan(scorePhrase("CLK"))
+  expect(scorePhrase("B2")).toBeLessThan(scorePhrase("RST"))
+  expect(scorePhrase("IO3")).toBeLessThan(scorePhrase("CS"))
+})
+
+it("prefers meaningful signal hints over package coordinate names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "BGA_DEVICE",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "A1",
+      pin_number: 1,
+      port_hints: ["CLK"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    generateNetName({
+      circuitJson,
+      connectedIds: ["source_port_0"],
+    }),
+  ).toBe("U1_CLK")
 })
 
 it("keeps useful numbered pin labels for generic pin names", () => {

--- a/tests/test4-numbered-pin-labels.test.ts
+++ b/tests/test4-numbered-pin-labels.test.ts
@@ -1,6 +1,17 @@
 import { expect, it } from "bun:test"
 import type { AnyCircuitElement } from "circuit-json"
 import { getReadableNameForPin } from "lib/getReadableNameForPin"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores useful GPIO-style numbered labels without promoting generic coordinates", () => {
+  expect(scorePhrase("14")).toBe(0.5)
+  expect(scorePhrase("pin14")).toBe(0.5)
+  expect(scorePhrase("GP14")).toBeGreaterThan(scorePhrase("CLK"))
+  expect(scorePhrase("GPIO14")).toBeGreaterThan(scorePhrase("CLK"))
+  expect(scorePhrase("A1")).toBeLessThanOrEqual(scorePhrase("CLK"))
+  expect(scorePhrase("B2")).toBeLessThanOrEqual(scorePhrase("RST"))
+  expect(scorePhrase("IO3")).toBeLessThanOrEqual(scorePhrase("CS"))
+})
 
 it("keeps useful numbered pin labels for generic pin names", () => {
   const circuitJson = [

--- a/tests/test4-numbered-pin-labels.test.ts
+++ b/tests/test4-numbered-pin-labels.test.ts
@@ -7,6 +7,9 @@ import { scorePhrase } from "lib/scorePhrase"
 it("scores useful GPIO-style numbered labels without promoting generic coordinates", () => {
   expect(scorePhrase("14")).toBe(0.5)
   expect(scorePhrase("pin14")).toBe(0.5)
+  expect(scorePhrase("PIN_14")).toBe(0.5)
+  expect(scorePhrase("PIN-14")).toBe(0.5)
+  expect(scorePhrase("P14")).toBe(0.5)
   expect(scorePhrase("GP14")).toBeGreaterThan(scorePhrase("CLK"))
   expect(scorePhrase("GPIO14")).toBeGreaterThan(scorePhrase("CLK"))
   expect(scorePhrase("A1")).toBeLessThan(scorePhrase("CLK"))
@@ -29,6 +32,33 @@ it("prefers meaningful signal hints over package coordinate names", () => {
       source_component_id: "source_component_0",
       name: "A1",
       pin_number: 1,
+      port_hints: ["CLK"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    generateNetName({
+      circuitJson,
+      connectedIds: ["source_port_0"],
+    }),
+  ).toBe("U1_CLK")
+})
+
+it("prefers meaningful signal hints over separated generic pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "PIN_HEADER",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "PIN_14",
+      pin_number: 14,
       port_hints: ["CLK"],
     },
   ] as AnyCircuitElement[]


### PR DESCRIPTION
## Summary
- keep generic numeric pin names like `pin14` low-scored
- allow useful GPIO-style labels like `GP14` and `GPIO14` to appear in readable netlists
- avoid promoting generic package/coordinate labels like `A1`, `B2`, and `IO3` over meaningful signal names
- add regression tests for numbered GPIO labels, generic alphanumeric labels, and readable pin output

Fixes #4

## Testing
- `npx bun test`
- `npx bun run build`
- `npx biome check lib/scorePhrase.ts tests/test4-numbered-pin-labels.test.ts`

## Bounty
This PR addresses the Algora bounty on #4.

/claim #4