### PR TITLE
Score precision data converter pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const specializedSignalScores = [
+  {
+    pattern:
+      /(?:^|[_-])(?:(?:ADC|DAC)_(?:DRDY|CNVST|CONVST|BUSY|EOC|EOS|START|SYNC|PWDN|LDAC|CLR)|CNVST|CONVST|LDAC|REF[PN]|VREF[PN]?|AIN\d+[PN]?)(?:$|[_+\-\d])/,
+    score: 1.18,
+  },
+]
+
 export const scorePhrase = (phrase: string) => {
+  const upperPhrase = phrase.toUpperCase()
+  for (const { pattern, score } of specializedSignalScores) {
+    if (pattern.test(upperPhrase)) return score
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-precision-data-converter-pin-labels.test.tsx
+++ b/tests/test4-precision-data-converter-pin-labels.test.tsx
@@ -1,0 +1,51 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores precision data-converter aliases before generic digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="ADS8688"
+        pinLabels={{
+          pin1: ["ADC_DRDY1"],
+          pin2: ["CNVST1"],
+          pin3: ["DAC_LDAC1"],
+          pin4: ["AIN0P"],
+          pin5: ["REFP1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+      <resistor resistance="1k" footprint="0402" name="R5" />
+
+      <trace from=".U1 .ADC_DRDY1" to=".R1 > .pin1" />
+      <trace from=".U1 .CNVST1" to=".R2 > .pin1" />
+      <trace from=".U1 .DAC_LDAC1" to=".R3 > .pin1" />
+      <trace from=".U1 .AIN0P" to=".R4 > .pin1" />
+      <trace from=".U1 .REFP1" to=".R5 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_ADC_DRDY1")
+  expect(readableNetlist).toContain("NET: U1_CNVST1")
+  expect(readableNetlist).toContain("NET: U1_DAC_LDAC1")
+  expect(readableNetlist).toContain("NET: U1_AIN0P")
+  expect(readableNetlist).toContain("NET: U1_REFP1")
+  expect(readableNetlist).toContain("  - U1 ADC_DRDY1")
+  expect(readableNetlist).toContain("  - U1 CNVST1")
+  expect(readableNetlist).toContain("  - U1 DAC_LDAC1")
+  expect(readableNetlist).toContain("  - U1 AIN0P")
+  expect(readableNetlist).toContain("  - U1 REFP1")
+  expect(readableNetlist).toContain("- pin1(ADC_DRDY1): NETS(U1_ADC_DRDY1)")
+  expect(readableNetlist).toContain("- pin2(CNVST1): NETS(U1_CNVST1)")
+  expect(readableNetlist).toContain("- pin3(DAC_LDAC1): NETS(U1_DAC_LDAC1)")
+  expect(readableNetlist).toContain("- pin4(AIN0P): NETS(U1_AIN0P)")
+  expect(readableNetlist).toContain("- pin5(REFP1): NETS(U1_REFP1)")
+})


### PR DESCRIPTION
## Summary
- score precision ADC/DAC data-converter aliases such as ADC_DRDY1, CNVST1, DAC_LDAC1, AIN0P, and REFP1 before the generic digit fallback
- preserve those labels in generated NET names and readable component pin entries
- keep this scoped away from the existing generic analog-peripheral ADC0/DAC0/PWM0 slice

/claim #4

## Verification
- npx.cmd --yes bun test tests/test4-precision-data-converter-pin-labels.test.tsx
- npx.cmd --yes bun x biome check lib/scorePhrase.ts tests/test4-precision-data-converter-pin-labels.test.tsx
- npx.cmd --yes bun test
- npx.cmd --yes bun run build
- git diff --check