### PR TITLE
Fix readable labels for generic chip pins

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -36,13 +36,15 @@ export const convertCircuitJsonToReadableNetlist = (
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
+      const details = [component.display_resistance, footprint]
+        .filter(Boolean)
+        .join(" ")
+      componentDescription = [details, "resistor"].filter(Boolean).join(" ")
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
+      const details = [component.display_capacitance, footprint]
+        .filter(Boolean)
+        .join(" ")
+      componentDescription = [details, "capacitor"].filter(Boolean).join(" ")
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -145,9 +147,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,19 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const lowInformationPinHints = new Set([
+  "anode",
+  "cathode",
+  "left",
+  "right",
+  "neg",
+  "negative",
+  "pos",
+  "positive",
+])
+
+const isGenericPinName = (name: string) => /^pin\d+$/i.test(name)
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -37,18 +50,32 @@ export const getReadableNameForPin = ({
   const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
 
   const additionalPinLabels: string[] = []
+  const addAdditionalPinLabel = (label: string) => {
+    if (!label || label === mainPinName) return
+    if (!additionalPinLabels.includes(label)) {
+      additionalPinLabels.push(label)
+    }
+  }
 
   if (isPositive && component.ftype !== "simple_resistor") {
-    additionalPinLabels.push("+")
+    addAdditionalPinLabel("+")
   } else if (isNegative && component.ftype !== "simple_resistor") {
-    additionalPinLabels.push("-")
+    addAdditionalPinLabel("-")
   }
 
   for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
-      additionalPinLabels.push(port_hint)
+    const trimmedHint = port_hint.trim()
+    if (!trimmedHint || trimmedHint === mainPinName) continue
+    if (trimmedHint === String(port.pin_number)) continue
+    const score = scorePhrase(trimmedHint)
+    const shouldIncludeNumberedLabel =
+      isGenericPinName(mainPinName) &&
+      component.ftype !== "simple_resistor" &&
+      component.ftype !== "simple_capacitor" &&
+      !isGenericPinName(trimmedHint) &&
+      !lowInformationPinHints.has(trimmedHint.toLowerCase())
+    if (score > 1 || shouldIncludeNumberedLabel) {
+      addAdditionalPinLabel(trimmedHint)
     }
   }
 

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -16,6 +16,10 @@ const wordQualityScore = {
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  GP: 1.1,
+  ADC: 1.1,
+  VBUS: 1.1,
+  VCC: 1.1,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +40,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (phrase.toLowerCase().includes(word.toLowerCase())) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/get-readable-name-for-pin.test.ts
+++ b/tests/get-readable-name-for-pin.test.ts
@@ -1,0 +1,60 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("includes useful numbered chip pin labels when the port name is generic", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_chip",
+      name: "U1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "14", "GP10", "LED16_DI"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 pin14 (GP10,LED16_DI)")
+})
+
+it("keeps passive pin names concise when their hints are low-information", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("R1 pin1")
+})
+
+it("scores useful numbered GPIO labels higher than generic pin numbers", () => {
+  expect(scorePhrase("GPIO1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("GP10")).toBeGreaterThan(scorePhrase("pin14"))
+})


### PR DESCRIPTION
/claim #4

Closes #4.

## Summary
- Include useful chip pin hints when a source port name is only a generic `pinN`, so net lines show labels like `GP10` / `LED16_DI` instead of only `U1 pin14`.
- Keep passive pin names concise by filtering low-information position/polarity hints.
- Avoid `undefined` in resistor/capacitor descriptions and component pin headers when optional footprint/value fields are absent.

## Tests
- `npx --no-install biome check .`
- `npx --no-install tsc --noEmit`
- `npm run build`

Note: I could not run `bun test` locally because Bun is not installed in this environment.