### PR TITLE
Score microbit edge pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])((BBC_)?MICRO_?BIT_?(P\d+|EDGE_P\d+|PAD\d+|LOGO|SPEAKER|BUTTON_[AB]|I2C_(SCL|SDA)|UART_(TX|RX))|EDGE_(P\d+|PAD\d+))([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-microbit-edge-pin-labels.test.tsx
+++ b/tests/test4-microbit-edge-pin-labels.test.tsx
@@ -1,0 +1,38 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves microbit edge connector pin labels in readable net names", () => {
+  expect(scorePhrase("MICROBIT_P0")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("EDGE_P1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("MICROBIT_LOGO")).toBeGreaterThan(scorePhrase("pin8"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="dip28"
+        manufacturerPartNumber="BBC micro:bit edge connector"
+        pinLabels={{
+          pin1: ["MICROBIT_P0"],
+          pin2: ["EDGE_P1"],
+          pin3: ["MICROBIT_LOGO"],
+          pin4: ["MICROBIT_BUTTON_A"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="1uF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .MICROBIT_P0" to=".R1 > .pin1" />
+      <trace from=".U1 .EDGE_P1" to=".C1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_MICROBIT_P0")
+  expect(netlist).toContain("  - U1 MICROBIT_P0")
+  expect(netlist).toContain("NET: U1_EDGE_P1")
+  expect(netlist).toContain("  - U1 EDGE_P1")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for BBC micro:bit edge-connector aliases before the generic digit fallback
- preserve labels like `MICROBIT_P0` and `EDGE_P1` in generated NET names and readable pin entries when the physical source port name is generic
- add regression coverage for micro:bit edge-connector labels on a generic chip pin path

This scope is intentionally separate from Arduino shield, Raspberry Pi HAT, PMOD, maker-connector, GPIO-expander, and generic numbered-pin label slices.

## Verification
- `bun test tests/test4-microbit-edge-pin-labels.test.tsx`
- `bunx biome check lib/scorePhrase.ts tests/test4-microbit-edge-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before submission.