### PR TITLE
[codex] Score USB PD controller pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])(USB_?PD(_?(INT|IRQ|ALERT|VBUS|FRS|SRC|SNK))?[0-9]*|PD_(INT|IRQ|ALERT)[0-9]*|VBUS_(DET|EN|OK|DISCH|DISCHARGE)[0-9]*|FRS(_?TX)?[0-9]*|SRC_EN[0-9]*|SNK_EN[0-9]*|TCPC_ALERT[0-9]*|UCPD(_?(INT|IRQ|FRS|VBUS))?[0-9]*)([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.25
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-usb-pd-controller-pin-labels.test.tsx
+++ b/tests/test4-usb-pd-controller-pin-labels.test.tsx
@@ -1,0 +1,104 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores USB Power Delivery controller pin labels before digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn16"
+        manufacturerPartNumber="USB-PD-CONTROLLER"
+        pinLabels={{
+          pin1: ["USBPD_INT1"],
+          pin2: ["VBUS_DET1"],
+          pin3: ["FRS_TX1"],
+          pin4: ["SRC_EN1"],
+          pin5: ["VDD"],
+          pin6: ["GND"],
+          pin7: ["CC1"],
+          pin8: ["CC2"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C2" />
+
+      <trace from=".U1 .USBPD_INT1" to=".R1 .pin1" />
+      <trace from=".U1 .VBUS_DET1" to=".R2 .pin1" />
+      <trace from=".U1 .FRS_TX1" to=".C1 .pin1" />
+      <trace from=".U1 .SRC_EN1" to=".C2 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: USB-PD-CONTROLLER, qfn16
+     - R1: 10kΩ 0402 resistor
+     - R2: 10kΩ 0402 resistor
+     - C1: 100nF 0402 capacitor
+     - C2: 100nF 0402 capacitor
+
+    NET: U1_USBPD_INT1
+      - U1 USBPD_INT1
+      - R1 pin1
+
+    NET: U1_VBUS_DET1
+      - U1 VBUS_DET1
+      - R2 pin1
+
+    NET: U1_FRS_TX1
+      - U1 FRS_TX1
+      - C1 pin1 (+)
+
+    NET: U1_SRC_EN1
+      - U1 SRC_EN1
+      - C2 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (USB-PD-CONTROLLER)
+    - pin1(USBPD_INT1): NETS(U1_USBPD_INT1)
+    - pin2(VBUS_DET1): NETS(U1_VBUS_DET1)
+    - pin3(FRS_TX1): NETS(U1_FRS_TX1)
+    - pin4(SRC_EN1): NETS(U1_SRC_EN1)
+    - pin5(VDD): NOT_CONNECTED
+    - pin6(GND): NOT_CONNECTED
+    - pin7(CC1): NOT_CONNECTED
+    - pin8(CC2): NOT_CONNECTED
+    - pin9: NOT_CONNECTED
+    - pin10: NOT_CONNECTED
+    - pin11: NOT_CONNECTED
+    - pin12: NOT_CONNECTED
+    - pin13: NOT_CONNECTED
+    - pin14: NOT_CONNECTED
+    - pin15: NOT_CONNECTED
+    - pin16: NOT_CONNECTED
+
+    R1 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_USBPD_INT1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R2 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_VBUS_DET1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    C1 (100nF 0402)
+    - pin1(pos, anode, left): NETS(U1_FRS_TX1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+
+    C2 (100nF 0402)
+    - pin1(pos, anode, left): NETS(U1_SRC_EN1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- score USB Power Delivery controller control/status aliases before the generic digit fallback
- preserve labels such as `USBPD_INT1`, `VBUS_DET1`, `FRS_TX1`, and `SRC_EN1` in generated NET names and component pin listings
- add focused readable-netlist regression coverage for the USB PD controller case

## Non-overlap check
I searched the issue thread and open PR titles/bodies for `USB_PD`, `USBPD`, `POWER_DELIVERY`, `PD_INT`, `VBUS_DET`, `VBUS_EN`, `VBUS_OK`, `FRS`, `FRS_TX`, `SRC_EN`, `SNK_EN`, `TCPC`, and `UCPD` and did not find an existing slice. This stays separate from the existing USB-C connector label work (`CC1`, `CC2`, `SBU1`, `SBU2`) and EVSE/control-pilot slices.

## Verification
- `bun test tests/test4-usb-pd-controller-pin-labels.test.tsx --update-snapshots`
- `bun test`
- `bun run format:check`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.

/claim #4