### PR TITLE
Score NFC and RFID pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(NFC_IRQ\d*|RFID_IRQ\d*|FIELD_DET\d*|RF_FIELD\d*|NFC_FIELD\d*|RFID_FIELD\d*|ANT[12])([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-nfc-rfid-pin-labels.test.tsx
+++ b/tests/test4-nfc-rfid-pin-labels.test.tsx
@@ -1,0 +1,38 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves NFC and RFID reader pin labels in readable net names", () => {
+  expect(scorePhrase("NFC_IRQ1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("FIELD_DET1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("ANT1")).toBeGreaterThan(scorePhrase("pin8"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="PN532"
+        pinLabels={{
+          pin1: ["NFC_IRQ1"],
+          pin2: ["FIELD_DET1"],
+          pin3: ["ANT1"],
+          pin4: ["ANT2"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="10pF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .NFC_IRQ1" to=".R1 > .pin1" />
+      <trace from=".U1 .FIELD_DET1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_NFC_IRQ1")
+  expect(netlist).toContain("  - U1 NFC_IRQ1")
+  expect(netlist).toContain("NET: U1_FIELD_DET1")
+  expect(netlist).toContain("  - U1 FIELD_DET1")
+})


### PR DESCRIPTION
## Summary
- score NFC/RFID reader aliases before the numeric-pin fallback
- preserve labels such as NFC_IRQ1, FIELD_DET1, and ANT1 in readable net names
- add a regression test covering generated readable net output

/claim #4

## Verification
- bun test tests/test4-nfc-rfid-pin-labels.test.tsx
- bun test
- bunx biome check lib/scorePhrase.ts tests/test4-nfc-rfid-pin-labels.test.tsx
- bun run build
- git diff --check