### PR TITLE
[codex] Score insulation monitor pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])((IMD|RISO|GFCI|RCD|GFD|RCM|ELCB)(_?(TEST|FAULT|TRIP|ALARM|RESET|SENSE|OUT|IN))?[0-9]*|GROUND_FAULT[0-9]*|EARTH_FAULT[0-9]*|LEAKAGE(_?(CURRENT|SENSE|FAULT))?[0-9]*)([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.25
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-insulation-monitor-pin-labels.test.tsx
+++ b/tests/test4-insulation-monitor-pin-labels.test.tsx
@@ -1,0 +1,96 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores insulation monitor pin labels before digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="IMD-MONITOR"
+        pinLabels={{
+          pin1: ["IMD_TEST1"],
+          pin2: ["RISO_ALARM1"],
+          pin3: ["GFCI_TRIP1"],
+          pin4: ["LEAKAGE_SENSE1"],
+          pin5: ["VDD"],
+          pin6: ["GND"],
+          pin7: ["GPIO1"],
+          pin8: ["GPIO2"],
+        }}
+      />
+      <resistor resistance="100k" footprint="0402" name="R1" />
+      <resistor resistance="100k" footprint="0402" name="R2" />
+      <capacitor capacitance="10nF" footprint="0402" name="C1" />
+      <capacitor capacitance="10nF" footprint="0402" name="C2" />
+
+      <trace from=".U1 .IMD_TEST1" to=".R1 .pin1" />
+      <trace from=".U1 .RISO_ALARM1" to=".R2 .pin1" />
+      <trace from=".U1 .GFCI_TRIP1" to=".C1 .pin1" />
+      <trace from=".U1 .LEAKAGE_SENSE1" to=".C2 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: IMD-MONITOR, soic8
+     - R1: 100kΩ 0402 resistor
+     - R2: 100kΩ 0402 resistor
+     - C1: 10nF 0402 capacitor
+     - C2: 10nF 0402 capacitor
+
+    NET: U1_IMD_TEST1
+      - U1 IMD_TEST1
+      - R1 pin1
+
+    NET: U1_RISO_ALARM1
+      - U1 RISO_ALARM1
+      - R2 pin1
+
+    NET: U1_GFCI_TRIP1
+      - U1 GFCI_TRIP1
+      - C1 pin1 (+)
+
+    NET: U1_LEAKAGE_SENSE1
+      - U1 LEAKAGE_SENSE1
+      - C2 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (IMD-MONITOR)
+    - pin1(IMD_TEST1): NETS(U1_IMD_TEST1)
+    - pin2(RISO_ALARM1): NETS(U1_RISO_ALARM1)
+    - pin3(GFCI_TRIP1): NETS(U1_GFCI_TRIP1)
+    - pin4(LEAKAGE_SENSE1): NETS(U1_LEAKAGE_SENSE1)
+    - pin5(VDD): NOT_CONNECTED
+    - pin6(GND): NOT_CONNECTED
+    - pin7(GPIO1): NOT_CONNECTED
+    - pin8(GPIO2): NOT_CONNECTED
+
+    R1 (100kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_IMD_TEST1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R2 (100kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_RISO_ALARM1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    C1 (10nF 0402)
+    - pin1(pos, anode, left): NETS(U1_GFCI_TRIP1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+
+    C2 (10nF 0402)
+    - pin1(pos, anode, left): NETS(U1_LEAKAGE_SENSE1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- score insulation-monitor and ground-fault monitor aliases before the generic digit fallback
- preserve labels such as `IMD_TEST1`, `RISO_ALARM1`, `GFCI_TRIP1`, and `LEAKAGE_SENSE1` in generated NET names and component pin lists
- add a focused readable-netlist regression test for those aliases

## Non-overlap
I checked the current open PRs for insulation monitor, isolation monitor, ground fault, GFCI, RCD, leakage current, earth fault, IMD, and RISO before opening this. I did not find an existing PR covering this safety-monitoring label slice.

## Tests
- `bun test tests/test4-insulation-monitor-pin-labels.test.tsx --update-snapshots`
- `bun test`
- `bun run format:check`
- `bun run build`
- `git diff --check`

/claim #4
