### PR TITLE
Score resistive touch pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(RESISTIVE_TOUCH|XPT2046_IRQ|TSC2046_IRQ|ADS7843_IRQ|PENIRQ|PEN_IRQ|TOUCHSCREEN_IRQ|XP_YP|XM_YM)\d*([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-resistive-touch-pin-labels.test.tsx
+++ b/tests/test4-resistive-touch-pin-labels.test.tsx
@@ -1,0 +1,33 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves resistive touchscreen pin labels in readable net names", () => {
+  expect(scorePhrase("XPT2046_IRQ1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("PENIRQ1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("ADS7843_IRQ1")).toBeGreaterThan(scorePhrase("pos"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="XPT2046"
+        pinLabels={{
+          pin1: ["XPT2046_IRQ1", "PENIRQ1"],
+          pin2: ["ADS7843_IRQ1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .XPT2046_IRQ1" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_XPT2046_IRQ1")
+  expect(netlist).toContain("  - U1 XPT2046_IRQ1 (PENIRQ1)")
+  expect(netlist).not.toContain("NET: R1_pos")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for resistive touchscreen controller aliases before the generic digit fallback
- cover labels such as `XPT2046_IRQ1`, `PENIRQ1`, and `ADS7843_IRQ1` so readable NET names do not fall back to passive labels like `pos`
- add a regression test for generated net names and readable pin entries

/claim #4

## Non-overlap check
I searched existing PR titles/bodies and issue comments for RESISTIVE_TOUCH, XPT2046, TSC2046, ADS7843, PENIRQ, PEN_IRQ, TOUCHSCREEN_IRQ, XP_YP, and XM_YM and found no existing slice. The nearby touch work in #138 covers capacitive touch/proximity aliases such as TOUCH0, CAPSENSE, CSD, CSX, CTSU, and PROX_INT; this PR stays scoped to resistive touchscreen controller labels.

## Verification
- `bun test tests/test4-resistive-touch-pin-labels.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check lib/scorePhrase.ts tests/test4-resistive-touch-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and verification output before opening this PR.