### PR TITLE
[codex] Score sub-GHz radio pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,6 +36,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    /(^|[^A-Z0-9])((GDO|PKT_SYNC|PACKET_SYNC|OOK_DATA|FSK_DATA|ASK_DATA|RXCLK|DCLK)[0-9]*|RFM69_(DIO|IRQ)[0-9]*|CC1101_GDO[0-9]*)([^A-Z0-9]|$)/.test(
+      normalizedPhrase,
+    )
+  ) {
+    return 1.25
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-subghz-radio-pin-labels.test.tsx
+++ b/tests/test4-subghz-radio-pin-labels.test.tsx
@@ -1,0 +1,96 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores sub-GHz packet radio pin labels before digit fallback", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="CC1101-RADIO"
+        pinLabels={{
+          pin1: ["GDO0"],
+          pin2: ["GDO2"],
+          pin3: ["OOK_DATA1"],
+          pin4: ["PKT_SYNC1"],
+          pin5: ["VDD"],
+          pin6: ["GND"],
+          pin7: ["GPIO1"],
+          pin8: ["GPIO2"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C2" />
+
+      <trace from=".U1 .GDO0" to=".R1 .pin1" />
+      <trace from=".U1 .GDO2" to=".R2 .pin1" />
+      <trace from=".U1 .OOK_DATA1" to=".C1 .pin1" />
+      <trace from=".U1 .PKT_SYNC1" to=".C2 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: CC1101-RADIO, soic8
+     - R1: 10kΩ 0402 resistor
+     - R2: 10kΩ 0402 resistor
+     - C1: 100nF 0402 capacitor
+     - C2: 100nF 0402 capacitor
+
+    NET: U1_GDO0
+      - U1 GDO0
+      - R1 pin1
+
+    NET: U1_GDO2
+      - U1 GDO2
+      - R2 pin1
+
+    NET: U1_OOK_DATA1
+      - U1 OOK_DATA1
+      - C1 pin1 (+)
+
+    NET: U1_PKT_SYNC1
+      - U1 PKT_SYNC1
+      - C2 pin1 (+)
+
+
+    COMPONENT_PINS:
+    U1 (CC1101-RADIO)
+    - pin1(GDO0): NETS(U1_GDO0)
+    - pin2(GDO2): NETS(U1_GDO2)
+    - pin3(OOK_DATA1): NETS(U1_OOK_DATA1)
+    - pin4(PKT_SYNC1): NETS(U1_PKT_SYNC1)
+    - pin5(VDD): NOT_CONNECTED
+    - pin6(GND): NOT_CONNECTED
+    - pin7(GPIO1): NOT_CONNECTED
+    - pin8(GPIO2): NOT_CONNECTED
+
+    R1 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_GDO0)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R2 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_GDO2)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    C1 (100nF 0402)
+    - pin1(pos, anode, left): NETS(U1_OOK_DATA1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+
+    C2 (100nF 0402)
+    - pin1(pos, anode, left): NETS(U1_PKT_SYNC1)
+    - pin2(neg, cathode, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- score focused sub-GHz / ISM packet radio aliases before the generic digit fallback
- preserve labels such as `GDO0`, `GDO2`, `OOK_DATA1`, and `PKT_SYNC1` in generated NET names and component pin lists
- add a focused readable-netlist regression test for those aliases

## Non-overlap
I checked current PRs for GDO0, GDO2, OOK_DATA, FSK_DATA, ASK_DATA, RFM69, CC1101, SX1231, sub-GHz radio, and radio data before opening this. This slice avoids existing LoRa DIO/TCXO, RF antenna/amplifier/switch, ham-radio, MIDI, infrared, and NMEA work.

## Tests
- `bun test tests/test4-subghz-radio-pin-labels.test.tsx --update-snapshots`
- `bun test`
- `bun run format:check`
- `bun run build`
- `git diff --check`

/claim #4
