### PR TITLE
Score Fibre Channel and InfiniBand pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const storageFabricLinkPattern =
+  /\b(?:FC_(?:RX|TX)\d*|FIBRE_CHANNEL(?:[_-]?(?:RX|TX|LOS|LOCK)\d*)?|FIBER_CHANNEL(?:[_-]?(?:RX|TX|LOS|LOCK)\d*)?|IB_LANE\d*|INFINIBAND(?:[_-]?(?:RX|TX|LANE|LINK|LOCK)\d*)?)\b/i
+
 export const scorePhrase = (phrase: string) => {
+  if (storageFabricLinkPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-fibrechannel-infiniband-pin-labels.test.ts
+++ b/tests/test4-fibrechannel-infiniband-pin-labels.test.ts
@@ -1,0 +1,120 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+const makeStorageFabricCircuitJson = (): AnyCircuitElement[] =>
+  [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      manufacturer_part_number: "STORAGE-FABRIC",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r1",
+      name: "R1",
+      resistance: 100,
+      display_resistance: "100Ω",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r2",
+      name: "R2",
+      resistance: 100,
+      display_resistance: "100Ω",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r3",
+      name: "R3",
+      resistance: 100,
+      display_resistance: "100Ω",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_20",
+      source_component_id: "source_component_u1",
+      name: "pin20",
+      pin_number: 20,
+      port_hints: ["FC_RX0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_21",
+      source_component_id: "source_component_u1",
+      name: "pin21",
+      pin_number: 21,
+      port_hints: ["FC_TX1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_22",
+      source_component_id: "source_component_u1",
+      name: "pin22",
+      pin_number: 22,
+      port_hints: ["IB_LANE1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "source_component_r1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r2_1",
+      source_component_id: "source_component_r2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r3_1",
+      source_component_id: "source_component_r3",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_fc_rx",
+      connected_source_port_ids: ["source_port_u1_20", "source_port_r1_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_fc_tx",
+      connected_source_port_ids: ["source_port_u1_21", "source_port_r2_1"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_ib_lane",
+      connected_source_port_ids: ["source_port_u1_22", "source_port_r3_1"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+it("preserves Fibre Channel and InfiniBand aliases in readable net names", () => {
+  const netlist = convertCircuitJsonToReadableNetlist(
+    makeStorageFabricCircuitJson(),
+  )
+
+  expect(netlist).toContain("NET: U1_FC_RX0")
+  expect(netlist).toContain("NET: U1_FC_TX1")
+  expect(netlist).toContain("NET: U1_IB_LANE1")
+  expect(netlist).toContain("U1 pin20 (FC_RX0)")
+  expect(netlist).toContain("U1 pin21 (FC_TX1)")
+  expect(netlist).toContain("U1 pin22 (IB_LANE1)")
+  expect(netlist).toContain("- pin20(FC_RX0): NETS(U1_FC_RX0)")
+  expect(netlist).toContain("- pin21(FC_TX1): NETS(U1_FC_TX1)")
+  expect(netlist).toContain("- pin22(IB_LANE1): NETS(U1_IB_LANE1)")
+})


### PR DESCRIPTION
Fixes part of #4

/claim #4

## Summary
- Add focused scoring for Fibre/Fiber Channel and InfiniBand aliases before the generic numeric fallback.
- Preserve labels such as `FC_RX0`, `FC_TX1`, and `IB_LANE1` in generated readable NET names and component pin entries.
- Keep the scope separate from existing PCIe, Ethernet, optical transport, chiplet interconnect, and high-speed fabric-link label slices.

## Non-overlap check
Searched the issue thread and PRs for Fibre Channel, Fiber Channel, InfiniBand, `FC_RX`, `FC_TX`, and `IB_LANE` before opening this; no matching existing attempt or PR showed up.

## Validation
- `bun test tests/test4-fibrechannel-infiniband-pin-labels.test.ts`
- `bun x biome check lib/scorePhrase.ts tests/test4-fibrechannel-infiniband-pin-labels.test.ts --write`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.