### PR TITLE
Fix readable chip pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -7,7 +7,10 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
-import { getReadableNameForPin } from "./getReadableNameForPin"
+import {
+  getReadableChipPinName,
+  getReadableNameForPin,
+} from "./getReadableNameForPin"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -145,9 +148,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = `${component.name} (${details})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = `${component.name} (${details})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }
@@ -156,10 +165,19 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
+        const pinNumberLabel =
+          port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          component.ftype === "simple_chip"
+            ? getReadableChipPinName(port)
+            : (port.name ?? pinNumberLabel ?? port.source_port_id)
         const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
+        if (pinNumberLabel && pinNumberLabel !== mainPin) {
+          aliases.push(pinNumberLabel)
+        }
+        if (port.name && port.name !== mainPin) {
+          aliases.push(port.name)
+        }
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,32 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const getPinNumberLabel = (port: SourcePort): string | undefined =>
+  port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+
+const isGenericPinLabel = (
+  label: string | undefined,
+  port: SourcePort,
+): boolean => {
+  if (!label) return false
+
+  const normalizedLabel = label.toLowerCase()
+  return (
+    normalizedLabel === getPinNumberLabel(port)?.toLowerCase() ||
+    normalizedLabel === String(port.pin_number)
+  )
+}
+
+export const getReadableChipPinName = (port: SourcePort): string => {
+  const readableLabel = [port.name, ...(port.port_hints ?? [])].find(
+    (label) => label && !isGenericPinLabel(label, port),
+  )
+
+  return (
+    readableLabel ?? getPinNumberLabel(port) ?? port.name ?? port.source_port_id
+  )
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +60,12 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName =
+    component.ftype === "simple_chip"
+      ? getReadableChipPinName(port)
+      : port.name
+        ? port.name
+        : `Pin${port.pin_number}`
 
   const additionalPinLabels: string[] = []
 

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)

--- a/tests/test4-readable-pin-labels.test.tsx
+++ b/tests/test4-readable-pin-labels.test.tsx
@@ -1,0 +1,80 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("uses readable chip labels in component pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "TEST_CHIP",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["GPIO1", "SCL"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "GND",
+      pin_number: 2,
+      port_hints: ["GND"],
+    },
+  ] as any[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 GPIO1 (SCL)")
+  expect(netlist).toContain("- GPIO1(pin1, SCL): NOT_CONNECTED")
+  expect(netlist).toContain("- GND(pin2): NOT_CONNECTED")
+  expect(netlist).not.toContain("undefined")
+})
+
+it("omits missing footprints from component pin headers", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "R1",
+      ftype: "simple_resistor",
+      display_resistance: "1k",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "C1",
+      ftype: "simple_capacitor",
+      display_capacitance: "1nF",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 1,
+      port_hints: ["pos", "anode", "left"],
+    },
+  ] as any[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+})


### PR DESCRIPTION
Fixes #4.

## Summary
- Prefer readable chip pin labels over generic `pinN` names when generating readable netlists.
- Keep the physical pin number as an alias in `COMPONENT_PINS`, e.g. `GPIO1(pin1, SCL)`.
- Avoid printing `undefined` in resistor/capacitor component pin headers when footprint data is missing.

## Verification
- `bun test tests/test4-readable-pin-labels.test.tsx`
- `npm run build`

Note: `bun test` for the full suite still fails in existing fixture tests before this change is exercised because `@tscircuit/core` imports `distanceBetweenCircleAndPolygon` from the installed `@tscircuit/circuit-json-util`, where that export is unavailable in this install.
