### PR TITLE
Score HVAC controller pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -16,6 +16,11 @@ const wordQualityScore = {
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  HVAC_COMP: 1.12,
+  COMPRESSOR: 1.12,
+  FAN_RELAY: 1.12,
+  DEFROST: 1.12,
+  THERMOSTAT: 1.12,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -35,14 +40,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
-export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+export const scorePhrase = (phrase: string): number => {
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-hvac-controller-pin-labels.test.ts
+++ b/tests/test4-hvac-controller-pin-labels.test.ts
@@ -1,0 +1,114 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves HVAC controller aliases on generic physical pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_u1",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "HVAC_CTRL",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_comp",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "14", "HVAC_COMP1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_fan",
+      source_component_id: "source_component_u1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["pin15", "15", "FAN_RELAY1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_defrost",
+      source_component_id: "source_component_u1",
+      name: "pin16",
+      pin_number: 16,
+      port_hints: ["pin16", "16", "DEFROST1"],
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_r1",
+      ftype: "simple_resistor",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1p1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_r2",
+      ftype: "simple_resistor",
+      name: "R2",
+      resistance: 1000,
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r2p1",
+      source_component_id: "source_component_r2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_r3",
+      ftype: "simple_resistor",
+      name: "R3",
+      resistance: 1000,
+      display_resistance: "1kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r3p1",
+      source_component_id: "source_component_r3",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left", "pin1", "1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_comp",
+      connected_source_port_ids: ["source_port_comp", "source_port_r1p1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_fan",
+      connected_source_port_ids: ["source_port_fan", "source_port_r2p1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_defrost",
+      connected_source_port_ids: ["source_port_defrost", "source_port_r3p1"],
+      connected_source_net_ids: [],
+    },
+  ] satisfies AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_HVAC_COMP1")
+  expect(netlist).toContain("  - U1 pin14 (HVAC_COMP1)")
+  expect(netlist).toContain("NET: U1_FAN_RELAY1")
+  expect(netlist).toContain("  - U1 pin15 (FAN_RELAY1)")
+  expect(netlist).toContain("NET: U1_DEFROST1")
+  expect(netlist).toContain("  - U1 pin16 (DEFROST1)")
+})


### PR DESCRIPTION
## Summary
- score HVAC compressor/fan/defrost controller aliases before the generic numeric fallback
- add a regression test for generic physical pins carrying `HVAC_COMP1`, `FAN_RELAY1`, and `DEFROST1` hints

## Validation
- `bun test tests/test4-hvac-controller-pin-labels.test.ts`
- `bun test`
- `bunx biome check lib/scorePhrase.ts tests/test4-hvac-controller-pin-labels.test.ts`
- `bun run build`
- `git diff --check`

/claim #4