### PR TITLE
Score SENT and PSI5 pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,24 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const automotiveSensorInterfaceAliases = [
+  /(^|[_-])SENT([_-]|$)/,
+  /(^|[_-])PSI5([_-]|$)/,
+  /(^|[_-])SENT_(OUT|IN|TX|RX|DATA|SYNC|NIBBLE|PAUSE|CRC|TICK)/,
+  /(^|[_-])PSI5_(DATA|SYNC|TX|RX|BUS|SENSOR)/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  if (
+    automotiveSensorInterfaceAliases.some((pattern) =>
+      pattern.test(normalizedPhrase),
+    )
+  ) {
+    return 1.2
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/automotive-sensor-interface-pin-labels.test.ts
+++ b/tests/automotive-sensor-interface-pin-labels.test.ts
@@ -1,0 +1,98 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves SENT and PSI5 automotive sensor-interface labels", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "SENT-PSI5",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "SENT_OUT1", "SENT_SYNC1"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["pin15", "PSI5_DATA1", "PSI5_SYNC1"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["cathode", "neg", "right", "pin2", "2"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_3"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+      "COMPONENTS:
+       - U1: SENT-PSI5
+       - R1: 1kΩ resistor
+
+      NET: U1_SENT_OUT1
+        - U1 pin14 (SENT_OUT1,SENT_SYNC1)
+        - R1 pin1
+
+      NET: U1_PSI5_DATA1
+        - U1 pin15 (PSI5_DATA1,PSI5_SYNC1)
+        - R1 pin2
+
+
+      COMPONENT_PINS:
+      U1 (SENT-PSI5)
+      - pin14(SENT_OUT1, SENT_SYNC1): NETS(U1_SENT_OUT1)
+      - pin15(PSI5_DATA1, PSI5_SYNC1): NETS(U1_PSI5_DATA1)
+
+      R1 (1kΩ undefined)
+      - pin1(anode, pos, left): NETS(U1_SENT_OUT1)
+      - pin2(cathode, neg, right): NETS(U1_PSI5_DATA1)
+      "
+    `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- Add focused scoring for automotive SENT and PSI5 sensor-interface aliases before the generic digit fallback.
- Preserve digit-bearing labels such as `SENT_OUT1`, `SENT_SYNC1`, `PSI5_DATA1`, and `PSI5_SYNC1` in generated readable NET names and pin entries.
- Add raw Circuit JSON regression coverage so the test avoids unrelated JSX rendering paths.

## Non-overlap check
I searched current open PRs and the issue thread for `SENT`, `PSI5`, and automotive sensor-interface coverage. Existing nearby work covers CAN/LIN, automotive diagnostics/FlexRay, avionics, industrial sensor links, and generic numbered pins; this patch is limited to SENT/PSI5 sensor labels.

## Verification
- `bun test tests/automotive-sensor-interface-pin-labels.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run build`
- `bunx biome check lib/scorePhrase.ts tests/automotive-sensor-interface-pin-labels.test.ts`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.
