### PR TITLE
fix: preserve ESP32 strapping pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -15,6 +15,12 @@ const wordQualityScore = {
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
+  MTDI: 1.15,
+  MTDO: 1.15,
+  U0RXD: 1.15,
+  U0TXD: 1.15,
+  CHIP_PU: 1.15,
+  BOOT: 1.15,
   GPIO: 1.1,
   cathode: 0.5,
   anode: 0.5,
@@ -36,6 +42,9 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  if (/^U0(?:RXD|TXD)$/.test(phrase)) {
+    return 1.15
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-esp32-strapping-labels.test.tsx
+++ b/tests/test4-esp32-strapping-labels.test.tsx
@@ -1,0 +1,69 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves ESP32 strapping and bootloader pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="ESP32-S3"
+        pinLabels={{
+          pin1: ["GPIO12", "MTDI"],
+          pin2: ["GPIO15", "MTDO"],
+          pin3: ["GPIO0", "BOOT"],
+          pin4: ["GPIO3", "U0RXD"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+      <trace from=".U1 .GPIO12" to=".R1 .pin1" />
+      <trace from=".U1 .GPIO15" to=".R2 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: ESP32-S3, soic8
+     - R1: 10kΩ 0402 resistor
+     - R2: 10kΩ 0402 resistor
+
+    NET: U1_MTDI
+      - U1 GPIO12 (MTDI)
+      - R1 pin1
+
+    NET: U1_MTDO
+      - U1 GPIO15 (MTDO)
+      - R2 pin1
+
+
+    COMPONENT_PINS:
+    U1 (ESP32-S3)
+    - pin1(GPIO12, MTDI): NETS(U1_MTDI)
+    - pin2(GPIO15, MTDO): NETS(U1_MTDO)
+    - pin3(GPIO0, BOOT): NOT_CONNECTED
+    - pin4(GPIO3, U0RXD): NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_MTDI)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R2 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_MTDO)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary

- Add scoring for ESP32 bootstrapping / ROM UART aliases (`MTDI`, `MTDO`, `U0RXD`, `U0TXD`, `CHIP_PU`, `BOOT`)
- Preserve those labels in generated NET names and pin labels instead of falling back to generic GPIO labels
- Add a focused regression test for ESP32-S3 strapping pins

Fixes #4

## Test Plan

- `bun test`
- `bun run format:check`
