### PR TITLE
Score BMC platform management pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,12 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  MCTP: 1.2,
+  PECI: 1.2,
+  IPMI: 1.2,
+  SGPIO: 1.2,
+  SMBALERT: 1.2,
+  BMC: 1.15,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -36,13 +42,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/platform-management-pin-labels.test.tsx
+++ b/tests/platform-management-pin-labels.test.tsx
@@ -1,0 +1,37 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores platform-management aliases above generic numbered labels", () => {
+  expect(scorePhrase("MCTP_ALERT1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("PECI_DATA1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("IPMI_IRQ1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("SGPIO_CLK1")).toBeGreaterThan(scorePhrase("pin14"))
+})
+
+it("uses platform-management aliases instead of generic numbered pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="BMC-SIDEBAND-IC"
+        pinLabels={{
+          pin14: ["MCTP_ALERT1", "PECI_DATA1", "IPMI_IRQ1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .MCTP_ALERT1" to=".R1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_MCTP_ALERT1")
+  expect(netlist).toContain("U1 MCTP_ALERT1 (PECI_DATA1,IPMI_IRQ1)")
+  expect(netlist).toContain(
+    "- pin14(MCTP_ALERT1, PECI_DATA1, IPMI_IRQ1): NETS(U1_MCTP_ALERT1)",
+  )
+})


### PR DESCRIPTION
## Summary
- score BMC/platform-management sideband aliases such as `MCTP_ALERT1`, `PECI_DATA1`, `IPMI_IRQ1`, and `SGPIO_CLK1`
- check explicit technical vocabulary before the generic digit fallback
- add regression coverage for scoring and generated readable netlist output

## Verification
- `npx bun test tests/platform-management-pin-labels.test.tsx`
- `npx bun test`
- `npx biome check lib/scorePhrase.ts tests/platform-management-pin-labels.test.tsx`
- `npx tsc --noEmit`
- `git diff --check`

Note: `bun test` prints a parent-directory PermissionDenied diagnostic in this local Codex workspace while still exiting 0 with all tests passing.

/claim #4