### PR TITLE
Score TDC pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(TDC_START|TDC_STOP|TDC_DONE|TDC_INT|TIME_TO_DIGITAL|TIME_DIGITAL_READY|PULSE_MEAS)\d*([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-tdc-pin-labels.test.tsx
+++ b/tests/test4-tdc-pin-labels.test.tsx
@@ -1,0 +1,33 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves time-to-digital converter pin labels in readable net names", () => {
+  expect(scorePhrase("TDC_START1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("TDC_STOP1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("TIME_TO_DIGITAL1")).toBeGreaterThan(scorePhrase("pos"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="TDC7200"
+        pinLabels={{
+          pin1: ["TDC_START1", "TDC_STOP1"],
+          pin2: ["TIME_TO_DIGITAL1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .TDC_START1" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_TDC_START1")
+  expect(netlist).toContain("  - U1 TDC_START1 (TDC_STOP1)")
+  expect(netlist).not.toContain("NET: R1_pos")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for time-to-digital converter aliases before the generic digit fallback
- cover labels such as `TDC_START1`, `TDC_STOP1`, and `TIME_TO_DIGITAL1` so readable NET names do not fall back to passive labels like `pos`
- add a regression test for generated net names and readable pin entries

/claim #4

## Non-overlap check
I searched existing PR titles/bodies and issue comments for TDC_START, TDC_STOP, TDC_DONE, TDC_INT, TIME_DIGITAL, TIME_TO_DIGITAL, and PULSE_MEAS and found no existing slice. This stays separate from precision ADC/DAC converter aliases, GNSS timepulse labels, PLL/clock-generator aliases, and ultrasonic/rangefinder sensor labels.

## Verification
- `bun test tests/test4-tdc-pin-labels.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check lib/scorePhrase.ts tests/test4-tdc-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and verification output before opening this PR.