### PR TITLE
Fix readable netlist pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,16 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        header = `${component.name} (${[component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        header = `${component.name} (${[
+          component.display_capacitance,
+          footprint,
+        ]
+          .filter(Boolean)
+          .join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -15,7 +15,11 @@ const wordQualityScore = {
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
+  ADC: 1.15,
+  UART: 1.15,
+  SPI: 1.15,
   GPIO: 1.1,
+  GP: 1.1,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
@@ -36,13 +40,12 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.toUpperCase()
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
   }
+  if (phrase.match(/\d+/)) return 0.5
   return 1
 }

--- a/tests/test4-pin-label-regressions.test.tsx
+++ b/tests/test4-pin-label-regressions.test.tsx
@@ -1,0 +1,43 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("includes useful numeric pin aliases in readable pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="TEST"
+        pinLabels={{
+          pin14: ["GP25", "ADC2"],
+        }}
+      />
+      <trace from=".U1 .GP25" to="net.SENSOR" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("  - U1 GP25 (ADC2)")
+  expect(netlist).toContain("- pin14(GP25, ADC2): NETS(SENSOR)")
+})
+
+it("does not include undefined in resistor pin section headings", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <resistor name="R1" resistance="1k" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("R1 (1kΩ)")
+})


### PR DESCRIPTION
/claim #4\n\nFixes #4.\n\nChanges:\n- Preserve useful numeric chip pin aliases like GP25/ADC2 in readable pin labels instead of suppressing them as generic numeric strings.\n- Avoid rendering undefined in resistor/capacitor component pin section headings when there is no footprint.\n- Add regression coverage for both cases.\n\nTested:\n- npx --yes bun test