### PR TITLE
Score single-pair Ethernet pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(10BASE[_-]?T1[SL]?|100BASE[_-]?T1|1000BASE[_-]?T1|T1[SL]|SPE|TC10|OPENALLIANCE)([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-single-pair-ethernet-pin-labels.test.tsx
+++ b/tests/test4-single-pair-ethernet-pin-labels.test.tsx
@@ -1,0 +1,80 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores single-pair ethernet pin labels before digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="LAN8670"
+        pinLabels={{
+          pin1: ["T1S_P1"],
+          pin2: ["T1L_RXP1"],
+          pin3: ["TC10_WAKE1"],
+          pin4: ["OPENALLIANCE_IRQ1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .T1S_P1" to=".R1 .pin1" />
+      <trace from=".U1 .T1L_RXP1" to=".C1 .pin1" />
+      <trace from=".U1 .TC10_WAKE1" to=".R1 .pin2" />
+      <trace from=".U1 .OPENALLIANCE_IRQ1" to=".C1 .pin2" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: LAN8670, soic8
+     - R1: 1kΩ 0402 resistor
+     - C1: 1nF 0402 capacitor
+
+    NET: U1_T1S_P1
+      - U1 T1S_P1
+      - R1 pin1
+
+    NET: U1_T1L_RXP1
+      - U1 T1L_RXP1
+      - C1 pin1 (+)
+
+    NET: U1_TC10_WAKE1
+      - U1 TC10_WAKE1
+      - R1 pin2
+
+    NET: U1_OPENALLIANCE_IRQ1
+      - U1 OPENALLIANCE_IRQ1
+      - C1 pin2 (-)
+
+
+    COMPONENT_PINS:
+    U1 (LAN8670)
+    - pin1(T1S_P1): NETS(U1_T1S_P1)
+    - pin2(T1L_RXP1): NETS(U1_T1L_RXP1)
+    - pin3(TC10_WAKE1): NETS(U1_TC10_WAKE1)
+    - pin4(OPENALLIANCE_IRQ1): NETS(U1_OPENALLIANCE_IRQ1)
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_T1S_P1)
+    - pin2(cathode, neg, right): NETS(U1_TC10_WAKE1)
+
+    C1 (1nF 0402)
+    - pin1(pos, anode, left): NETS(U1_T1L_RXP1)
+    - pin2(neg, cathode, right): NETS(U1_OPENALLIANCE_IRQ1)
+    "
+  `)
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Summary
- Add focused scoring for single-pair Ethernet / OPEN Alliance TC10 aliases before the generic digit fallback.
- Preserve `T1S_P1`, `T1L_RXP1`, `TC10_WAKE1`, and `OPENALLIANCE_IRQ1` in generated `NET:` names and readable pin entries instead of falling back to passive labels like `pos` or physical labels like `pin14`.
- Add regression coverage for generated net names and component pin entries.

## Verification
- `bun test tests/test4-single-pair-ethernet-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/test4-single-pair-ethernet-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.