### PR TITLE
Score optical transport pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const opticalTransportLabelPattern =
+  /SONET|SDH|OTN|CPRI|ECPRI|OTU\d+|ODU\d+|OPU\d+|OC\d+|STM\d+|FRAME_SYNC|FEC_LOCK/
+
 export const scorePhrase = (phrase: string) => {
+  if (opticalTransportLabelPattern.test(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/optical-transport-pin-labels.test.ts
+++ b/tests/optical-transport-pin-labels.test.ts
@@ -1,0 +1,67 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("preserves optical transport pin aliases in readable netlists", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_framer",
+      name: "U1",
+      manufacturer_part_number: "OTN framer",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_framer_cpri_rx",
+      source_component_id: "source_component_framer",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["CPRI_RX0"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r1",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1k",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_r1",
+      source_component_id: "source_component_r1",
+      footprinter_string: "0402",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_cpri_rx",
+      connected_source_port_ids: [
+        "source_port_framer_cpri_rx",
+        "source_port_r1_1",
+      ],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_CPRI_RX0")
+  expect(netlist).toContain("  - U1 pin14 (CPRI_RX0)")
+  expect(netlist).toContain("- pin14(CPRI_RX0): NETS(U1_CPRI_RX0)")
+})
+
+it("scores optical transport aliases before the generic digit fallback", () => {
+  expect(scorePhrase("CPRI_RX0")).toBeGreaterThan(1)
+  expect(scorePhrase("OTU2_FRAME_SYNC")).toBeGreaterThan(1)
+  expect(scorePhrase("SDH_AIS1")).toBeGreaterThan(1)
+  expect(scorePhrase("SONET_LOF1")).toBeGreaterThan(1)
+})


### PR DESCRIPTION
## Summary
- add focused scoring for SONET, SDH, OTN, CPRI/eCPRI, OTU/ODU/OPU, OC/STM, frame-sync, and FEC-lock pin aliases
- add regression coverage proving a generic `pin14` with `CPRI_RX0` produces a readable `U1_CPRI_RX0` net and pin label

## Why
Digit-bearing optical transport / fronthaul labels currently fall through to the generic numeric fallback, so generated net names can prefer weaker passive labels like `pos` and omit the useful transport signal from readable net entries.

## Verification
- `npm exec --yes bun -- test tests/optical-transport-pin-labels.test.ts`
- `npm exec --yes bun -- x biome check lib/scorePhrase.ts tests/optical-transport-pin-labels.test.ts`
- `npm exec --yes bun -- test`
- `npm exec --yes bun -- run build`
- `git diff --check`

/claim #4