### PR TITLE
Score SDR baseband IQ pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(SDR|BASEBAND|IQ_?SEL[0-9]*|I_?OUT[0-9]*|Q_?OUT[0-9]*|I_?IN[0-9]*|Q_?IN[0-9]*)([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-sdr-baseband-iq-pin-labels.test.tsx
+++ b/tests/test4-sdr-baseband-iq-pin-labels.test.tsx
@@ -1,0 +1,80 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores SDR baseband I/Q pin labels before digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="AD9361"
+        pinLabels={{
+          pin1: ["SDR_I1"],
+          pin2: ["BASEBAND_Q1"],
+          pin3: ["IQ_SEL1"],
+          pin4: ["Q_OUT1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .SDR_I1" to=".R1 .pin1" />
+      <trace from=".U1 .BASEBAND_Q1" to=".C1 .pin1" />
+      <trace from=".U1 .IQ_SEL1" to=".R1 .pin2" />
+      <trace from=".U1 .Q_OUT1" to=".C1 .pin2" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: AD9361, soic8
+     - R1: 1kΩ 0402 resistor
+     - C1: 1nF 0402 capacitor
+
+    NET: U1_SDR_I1
+      - U1 SDR_I1
+      - R1 pin1
+
+    NET: U1_BASEBAND_Q1
+      - U1 BASEBAND_Q1
+      - C1 pin1 (+)
+
+    NET: U1_IQ_SEL1
+      - U1 IQ_SEL1
+      - R1 pin2
+
+    NET: U1_Q_OUT1
+      - U1 Q_OUT1
+      - C1 pin2 (-)
+
+
+    COMPONENT_PINS:
+    U1 (AD9361)
+    - pin1(SDR_I1): NETS(U1_SDR_I1)
+    - pin2(BASEBAND_Q1): NETS(U1_BASEBAND_Q1)
+    - pin3(IQ_SEL1): NETS(U1_IQ_SEL1)
+    - pin4(Q_OUT1): NETS(U1_Q_OUT1)
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_SDR_I1)
+    - pin2(cathode, neg, right): NETS(U1_IQ_SEL1)
+
+    C1 (1nF 0402)
+    - pin1(pos, anode, left): NETS(U1_BASEBAND_Q1)
+    - pin2(neg, cathode, right): NETS(U1_Q_OUT1)
+    "
+  `)
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Summary
- Add focused scoring for SDR / baseband I-Q aliases before the generic digit fallback.
- Preserve `SDR_I1`, `BASEBAND_Q1`, `IQ_SEL1`, and `Q_OUT1` in generated `NET:` names and readable pin entries instead of falling back to passive labels like `neg` or physical labels like `pin14`.
- Add regression coverage for generated net names and component pin entries.

## Verification
- `bun test tests/test4-sdr-baseband-iq-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/test4-sdr-baseband-iq-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.