### PR TITLE
Score GNSS/GPS pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const hasGnssGpsAlias = (phrase: string) =>
+  /(?:^|_)(?:GNSS|GPS)(?:$|_|\d)/.test(phrase.toUpperCase())
+
 export const scorePhrase = (phrase: string) => {
+  if (hasGnssGpsAlias(phrase)) {
+    return 1.23
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-gnss-gps-pin-labels.test.ts
+++ b/tests/test4-gnss-gps-pin-labels.test.ts
@@ -1,0 +1,80 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores GNSS/GPS aliases before the generic digit fallback", () => {
+  expect(scorePhrase("GNSS_PPS1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("GPS_FIX1")).toBeGreaterThan(scorePhrase("pos"))
+})
+
+it("keeps GNSS/GPS aliases in readable netlists", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "NEO-M9N",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_2",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      name: "pin14",
+      port_hints: ["GNSS_PPS1", "PPS", "timepulse"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      pin_number: 15,
+      name: "pin15",
+      port_hints: ["GPS_FIX1", "fix"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_2",
+      pin_number: 1,
+      name: "pin1",
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      pin_number: 2,
+      name: "pin2",
+      port_hints: ["cathode", "neg", "right"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_2", "source_port_4"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_GNSS_PPS1")
+  expect(netlist).toContain("  - U1 pin14 (GNSS_PPS1)")
+  expect(netlist).toContain("NET: U1_GPS_FIX1")
+  expect(netlist).toContain("  - U1 pin15 (GPS_FIX1)")
+})


### PR DESCRIPTION
## Summary
- add focused pre-digit scoring for GNSS/GPS aliases such as `GNSS_PPS1` and `GPS_FIX1`
- add raw Circuit JSON regression coverage showing those labels survive in generated NET names and readable pin entries
- avoid changing generic numeric-pin scoring for unrelated labels

## Verification
- `git diff --check`
- GitHub CI is green: `test`, `dependency-check`, `format-check`, and `type-check`
- Not run: project tests/build locally, to avoid executing untrusted repo scripts in this safety-constrained session.

/claim #4
