### PR TITLE
Score HVIL pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(HVIL|HVIL_LOOP|HVIL_RETURN|HV_INTERLOCK|HIGH_VOLTAGE_INTERLOCK|INTERLOCK_LOOP|INTERLOCK_RETURN|HV_CONNECTOR_DET)\d*([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-hvil-pin-labels.test.tsx
+++ b/tests/test4-hvil-pin-labels.test.tsx
@@ -1,0 +1,33 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves HVIL interlock pin labels in readable net names", () => {
+  expect(scorePhrase("HVIL_LOOP1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("HV_INTERLOCK1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("HV_CONNECTOR_DET1")).toBeGreaterThan(scorePhrase("pos"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="HV_MONITOR"
+        pinLabels={{
+          pin1: ["HVIL_LOOP1", "HV_INTERLOCK1"],
+          pin2: ["HV_CONNECTOR_DET1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .HVIL_LOOP1" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_HVIL_LOOP1")
+  expect(netlist).toContain("  - U1 HVIL_LOOP1 (HV_INTERLOCK1)")
+  expect(netlist).not.toContain("NET: R1_pos")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for high-voltage interlock / HVIL aliases before the generic digit fallback
- cover labels such as `HVIL_LOOP1`, `HV_INTERLOCK1`, and `HV_CONNECTOR_DET1` so readable NET names do not fall back to passive labels like `pos`
- add a regression test for generated net names and readable pin entries

/claim #4

## Non-overlap check
I searched existing PR titles/bodies and issue comments for HVIL, HIGH_VOLTAGE_INTERLOCK, HV_INTERLOCK, INTERLOCK_LOOP, and HV_CONNECTOR terms and did not find an existing slice. This stays separate from EVSE/control-pilot, automotive SENT/PSI5, gate-driver, and generic proximity-detection alias work.

## Verification
- `bun test tests/test4-hvil-pin-labels.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check lib/scorePhrase.ts tests/test4-hvil-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and verification output before opening this PR.