### PR TITLE
Fix readable nets for custom source port ids

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -20,6 +20,9 @@ export const convertCircuitJsonToReadableNetlist = (
   const source_components = su(circuitJson).source_component.list()
   const source_nets = su(circuitJson).source_net.list()
   const source_traces = su(circuitJson).source_trace.list()
+  const sourcePortIds = new Set(source_ports.map((p) => p.source_port_id))
+  const getConnectedSourcePortIds = (connectedIds: string[]) =>
+    connectedIds.filter((id) => sourcePortIds.has(id))
   // Build readable netlist
   const netlist: string[] = []
 
@@ -70,9 +73,7 @@ export const convertCircuitJsonToReadableNetlist = (
       netName = generateNetName({ circuitJson, connectedIds })
     }
 
-    const connectedPortCount = connectedIds.filter((id) =>
-      id.startsWith("source_port"),
-    ).length
+    const connectedPortCount = getConnectedSourcePortIds(connectedIds).length
 
     if (connectedPortCount <= 1) continue
 
@@ -97,18 +98,15 @@ export const convertCircuitJsonToReadableNetlist = (
   // Process nets with only one connection
   let hasEmptyNets = false
   for (const [netId, connectedIds] of Object.entries(netMap)) {
-    const connectedPortCount = connectedIds.filter((id) =>
-      id.startsWith("source_port"),
-    ).length
+    const connectedSourcePortIds = getConnectedSourcePortIds(connectedIds)
+    const connectedPortCount = connectedSourcePortIds.length
     if (connectedPortCount === 1) {
       if (!hasEmptyNets) {
         netlist.push("")
         netlist.push("EMPTY NET PINS:")
         hasEmptyNets = true
       }
-      const source_port_id = netMap[netId].find((id) =>
-        id.startsWith("source_port"),
-      )!
+      const source_port_id = connectedSourcePortIds[0]
       const pinName = getReadableNameForPin({
         circuitJson,
         source_port_id,
@@ -122,7 +120,7 @@ export const convertCircuitJsonToReadableNetlist = (
   // build map of port ids to the nets they connect to
   const portIdToNetNames: Record<string, string[]> = {}
   for (const [netId, connectedIds] of Object.entries(netMap)) {
-    const portIds = connectedIds.filter((id) => id.startsWith("source_port"))
+    const portIds = getConnectedSourcePortIds(connectedIds)
     if (portIds.length === 0) continue
     const net = source_nets.find((n) => connectedIds.includes(n.source_net_id))
     let netName = net?.name

--- a/tests/test4-custom-source-port-ids.test.ts
+++ b/tests/test4-custom-source-port-ids.test.ts
@@ -1,0 +1,52 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("uses actual source_port ids when rendering readable nets", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "J1",
+      manufacturer_part_number: "CONN",
+    },
+    {
+      type: "source_port",
+      source_port_id: "u1-alert",
+      source_component_id: "source_component_1",
+      name: "ALERT",
+      pin_number: 1,
+      port_hints: ["ALERT"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "j1-alert",
+      source_component_id: "source_component_2",
+      name: "ALERT_IN",
+      pin_number: 2,
+      port_hints: ["ALERT_IN"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["u1-alert", "j1-alert"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ALERT")
+  expect(netlist).toContain("  - U1 ALERT")
+  expect(netlist).toContain("  - J1 ALERT_IN")
+  expect(netlist).toContain("- pin1(ALERT): NETS(U1_ALERT)")
+  expect(netlist).toContain("- pin2(ALERT_IN): NETS(U1_ALERT)")
+})


### PR DESCRIPTION
## Summary
- Use the actual `source_port.source_port_id` values when identifying connected source ports instead of assuming ids start with `source_port`.
- Fix readable NET sections and `COMPONENT_PINS` mappings for valid Circuit JSON that uses custom source port ids like `u1-alert` / `j1-alert`.
- Add a raw Circuit JSON regression test that avoids the JSX renderer path and covers the custom-id case directly.

## Why
Circuit JSON only requires `source_port_id` to be a string. On current main, custom ids are skipped by the `startsWith("source_port")` checks, so a two-port connection can be omitted from the NET section and both component pins can render as `NOT_CONNECTED`.

## Verification
- `bun test tests/test4-custom-source-port-ids.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test4-custom-source-port-ids.test.ts`
- `bun run build`
- `git diff --check`

/claim #4