### PR TITLE
Score Raspberry Pi HAT pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])((RPI|RASPI|RASPBERRY_PI|PI)_(GPIO\d+|ID_(SD|SC)|HAT_ID_(SD|SC)|3V3|5V|RUN|GLOBAL_EN)|HAT_ID_(SD|SC))([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-raspberry-pi-hat-pin-labels.test.tsx
+++ b/tests/test4-raspberry-pi-hat-pin-labels.test.tsx
@@ -1,0 +1,38 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves Raspberry Pi HAT pin labels in readable net names", () => {
+  expect(scorePhrase("RPI_GPIO17")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("PI_5V")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("HAT_ID_SD")).toBeGreaterThan(scorePhrase("pin8"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="dip28"
+        manufacturerPartNumber="Raspberry Pi HAT header"
+        pinLabels={{
+          pin1: ["RPI_GPIO17"],
+          pin2: ["HAT_ID_SD"],
+          pin3: ["PI_5V"],
+          pin4: ["HAT_ID_SC"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="1uF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .RPI_GPIO17" to=".R1 > .pin1" />
+      <trace from=".U1 .HAT_ID_SD" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_RPI_GPIO17")
+  expect(netlist).toContain("  - U1 RPI_GPIO17")
+  expect(netlist).toContain("NET: U1_HAT_ID_SD")
+  expect(netlist).toContain("  - U1 HAT_ID_SD")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for Raspberry Pi/HAT header aliases before the generic digit fallback
- preserve labels like `RPI_GPIO17` and `HAT_ID_SD` in generated NET names and readable pin entries when the physical source port name is generic
- add regression coverage for Raspberry Pi HAT/header labels on a generic chip pin path

This scope is intentionally separate from Arduino shield, PMOD, maker-connector, GPIO-expander, and generic numbered-pin label slices.

## Verification
- `bun test tests/test4-raspberry-pi-hat-pin-labels.test.tsx`
- `bunx biome check lib/scorePhrase.ts tests/test4-raspberry-pi-hat-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before submission.