### PR TITLE
Score PON optical access pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const opticalAccessAliasPatterns = [
+  /(?:^|[_-])(?:GPON|EPON|XGPON|XGSPON|XGS_PON|NGPON|NG_PON)(?=$|[_\d-])/,
+  /(?:^|[_-])PON(?=$|[_\d-])/,
+  /(?:^|[_-])(?:ONU|OLT|BOSA|BURST)(?=$|[_\d-])/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  if (opticalAccessAliasPatterns.some((pattern) => pattern.test(phrase))) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-pon-optical-access-pin-labels.test.tsx
+++ b/tests/test4-pon-optical-access-pin-labels.test.tsx
@@ -1,0 +1,51 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves PON optical access aliases on generic chip pins", () => {
+  expect(scorePhrase("PON_TX_DISABLE1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("GPON_BURST_EN1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("EPON_RX_LOS1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("ONU_RESET1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("BOSA_RX1")).toBeGreaterThan(scorePhrase("pos"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="PON_ONU"
+        pinLabels={{
+          pin1: ["pin14", "PON_TX_DISABLE1"],
+          pin2: ["pin15", "GPON_BURST_EN1"],
+          pin3: ["pin16", "EPON_RX_LOS1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .pin14" to=".R1 .pin1" />
+      <trace from=".U1 .pin15" to=".C1 .pin1" />
+      <trace from=".U1 .pin16" to=".R1 .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_PON_TX_DISABLE1")
+  expect(netlist).toContain("NET: U1_GPON_BURST_EN1")
+  expect(netlist).toContain("NET: U1_EPON_RX_LOS1")
+  expect(netlist).toContain("  - U1 pin14 (PON_TX_DISABLE1)")
+  expect(netlist).toContain("  - U1 pin15 (GPON_BURST_EN1)")
+  expect(netlist).toContain("  - U1 pin16 (EPON_RX_LOS1)")
+  expect(netlist).toContain(
+    "- pin1(pin14, PON_TX_DISABLE1): NETS(U1_PON_TX_DISABLE1)",
+  )
+  expect(netlist).toContain(
+    "- pin2(pin15, GPON_BURST_EN1): NETS(U1_GPON_BURST_EN1)",
+  )
+  expect(netlist).toContain(
+    "- pin3(pin16, EPON_RX_LOS1): NETS(U1_EPON_RX_LOS1)",
+  )
+})


### PR DESCRIPTION
/claim #4

Refs #4.

Summary:
- Add a focused scorer guard for PON/GPON/EPON/xPON, ONU/OLT, BOSA, and burst-mode optical-access aliases before the generic digit fallback.
- Add regression coverage showing generic chip pins preserve `PON_TX_DISABLE1`, `GPON_BURST_EN1`, and `EPON_RX_LOS1` in generated NET names, NET pin entries, and COMPONENT_PINS net names.

Non-overlap checked before implementation: I searched the issue/PR queue for PON/xPON/ONU/OLT/BOSA coverage and kept this separate from existing SFP/QSFP management and optical-transport slices.

Verification:
- `npx --yes bun test tests/test4-pon-optical-access-pin-labels.test.tsx`
- `npx --yes bun x biome check lib/scorePhrase.ts tests/test4-pon-optical-access-pin-labels.test.tsx`
- `npx --yes bun test`
- `npx --yes bun run build`
- `git diff --check`

AI-assisted with Codex; diff reviewed locally before submission.