### PR TITLE
Score powerline modem pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])((G3|PRIME)_?PLC|HOMEPLUG|IEEE_?1901|G_?HN|POWERLINE)([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-powerline-modem-pin-labels.test.tsx
+++ b/tests/test4-powerline-modem-pin-labels.test.tsx
@@ -1,0 +1,45 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores powerline communication modem pin labels before numeric fallback", () => {
+  expect(scorePhrase("G3_PLC_TX1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("PRIME_PLC_RX1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("HOMEPLUG_AV1")).toBeGreaterThan(scorePhrase("pin3"))
+  expect(scorePhrase("IEEE1901_TX1")).toBeGreaterThan(scorePhrase("neg"))
+})
+
+it("keeps powerline modem labels in readable net names and pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="POWERLINE-MODEM"
+        pinLabels={{
+          pin1: ["G3_PLC_TX1"],
+          pin2: ["PRIME_PLC_RX1"],
+          pin3: ["HOMEPLUG_AV1"],
+          pin4: ["IEEE1901_TX1"],
+          pin5: ["GPIO1"],
+          pin6: ["VDD"],
+          pin7: ["GND"],
+          pin8: ["NC"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .G3_PLC_TX1" to=".R1 .pin1" />
+      <trace from=".U1 .PRIME_PLC_RX1" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_G3_PLC_TX1")
+  expect(netlist).toContain("  - U1 G3_PLC_TX1")
+  expect(netlist).toContain("NET: U1_PRIME_PLC_RX1")
+  expect(netlist).toContain("  - U1 PRIME_PLC_RX1")
+})


### PR DESCRIPTION
## Summary
- add focused scoring for powerline communication aliases such as G3_PLC_TX1, PRIME_PLC_RX1, HOMEPLUG_AV1, IEEE1901_TX1, and G.hn before the generic digit fallback
- add regression coverage showing readable NET names and pin entries preserve those labels

## Verification
- bun test tests/test4-powerline-modem-pin-labels.test.tsx
- bun x biome check lib/scorePhrase.ts tests/test4-powerline-modem-pin-labels.test.tsx
- bun test
- bun run build
- git diff --check

/claim #4