### PR TITLE
Score IMU pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(IMU_INT[12]|ACCEL_INT[12]|GYRO_INT[12]|INT[12]|DRDY\d*|DATA_READY\d*|FSYNC\d*|FRAME_SYNC\d*|SDO_SA0|SA0|AD0)([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-imu-pin-labels.test.tsx
+++ b/tests/test4-imu-pin-labels.test.tsx
@@ -1,0 +1,38 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves IMU interrupt and sync pin labels in readable net names", () => {
+  expect(scorePhrase("INT1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("FSYNC1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("SDO_SA0")).toBeGreaterThan(scorePhrase("pin8"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn24"
+        manufacturerPartNumber="ICM-42688-P"
+        pinLabels={{
+          pin1: ["INT1", "DRDY"],
+          pin2: ["FSYNC1"],
+          pin3: ["SDO_SA0"],
+          pin4: ["VDDIO"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .INT1" to=".R1 > .pin1" />
+      <trace from=".U1 .FSYNC1" to=".R2 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_INT1")
+  expect(netlist).toContain("  - U1 INT1 (DRDY)")
+  expect(netlist).toContain("NET: U1_FSYNC1")
+  expect(netlist).toContain("  - U1 FSYNC1")
+})


### PR DESCRIPTION
## Summary
- score common IMU/inertial sensor pin aliases before the numeric-pin fallback
- preserve labels such as INT1, FSYNC1, and SDO_SA0 in readable net names
- add a regression test covering generated readable net output

/claim #4

## Verification
- bun test tests/test4-imu-pin-labels.test.tsx
- bun test
- bunx biome check lib/scorePhrase.ts tests/test4-imu-pin-labels.test.tsx
- bun run build
- git diff --check