### PR TITLE
Score EVSE pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(EVSE_CP|EVSE_PP|CONTROL_PILOT|PROXIMITY_PILOT|J1772_CP|J1772_PP|TYPE2_CP|TYPE2_PP|CCS_PROX|CCS_LOCK|CHADEMO_CAN|EV_CHARGE_DET)\d*([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-evse-pin-labels.test.tsx
+++ b/tests/test4-evse-pin-labels.test.tsx
@@ -1,0 +1,33 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves EVSE control pilot pin labels in readable net names", () => {
+  expect(scorePhrase("EVSE_CP1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("CONTROL_PILOT1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("J1772_CP1")).toBeGreaterThan(scorePhrase("pos"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="EVSE_CTRL"
+        pinLabels={{
+          pin1: ["EVSE_CP1", "CONTROL_PILOT1"],
+          pin2: ["J1772_CP1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .EVSE_CP1" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_EVSE_CP1")
+  expect(netlist).toContain("  - U1 EVSE_CP1 (CONTROL_PILOT1)")
+  expect(netlist).not.toContain("NET: R1_pos")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for EVSE / charging-connector aliases before the generic digit fallback
- cover labels such as `EVSE_CP1`, `CONTROL_PILOT1`, and `J1772_CP1` so readable NET names do not fall back to passive labels like `pos`
- add a regression test for generated net names and readable pin entries

/claim #4

## Non-overlap check
I searched existing PR titles/bodies and issue comments for EVSE, CONTROL_PILOT, PROXIMITY_PILOT, J1772, CCS, CHAdeMO, Type 2, and EV_CHARGE terms and did not find an existing slice. This stays separate from generic capacitive proximity, PoE, automotive SENT/PSI5, and ESD/TVS alias work.

## Verification
- `bun test tests/test4-evse-pin-labels.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check lib/scorePhrase.ts tests/test4-evse-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and verification output before opening this PR.