### PR TITLE
Score PIC ICSP pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])((PIC_?)?ICSP(DATA|DAT|CLK)?[0-9]*|PGC[0-9]*|PGD[0-9]*|PICKIT(_?(CLK|DAT))?[0-9]*|MCLR_N?)([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-pic-icsp-pin-labels.test.tsx
+++ b/tests/test4-pic-icsp-pin-labels.test.tsx
@@ -1,0 +1,80 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores PIC ICSP programming pin labels before digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="PIC16F18313"
+        pinLabels={{
+          pin1: ["ICSPDAT1"],
+          pin2: ["ICSPCLK1"],
+          pin3: ["PGC1"],
+          pin4: ["PGD1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .ICSPDAT1" to=".R1 .pin1" />
+      <trace from=".U1 .ICSPCLK1" to=".C1 .pin1" />
+      <trace from=".U1 .PGC1" to=".R1 .pin2" />
+      <trace from=".U1 .PGD1" to=".C1 .pin2" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: PIC16F18313, soic8
+     - R1: 1kΩ 0402 resistor
+     - C1: 1nF 0402 capacitor
+
+    NET: U1_ICSPDAT1
+      - U1 ICSPDAT1
+      - R1 pin1
+
+    NET: U1_ICSPCLK1
+      - U1 ICSPCLK1
+      - C1 pin1 (+)
+
+    NET: U1_PGC1
+      - U1 PGC1
+      - R1 pin2
+
+    NET: U1_PGD1
+      - U1 PGD1
+      - C1 pin2 (-)
+
+
+    COMPONENT_PINS:
+    U1 (PIC16F18313)
+    - pin1(ICSPDAT1): NETS(U1_ICSPDAT1)
+    - pin2(ICSPCLK1): NETS(U1_ICSPCLK1)
+    - pin3(PGC1): NETS(U1_PGC1)
+    - pin4(PGD1): NETS(U1_PGD1)
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_ICSPDAT1)
+    - pin2(cathode, neg, right): NETS(U1_PGC1)
+
+    C1 (1nF 0402)
+    - pin1(pos, anode, left): NETS(U1_ICSPCLK1)
+    - pin2(neg, cathode, right): NETS(U1_PGD1)
+    "
+  `)
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Summary
- Add focused scoring for PIC ICSP / PICkit programming aliases before the generic digit fallback.
- Preserve `ICSPDAT1`, `ICSPCLK1`, `PGC1`, and `PGD1` in generated `NET:` names and readable pin entries instead of falling back to passive labels or physical labels like `pin14`.
- Add regression coverage for generated net names and component pin entries.

## Verification
- `bun test tests/test4-pic-icsp-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/test4-pic-icsp-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.