### PR TITLE
Score current transformer pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(ROGOWSKI_COIL|ROGOWSKI_OUT|CURRENT_CLAMP|CT_SECONDARY|CT_BURDEN|ZERO_FLUX|FLUXGATE_OUT|BURDEN_REF)\d*([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-current-transformer-pin-labels.test.tsx
+++ b/tests/test4-current-transformer-pin-labels.test.tsx
@@ -1,0 +1,33 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves current transformer and Rogowski pin labels in readable net names", () => {
+  expect(scorePhrase("ROGOWSKI_COIL1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("CURRENT_CLAMP1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("CT_SECONDARY1")).toBeGreaterThan(scorePhrase("pos"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="CURRENT_MONITOR"
+        pinLabels={{
+          pin1: ["ROGOWSKI_COIL1", "CURRENT_CLAMP1"],
+          pin2: ["CT_SECONDARY1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .ROGOWSKI_COIL1" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ROGOWSKI_COIL1")
+  expect(netlist).toContain("  - U1 ROGOWSKI_COIL1 (CURRENT_CLAMP1)")
+  expect(netlist).not.toContain("NET: R1_pos")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for Rogowski coil / current clamp / current-transformer secondary aliases before the generic digit fallback
- cover labels such as `ROGOWSKI_COIL1`, `CURRENT_CLAMP1`, and `CT_SECONDARY1` so readable NET names do not fall back to passive labels like `pos`
- add a regression test for generated net names and readable pin entries

/claim #4

## Non-overlap check
I searched existing PR titles/bodies and issue comments for ROGOWSKI, CURRENT_CLAMP, CT_SECONDARY, CURRENT_TRANSFORMER, BURDEN_RES, ZERO_FLUX, and related terms and did not find an existing slice. This stays separate from generic current-sense/shunt monitor labels, load-cell/bridge labels, and Hall/magnetic sensor aliases.

## Verification
- `bun test tests/test4-current-transformer-pin-labels.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check lib/scorePhrase.ts tests/test4-current-transformer-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and verification output before opening this PR.