### PR TITLE
Score energy meter pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const specializedSignalScores = [
+  {
+    pattern:
+      /(?:^|[_-])(?:(?:METER|ENERGY|WATT)_(?:CF\d+|PULSE\d+|SAG\d+|IRQ\d+|WARN\d+)|(?:ADE|ATM90E|HLW)_(?:CF\d+|IRQ\d+|WARN\d+|SAG\d+))(?:$|[_+\-\d])/,
+    score: 1.18,
+  },
+]
+
 export const scorePhrase = (phrase: string) => {
+  const upperPhrase = phrase.toUpperCase()
+  for (const { pattern, score } of specializedSignalScores) {
+    if (pattern.test(upperPhrase)) return score
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-energy-meter-pin-labels.test.tsx
+++ b/tests/test4-energy-meter-pin-labels.test.tsx
@@ -1,0 +1,49 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores energy-metering aliases before generic digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="ADE7953"
+        pinLabels={{
+          pin1: ["METER_CF1"],
+          pin2: ["ENERGY_PULSE1"],
+          pin3: ["ADE_IRQ1"],
+          pin4: ["ATM90E_WARN1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+
+      <trace from=".U1 .METER_CF1" to=".R1 > .pin1" />
+      <trace from=".U1 .ENERGY_PULSE1" to=".R2 > .pin1" />
+      <trace from=".U1 .ADE_IRQ1" to=".R3 > .pin1" />
+      <trace from=".U1 .ATM90E_WARN1" to=".R4 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_METER_CF1")
+  expect(readableNetlist).toContain("NET: U1_ENERGY_PULSE1")
+  expect(readableNetlist).toContain("NET: U1_ADE_IRQ1")
+  expect(readableNetlist).toContain("NET: U1_ATM90E_WARN1")
+  expect(readableNetlist).toContain("  - U1 METER_CF1")
+  expect(readableNetlist).toContain("  - U1 ENERGY_PULSE1")
+  expect(readableNetlist).toContain("  - U1 ADE_IRQ1")
+  expect(readableNetlist).toContain("  - U1 ATM90E_WARN1")
+  expect(readableNetlist).toContain("- pin1(METER_CF1): NETS(U1_METER_CF1)")
+  expect(readableNetlist).toContain(
+    "- pin2(ENERGY_PULSE1): NETS(U1_ENERGY_PULSE1)",
+  )
+  expect(readableNetlist).toContain("- pin3(ADE_IRQ1): NETS(U1_ADE_IRQ1)")
+  expect(readableNetlist).toContain(
+    "- pin4(ATM90E_WARN1): NETS(U1_ATM90E_WARN1)",
+  )
+})


### PR DESCRIPTION
## Summary
- score energy-metering IC pulse/status aliases such as METER_CF1, ENERGY_PULSE1, ADE_IRQ1, and ATM90E_WARN1 before the generic digit fallback
- preserve those labels in generated NET names and readable component pin entries
- keep this scoped away from the existing AC mains / triac / zero-cross alias slice

/claim #4

## Verification
- npx.cmd --yes bun test tests/test4-energy-meter-pin-labels.test.tsx
- npx.cmd --yes bun x biome check lib/scorePhrase.ts tests/test4-energy-meter-pin-labels.test.tsx
- npx.cmd --yes bun test
- npx.cmd --yes bun run build
- git diff --check