### PR TITLE
Score AVR programming pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const specializedSignalScores = [
+  {
+    pattern:
+      /(?:^|[_-])(?:UPDI(?:_(?:DATA|CLK))?|DEBUGWIRE|DWIRE|PDI_(?:DATA|CLK)|TPI_(?:DATA|CLK))(?:$|[_+\-\d])/,
+    score: 1.18,
+  },
+]
+
 export const scorePhrase = (phrase: string) => {
+  const upperPhrase = phrase.toUpperCase()
+  for (const { pattern, score } of specializedSignalScores) {
+    if (pattern.test(upperPhrase)) return score
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-avr-programming-pin-labels.test.tsx
+++ b/tests/test4-avr-programming-pin-labels.test.tsx
@@ -1,0 +1,39 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores AVR programming aliases before generic digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="ATtiny1616"
+        pinLabels={{
+          pin1: ["UPDI_DATA1"],
+          pin2: ["DEBUGWIRE1"],
+          pin3: ["PDI_CLK1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+
+      <trace from=".U1 .UPDI_DATA1" to=".R1 > .pin1" />
+      <trace from=".U1 .DEBUGWIRE1" to=".R2 > .pin1" />
+      <trace from=".U1 .PDI_CLK1" to=".R3 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_UPDI_DATA1")
+  expect(readableNetlist).toContain("NET: U1_DEBUGWIRE1")
+  expect(readableNetlist).toContain("NET: U1_PDI_CLK1")
+  expect(readableNetlist).toContain("  - U1 UPDI_DATA1")
+  expect(readableNetlist).toContain("  - U1 DEBUGWIRE1")
+  expect(readableNetlist).toContain("  - U1 PDI_CLK1")
+  expect(readableNetlist).toContain("- pin1(UPDI_DATA1): NETS(U1_UPDI_DATA1)")
+  expect(readableNetlist).toContain("- pin2(DEBUGWIRE1): NETS(U1_DEBUGWIRE1)")
+  expect(readableNetlist).toContain("- pin3(PDI_CLK1): NETS(U1_PDI_CLK1)")
+})


### PR DESCRIPTION
/claim #4

Summary:
- add focused scoring for AVR programming/debug aliases before the generic digit fallback
- preserve digit-bearing labels such as `UPDI_DATA1`, `DEBUGWIRE1`, and `PDI_CLK1` in generated readable NET names
- add regression coverage for generated NET names and COMPONENT_PINS entries

Verification:
- `npx.cmd --yes bun test`
- `npx.cmd --yes bun run build`
- `.
ode_modules\.bin\biome.exe check lib\scorePhrase.ts tests\test4-avr-programming-pin-labels.test.tsx`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and ran local verification before opening this PR.