### PR TITLE
Fix readable labels for generated chip pins

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,34 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinLabel = (label: string, pinNumber?: number) => {
+  const normalizedLabel = label.trim().toLowerCase()
+  return (
+    normalizedLabel === String(pinNumber) ||
+    normalizedLabel === `pin${pinNumber}` ||
+    /^pin\d+$/i.test(normalizedLabel)
+  )
+}
+
+const getBestMainPinLabel = (port: SourcePort): string => {
+  const fallbackLabel =
+    port.name || (port.pin_number !== undefined ? `Pin${port.pin_number}` : "")
+  const labels = Array.from(
+    new Set([...(port.name ? [port.name] : []), ...(port.port_hints ?? [])]),
+  ).filter(Boolean)
+
+  if (port.name && !isGenericPinLabel(port.name, port.pin_number)) {
+    return port.name
+  }
+
+  const readableLabels = labels.filter(
+    (label) => !isGenericPinLabel(label, port.pin_number),
+  )
+  if (readableLabels.length === 0) return fallbackLabel
+
+  return readableLabels.sort((a, b) => scorePhrase(b) - scorePhrase(a))[0]
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -33,8 +61,13 @@ export const getReadableNameForPin = ({
     ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
   )
 
-  // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  // Prefer semantic labels over generated chip names such as "pin14".
+  const mainPinName =
+    component.ftype === "simple_chip"
+      ? getBestMainPinLabel(port)
+      : port.name
+        ? port.name
+        : `Pin${port.pin_number}`
 
   const additionalPinLabels: string[] = []
 
@@ -47,7 +80,11 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (
+      score > 1 ||
+      (component.ftype === "simple_chip" &&
+        !isGenericPinLabel(port_hint, port.pin_number))
+    ) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/get-readable-name-for-pin.test.ts
+++ b/tests/get-readable-name-for-pin.test.ts
@@ -1,0 +1,28 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("uses semantic port hints instead of generated pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "GPIO15", "SCL"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 SCL (GPIO15)")
+})


### PR DESCRIPTION
Fixes #4

Generated chip pin names like `pin14` can hide the useful semantic labels stored in `port_hints`.

This change prefers meaningful chip labels from `port_hints` when the source port name is generic, while preserving existing behavior for resistors/capacitors.

Validation:
- bun test
- bun run build
- bunx biome check lib/getReadableNameForPin.ts tests/get-readable-name-for-pin.test.ts