### PR TITLE
Score analog dimming pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(ANALOG_DIM|DIM_0_10V|DIM_1_10V|DIM_SINK|DIM_SOURCE|DIM_CTRL|CURRENT_SINK_DIM|CURRENT_SOURCE_DIM|DIMMING_CTRL)\d*([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-analog-dimming-pin-labels.test.tsx
+++ b/tests/test4-analog-dimming-pin-labels.test.tsx
@@ -1,0 +1,40 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores analog dimming aliases before generic digit labels", () => {
+  expect(scorePhrase("ANALOG_DIM1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("DIM_0_10V1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("DIM_SINK1")).toBeGreaterThan(scorePhrase("left"))
+})
+
+it("preserves analog dimming labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="LM3409"
+        pinLabels={{
+          pin1: ["ANALOG_DIM1", "DIM_0_10V1"],
+          pin2: ["DIM_SINK1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .ANALOG_DIM1" to=".R1 > .pin1" />
+      <trace from=".U1 .DIM_SINK1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ANALOG_DIM1")
+  expect(netlist).toContain("  - U1 ANALOG_DIM1 (DIM_0_10V1)")
+  expect(netlist).toContain("NET: U1_DIM_SINK1")
+  expect(netlist).toContain("  - U1 DIM_SINK1")
+  expect(netlist).not.toContain("NET: R1_pos")
+  expect(netlist).not.toContain("NET: C1_pos")
+})


### PR DESCRIPTION
## Summary
- score focused 0-10V / 1-10V analog dimming aliases before the generic digit fallback
- preserve digit-bearing labels such as `ANALOG_DIM1`, `DIM_0_10V1`, and `DIM_SINK1` in generated readable NET names and pin entries
- add focused regression coverage for the readable-netlist behavior

## Non-overlap check
I searched current PRs and the issue thread for `0-10V`, `1-10V`, `0_10V`, `1_10V`, `ANALOG_DIM`, `DIM_SINK`, `DIM_SOURCE`, `DIM_CTRL`, `CURRENT_SINK`, `DIMMER`, and related analog-dimming phrases. Existing nearby work covers DMX/DALI lighting-control, LED/backlight/PWM labels, and general fieldbus aliases; this patch is limited to analog dimming / current-sink dimming labels.

## Verification
- `bun test tests/test4-analog-dimming-pin-labels.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check lib/scorePhrase.ts tests/test4-analog-dimming-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.
