### PR TITLE
Score timing and timecode pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,12 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  PTP: 1.2,
+  IRIGB: 1.2,
+  IRIG: 1.2,
+  PPS: 1.2,
+  TIMEPULSE: 1.2,
+  TOD: 1.15,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -36,13 +42,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/score-phrase.test.ts
+++ b/tests/score-phrase.test.ts
@@ -1,0 +1,9 @@
+import { expect, it } from "bun:test"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores timecode pin aliases above generic numbered labels", () => {
+  expect(scorePhrase("PTP_1588")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("IRIGB1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("1PPS")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("TIMEPULSE")).toBeGreaterThan(scorePhrase("pos"))
+})

--- a/tests/timecode-pin-labels.test.tsx
+++ b/tests/timecode-pin-labels.test.tsx
@@ -1,0 +1,29 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("uses timing and timecode aliases instead of generic numbered pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="TIME-SYNC-IC"
+        pinLabels={{
+          pin14: ["PTP_1588", "IRIGB1", "1PPS"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .PTP_1588" to=".R1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_PTP_1588")
+  expect(netlist).toContain("U1 PTP_1588 (IRIGB1,1PPS)")
+  expect(netlist).toContain(
+    "- pin14(PTP_1588, IRIGB1, 1PPS): NETS(U1_PTP_1588)",
+  )
+})


### PR DESCRIPTION
## Summary
- score timing/timecode aliases such as `PTP_1588`, `IRIGB1`, `1PPS`, `TIMEPULSE`, and `TOD` as useful readable pin labels
- check known technical vocabulary before applying the generic digit penalty
- add direct scoring coverage and an end-to-end readable netlist regression

## Verification
- `npx bun test`
- `npx biome check lib/scorePhrase.ts tests/score-phrase.test.ts tests/timecode-pin-labels.test.tsx`
- `npx tsc --noEmit`
- `git diff --check`

Note: `bun test` prints a parent-directory PermissionDenied diagnostic in this local Codex workspace while still exiting 0 with all tests passing.

/claim #4