### PR TITLE
Score optical aliases in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,11 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  LASER: 1.18,
+  LIDAR: 1.18,
+  PHOTODIODE: 1.18,
+  PHOTO: 1.16,
+  APD: 1.16,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -36,13 +41,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-optical-pin-labels.test.tsx
+++ b/tests/test4-optical-pin-labels.test.tsx
@@ -1,0 +1,31 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("uses optical sensor aliases in readable net names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn16"
+        manufacturerPartNumber="OPTICAL_CTRL"
+        pinLabels={{
+          pin1: ["LASER_FIRE1"],
+          pin2: ["LIDAR_RX1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .LASER_FIRE1" to=".R1 .pin1" />
+      <trace from=".U1 .LIDAR_RX1" to=".R2 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_LASER_FIRE1")
+  expect(netlist).toContain("NET: U1_LIDAR_RX1")
+  expect(netlist).toContain("- U1 LASER_FIRE1")
+  expect(netlist).toContain("- U1 LIDAR_RX1")
+})


### PR DESCRIPTION
/claim #4

This keeps optical signal labels from being pushed below generic digit-bearing names.

What changed:
- Scores LASER, LIDAR, PHOTODIODE, PHOTO, and APD labels before the generic digit fallback.
- Adds a regression test showing `LASER_FIRE1` and `LIDAR_RX1` become the readable NET names instead of weaker passive labels.

Verification:
- `npx --yes bun test tests/test4-optical-pin-labels.test.tsx`
- `npx --yes bun test`
- `npx --yes bun run build`
- `npx --yes biome check lib\scorePhrase.ts tests\test4-optical-pin-labels.test.tsx`