### PR TITLE
Score Ethernet PHY pin labels in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -8,41 +8,47 @@
  * These unique port names are usually the best indicator of what the net is for
  */
 const wordQualityScore = {
-  MISO: 1.2,
-  MOSI: 1.2,
-  SCLK: 1.2,
-  SDA: 1.2,
-  SCL: 1.2,
-  RX: 1.15,
-  TX: 1.15,
-  GPIO: 1.1,
-  cathode: 0.5,
-  anode: 0.5,
-  GND: 1.1,
-  VDD: 1.1,
-  AGND: 1.1,
-  V5: 1.1,
-  V3: 1.1,
-  V1: 1.1,
-  neg: 0.9,
-  pos: 0.9,
-  pin: 0.5,
-  left: 0.3,
-  right: 0.3,
-}
+	MISO: 1.2,
+	MOSI: 1.2,
+	SCLK: 1.2,
+	SDA: 1.2,
+	SCL: 1.2,
+	RX: 1.15,
+	TX: 1.15,
+	TXP: 1.18,
+	TXN: 1.18,
+	RXP: 1.18,
+	RXN: 1.18,
+	MDIO: 1.18,
+	MDC: 1.18,
+	GPIO: 1.1,
+	cathode: 0.5,
+	anode: 0.5,
+	GND: 1.1,
+	VDD: 1.1,
+	AGND: 1.1,
+	V5: 1.1,
+	V3: 1.1,
+	V1: 1.1,
+	neg: 0.9,
+	pos: 0.9,
+	pin: 0.5,
+	left: 0.3,
+	right: 0.3,
+};
 
 const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
-  (a, b) => b[1] - a[1],
-)
+	(a, b) => b[1] - a[1],
+);
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
-  for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
-      return score
-    }
-  }
-  return 1
-}
+	for (const [word, score] of wordQualityScoreEntries) {
+		if (phrase.includes(word)) {
+			return score;
+		}
+	}
+	if (phrase.match(/\d+/)) {
+		return 0.5;
+	}
+	return 1;
+};

--- a/tests/test4-ethernet-pin-labels.test.tsx
+++ b/tests/test4-ethernet-pin-labels.test.tsx
@@ -1,0 +1,50 @@
+import { expect, it } from "bun:test";
+import type { AnyCircuitElement } from "circuit-json";
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist";
+
+it("keeps ethernet differential pin labels ahead of generic numeric pins", () => {
+	const circuitJson: AnyCircuitElement[] = [
+		{
+			type: "source_component",
+			ftype: "simple_chip",
+			source_component_id: "source_component_1",
+			name: "U1",
+			manufacturer_part_number: "ETH_PHY",
+		},
+		{
+			type: "source_component",
+			ftype: "simple_chip",
+			source_component_id: "source_component_2",
+			name: "J1",
+			manufacturer_part_number: "HEADER",
+		},
+		{
+			type: "source_port",
+			source_port_id: "source_port_1",
+			source_component_id: "source_component_1",
+			name: "pin1",
+			pin_number: 1,
+			port_hints: ["TXP1"],
+		},
+		{
+			type: "source_port",
+			source_port_id: "source_port_2",
+			source_component_id: "source_component_2",
+			name: "pin1",
+			pin_number: 1,
+			port_hints: ["pos", "pin1"],
+		},
+		{
+			type: "source_trace",
+			source_trace_id: "source_trace_1",
+			connected_source_port_ids: ["source_port_1", "source_port_2"],
+			connected_source_net_ids: [],
+		},
+	];
+
+	const netlist = convertCircuitJsonToReadableNetlist(circuitJson);
+
+	expect(netlist).toContain("NET: U1_TXP1");
+	expect(netlist).toContain("  - U1 pin1 (TXP1)");
+	expect(netlist).toContain("- pin1(TXP1): NETS(U1_TXP1)");
+});


### PR DESCRIPTION
Fixes tscircuit/circuit-json-to-readable-netlist#4

/claim #4

Summary:
- Add Ethernet PHY/RJ45 aliases (`TXP`, `TXN`, `RXP`, `RXN`, `MDIO`, `MDC`) to the readable phrase scorer.
- Score known aliases before the generic digit fallback so labels like `TXP1` win over weak hints such as `pos`.
- Add a raw Circuit JSON regression test proving the generated net name and pin output preserve `TXP1`.

Verification:
- `bun test tests/test4-ethernet-pin-labels.test.tsx`
- `biome check lib/scorePhrase.ts tests/test4-ethernet-pin-labels.test.tsx`
- `tsc -p tsconfig.json --noEmit`
- `git diff --check`

Note: full `bun test tests` currently fails in the three pre-existing JSX fixture tests because the local npm-installed dependency set reports `Export named 'distanceBetweenCircleAndPolygon' not found` from `@tscircuit/circuit-json-util`; the new raw Circuit JSON regression test passes independently.