### PR TITLE
Score load-cell pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const specializedSignalScores = [
+  {
+    pattern:
+      /(?:^|[_-])(?:LOADCELL|LOAD_CELL|STRAIN_GAUGE|WHEATSTONE|BRIDGE_(?:OUT|IN|SIG|EXC)|EXC(?:ITATION)?|SIG_[PN]|SENSE_[PN])(?:$|[_+\-\d])/,
+    score: 1.18,
+  },
+]
+
 export const scorePhrase = (phrase: string) => {
+  const upperPhrase = phrase.toUpperCase()
+  for (const { pattern, score } of specializedSignalScores) {
+    if (pattern.test(upperPhrase)) return score
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-load-cell-pin-labels.test.tsx
+++ b/tests/test4-load-cell-pin-labels.test.tsx
@@ -1,0 +1,37 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores load-cell and strain-gauge aliases before generic digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="HX711"
+        pinLabels={{
+          pin1: ["LOADCELL_EXC1"],
+          pin2: ["STRAIN_GAUGE1"],
+          pin3: ["BRIDGE_OUT1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .LOADCELL_EXC1" to=".R1 > .pin1" />
+      <trace from=".U1 .STRAIN_GAUGE1" to=".R1 > .pin2" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_LOADCELL_EXC1")
+  expect(readableNetlist).toContain("NET: U1_STRAIN_GAUGE1")
+  expect(readableNetlist).toContain("  - U1 LOADCELL_EXC1")
+  expect(readableNetlist).toContain("  - U1 STRAIN_GAUGE1")
+  expect(readableNetlist).toContain(
+    "- pin1(LOADCELL_EXC1): NETS(U1_LOADCELL_EXC1)",
+  )
+  expect(readableNetlist).toContain(
+    "- pin2(STRAIN_GAUGE1): NETS(U1_STRAIN_GAUGE1)",
+  )
+})


### PR DESCRIPTION
/claim #4

Summary:
- add focused scoring for load-cell / strain-gauge aliases before the generic digit fallback
- preserve digit-bearing labels such as `LOADCELL_EXC1` and `STRAIN_GAUGE1` in generated readable NET names
- add regression coverage for generated NET names and COMPONENT_PINS entries

Verification:
- `npx.cmd --yes bun test`
- `npx.cmd --yes bun run build`
- `.
ode_modules\.bin\biome.exe check lib\scorePhrase.ts tests\test4-load-cell-pin-labels.test.tsx`
- `git diff --cached --check`

AI-assisted with Codex; I reviewed the diff and ran local verification before opening this PR.