### PR TITLE
Score ESD and TVS pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,12 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(ESD|TVS|SURGE|TRANSIENT)([^A-Z0-9]|$)/.test(normalizedPhrase)
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-esd-tvs-pin-labels.test.tsx
+++ b/tests/test4-esd-tvs-pin-labels.test.tsx
@@ -1,0 +1,40 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores ESD and TVS protection aliases before generic digit labels", () => {
+  expect(scorePhrase("ESD_PROTECT1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("TVS_IO1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("SURGE_CLAMP1")).toBeGreaterThan(scorePhrase("left"))
+})
+
+it("preserves ESD and surge protection labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="TPD4E05U06"
+        pinLabels={{
+          pin1: ["ESD_PROTECT1", "TVS_IO1"],
+          pin2: ["SURGE_CLAMP1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .ESD_PROTECT1" to=".R1 > .pin1" />
+      <trace from=".U1 .SURGE_CLAMP1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ESD_PROTECT1")
+  expect(netlist).toContain("  - U1 ESD_PROTECT1 (TVS_IO1)")
+  expect(netlist).toContain("NET: U1_SURGE_CLAMP1")
+  expect(netlist).toContain("  - U1 SURGE_CLAMP1")
+  expect(netlist).not.toContain("NET: R1_pos")
+  expect(netlist).not.toContain("NET: C1_pos")
+})


### PR DESCRIPTION
## Summary
- score ESD/TVS/surge/transient protection aliases before the generic digit fallback
- preserve digit-bearing labels such as `ESD_PROTECT1`, `TVS_IO1`, and `SURGE_CLAMP1` in generated readable NET names and pin entries
- add focused regression coverage for the readable-netlist behavior

## Non-overlap check
I searched current open PRs and issue comments for ESD, TVS, transient, surge, suppressor, and IEC61000 slices. Existing nearby work covers gate-driver clamp/protection, eFuse/hot-swap, digital isolators, optocouplers, and broader power-management labels; this patch is limited to ESD/TVS/transient/surge protection aliases.

## Verification
- `bun test tests/test4-esd-tvs-pin-labels.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check lib/scorePhrase.ts tests/test4-esd-tvs-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.