### PR TITLE
Score high-speed fabric pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const highSpeedFabricLinkPattern =
+  /\b(?:SRIO|RAPIDIO|AURORA|INTERLAKEN|ILKN)(?:[_-]?(?:TXP|TXN|RXP|RXN|TX|RX|LANE|SYNC|REFCLK|CLK|VALID|READY|ERR|RESET|RST)\d*|[_-]?\d+)?\b/i
+
 export const scorePhrase = (phrase: string) => {
+  if (highSpeedFabricLinkPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-high-speed-fabric-pin-labels.test.ts
+++ b/tests/test4-high-speed-fabric-pin-labels.test.ts
@@ -1,0 +1,120 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+const makeFabricLinkCircuitJson = (): AnyCircuitElement[] =>
+  [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      manufacturer_part_number: "FPGA-FABRIC",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r1",
+      name: "R1",
+      resistance: 50,
+      display_resistance: "50Ω",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r2",
+      name: "R2",
+      resistance: 50,
+      display_resistance: "50Ω",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r3",
+      name: "R3",
+      resistance: 50,
+      display_resistance: "50Ω",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_14",
+      source_component_id: "source_component_u1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["SRIO_TXP0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_15",
+      source_component_id: "source_component_u1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["AURORA_RXN1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_16",
+      source_component_id: "source_component_u1",
+      name: "pin16",
+      pin_number: 16,
+      port_hints: ["ILKN_SYNC1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r2_1",
+      source_component_id: "source_component_r2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r3_1",
+      source_component_id: "source_component_r3",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_srio",
+      connected_source_port_ids: ["source_port_u1_14", "source_port_r1_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_aurora",
+      connected_source_port_ids: ["source_port_u1_15", "source_port_r2_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_ilkn",
+      connected_source_port_ids: ["source_port_u1_16", "source_port_r3_1"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+it("preserves high-speed fabric link aliases in generated readable net names", () => {
+  const netlist = convertCircuitJsonToReadableNetlist(
+    makeFabricLinkCircuitJson(),
+  )
+
+  expect(netlist).toContain("NET: U1_SRIO_TXP0")
+  expect(netlist).toContain("NET: U1_AURORA_RXN1")
+  expect(netlist).toContain("NET: U1_ILKN_SYNC1")
+  expect(netlist).toContain("U1 pin14 (SRIO_TXP0)")
+  expect(netlist).toContain("U1 pin15 (AURORA_RXN1)")
+  expect(netlist).toContain("U1 pin16 (ILKN_SYNC1)")
+  expect(netlist).toContain("- pin14(SRIO_TXP0): NETS(U1_SRIO_TXP0)")
+  expect(netlist).toContain("- pin15(AURORA_RXN1): NETS(U1_AURORA_RXN1)")
+  expect(netlist).toContain("- pin16(ILKN_SYNC1): NETS(U1_ILKN_SYNC1)")
+})


### PR DESCRIPTION
Fixes part of #4

/claim #4

## Summary
- Add focused scoring for FPGA/high-speed fabric link aliases before the generic numeric fallback.
- Preserve Serial RapidIO/SRIO, Aurora, and Interlaken labels such as `SRIO_TXP0`, `AURORA_RXN1`, and `ILKN_SYNC1` in generated readable NET names and component pin entries.
- Keep the scope separate from existing JESD204, PCIe, Ethernet, chiplet interconnect, SFP/QSFP, and generic SerDes label slices.

## Non-overlap check
Searched the issue thread and PRs for RapidIO, SRIO, Aurora, Xilinx Aurora, Interlaken, and ILKN before opening this; no matching existing attempt or PR showed up.

## Validation
- `bun test tests/test4-high-speed-fabric-pin-labels.test.ts`
- `bun x biome check lib/scorePhrase.ts tests/test4-high-speed-fabric-pin-labels.test.ts --write`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.