### PR TITLE
Score FPC connector pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(FPC(_PIN|_DET|_CONN)?|FFC(_PIN|_LANE|_DET|_CONN)?|FLAT_FLEX|FLEX_CABLE|BTB(_CONN)?|BOARD_TO_BOARD|MEZZANINE|SLIMSTACK|DF40|FH12|FH19|QSH|QTH)\d*([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-fpc-ffc-connector-pin-labels.test.tsx
+++ b/tests/test4-fpc-ffc-connector-pin-labels.test.tsx
@@ -1,0 +1,33 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves FPC and FFC connector pin labels in readable net names", () => {
+  expect(scorePhrase("FPC_PIN1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("FFC_LANE1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("BTB_CONN1")).toBeGreaterThan(scorePhrase("pos"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="J1"
+        footprint="soic8"
+        manufacturerPartNumber="FH12-10S"
+        pinLabels={{
+          pin1: ["FPC_PIN1", "FPC_DET"],
+          pin2: ["FFC_LANE1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+
+      <trace from=".J1 .FPC_PIN1" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: J1_FPC_PIN1")
+  expect(netlist).toContain("  - J1 FPC_PIN1 (FPC_DET)")
+  expect(netlist).not.toContain("NET: R1_pos")
+})


### PR DESCRIPTION
Addresses part of #4

/claim #4

## Summary
- Add focused scoring for FPC/FFC and board-to-board connector aliases before the generic digit fallback.
- Preserve connector labels such as `FPC_PIN1`, `FPC_DET`, `FFC_LANE1`, and `BTB_CONN1` in generated readable NET names and pin entries.
- Add focused regression coverage showing those labels beat weak physical/passive names.

## Non-overlap check
I searched the issue thread and current PR titles/bodies for FPC, FFC, flat-flex, board-to-board, mezzanine, BTB, and common connector-family aliases and did not find an existing slice. This stays separate from display, maker connector, backplane, USB, and generic numbered-pin work.

## Verification
- `npx --yes bun@latest test tests/test4-fpc-ffc-connector-pin-labels.test.tsx`
- `npx --yes bun@latest test`
- `npx --yes bun@latest x biome check lib/scorePhrase.ts tests/test4-fpc-ffc-connector-pin-labels.test.tsx`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes bun@latest run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.