### PR TITLE
Score EV charging pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase().replace(/[^A-Z0-9]+/g, "_")
+  if (
+    /(^|_)(EVSE|J1772|CCS|CHADEMO)(_|$)/.test(normalizedPhrase) ||
+    /(^|_)(CONTROL_PILOT|PROXIMITY_PILOT|CHARGE_PORT)(\d|_|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.25
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/evse-charging-pin-labels.test.tsx
+++ b/tests/evse-charging-pin-labels.test.tsx
@@ -1,0 +1,39 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves EV charging control aliases in readable net names and pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="EVSECTRL"
+        pinLabels={{
+          pin14: ["GPIO14", "EVSE_CP1"],
+          pin15: ["GPIO15", "J1772_PP1"],
+          pin16: ["GPIO16", "CCS_PROX1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="2k" footprint="0402" name="R2" />
+      <resistor resistance="3k" footprint="0402" name="R3" />
+
+      <trace from=".U1 .EVSE_CP1" to=".R1 > .pin1" />
+      <trace from=".U1 .J1772_PP1" to=".R2 > .pin1" />
+      <trace from=".U1 .CCS_PROX1" to=".R3 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_EVSE_CP1")
+  expect(netlist).toContain("NET: U1_J1772_PP1")
+  expect(netlist).toContain("NET: U1_CCS_PROX1")
+  expect(netlist).toContain("  - U1 GPIO14 (EVSE_CP1)")
+  expect(netlist).toContain("  - U1 GPIO15 (J1772_PP1)")
+  expect(netlist).toContain("  - U1 GPIO16 (CCS_PROX1)")
+  expect(netlist).toContain("- pin14(GPIO14, EVSE_CP1): NETS(U1_EVSE_CP1)")
+  expect(netlist).toContain("- pin15(GPIO15, J1772_PP1): NETS(U1_J1772_PP1)")
+  expect(netlist).toContain("- pin16(GPIO16, CCS_PROX1): NETS(U1_CCS_PROX1)")
+})


### PR DESCRIPTION
## Summary
- score EV charging / EVSE aliases before the generic digit fallback
- preserve labels like `EVSE_CP1`, `J1772_PP1`, and `CCS_PROX1` in generated readable net names
- add focused regression coverage for NET names, readable pin entries, and COMPONENT_PINS output

## Tests
- `bun test tests/evse-charging-pin-labels.test.tsx`
- `bun test`
- `bunx tsc --noEmit`
- `bunx biome check lib/scorePhrase.ts tests/evse-charging-pin-labels.test.tsx`
- `bun run build`
- `git diff --check`

/claim #4