### PR TITLE
Score Arduino shield pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])((ARDUINO|UNO)_([AD]\d+|SCL|SDA|AREF|IOREF|VIN)|MEGA_([AD]\d+|SCL|SDA|AREF|IOREF|VIN)|SHIELD_([AD]\d+|SCL|SDA|AREF|IOREF|VIN))([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-arduino-shield-pin-labels.test.tsx
+++ b/tests/test4-arduino-shield-pin-labels.test.tsx
@@ -1,0 +1,38 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves Arduino shield pin labels in readable net names", () => {
+  expect(scorePhrase("ARDUINO_D13")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("ARDUINO_A0")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("SHIELD_IOREF")).toBeGreaterThan(scorePhrase("pin8"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="dip28"
+        manufacturerPartNumber="ATMEGA328P"
+        pinLabels={{
+          pin1: ["ARDUINO_D13"],
+          pin2: ["ARDUINO_A0"],
+          pin3: ["SHIELD_IOREF"],
+          pin4: ["UNO_SCL"],
+        }}
+      />
+      <resistor resistance="330" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .ARDUINO_D13" to=".R1 > .pin1" />
+      <trace from=".U1 .ARDUINO_A0" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ARDUINO_D13")
+  expect(netlist).toContain("  - U1 ARDUINO_D13")
+  expect(netlist).toContain("NET: U1_ARDUINO_A0")
+  expect(netlist).toContain("  - U1 ARDUINO_A0")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for Arduino/Uno/Mega/shield header aliases before the generic digit fallback
- preserve labels like `ARDUINO_D13` and `ARDUINO_A0` in generated NET names and readable pin entries when the physical source port name is generic
- add regression coverage for Arduino shield/header labels on a generic chip pin path

This scope is intentionally separate from PMOD, maker-connector, GPIO, and generic numbered-pin label slices.

## Verification
- `bun test tests/test4-arduino-shield-pin-labels.test.tsx`
- `bunx biome check lib/scorePhrase.ts tests/test4-arduino-shield-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before submission.