### PR TITLE
Score chiplet interconnect pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,12 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const chipletInterconnectWords = ["UCIE", "AIB", "BOW", "D2D"]
+
 export const scorePhrase = (phrase: string) => {
+  if (chipletInterconnectWords.some((word) => phrase.includes(word))) {
+    return 1.25
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/chiplet-pin-labels.test.ts
+++ b/tests/chiplet-pin-labels.test.ts
@@ -1,0 +1,50 @@
+import { expect, it } from "bun:test"
+import { generateNetName } from "lib/generateNetName"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores chiplet interconnect labels before numeric fallback", () => {
+  expect(scorePhrase("UCIE_LANE0")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("AIB_TX0")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("BOW_RX1")).toBeGreaterThan(scorePhrase("neg"))
+  expect(scorePhrase("D2D_CLK1")).toBeGreaterThan(1)
+})
+
+it("uses UCIe chiplet labels in generated net names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "R1",
+      ftype: "simple_resistor",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["UCIE_LANE0", "D2D_CLK1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos", "right"],
+    },
+  ] as any[]
+
+  expect(
+    generateNetName({
+      circuitJson,
+      connectedIds: ["source_port_0", "source_port_1"],
+    }),
+  ).toBe("U1_UCIE_LANE0")
+})


### PR DESCRIPTION
## Summary
- Score UCIe, AIB, BoW, and D2D chiplet interconnect labels before the generic numeric fallback.
- Add focused regression coverage for scorePhrase and generated net names so labels like UCIE_LANE0 beat weak labels such as pin14/pos.

## Validation
- npx --yes bun test
- npx --yes @biomejs/biome@1.9.4 check lib/scorePhrase.ts tests/chiplet-pin-labels.test.ts
- npx --yes tsc --noEmit
- git diff --check

/claim #4