### PR TITLE
Prefer descriptive pin labels in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -159,12 +159,19 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin = getPreferredPinLabel(port)
+        const preferredPinLabel = getPreferredPinLabel(port)
+        const mainPin =
+          port.pin_number !== undefined ? `pin${port.pin_number}` : preferredPinLabel
         const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
+        if (preferredPinLabel !== mainPin) aliases.push(preferredPinLabel)
+        if (port.name && port.name !== mainPin && port.name !== preferredPinLabel) {
+          aliases.push(port.name)
+        }
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
-          if (hint !== mainPin && hint !== port.name) aliases.push(hint)
+          if (hint !== mainPin && hint !== port.name && hint !== preferredPinLabel) {
+            aliases.push(hint)
+          }
         }
         const aliasPart =
           aliases.length > 0

--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -7,7 +7,10 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
-import { getReadableNameForPin } from "./getReadableNameForPin"
+import {
+  getPreferredPinLabel,
+  getReadableNameForPin,
+} from "./getReadableNameForPin"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -156,8 +159,7 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const mainPin = getPreferredPinLabel(port)
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,29 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinLabel = (label: string) => /^pin\d+$/i.test(label.trim())
+
+const hasLettersAndDigits = (value: string) =>
+  /[a-z]/i.test(value) && /\d/.test(value)
+
+export const getPreferredPinLabel = (port: SourcePort): string => {
+  const name = port.name?.trim()
+  const hints = (port.port_hints ?? []).map((h) => h.trim()).filter(Boolean)
+
+  if (name && !isGenericPinLabel(name)) {
+    return name
+  }
+
+  const descriptiveHints = hints.filter((hint) => !isGenericPinLabel(hint))
+  const alphanumericHint = descriptiveHints.find(hasLettersAndDigits)
+  if (alphanumericHint) return alphanumericHint
+
+  if (descriptiveHints.length > 0) return descriptiveHints[0]
+  if (name) return name
+  if (port.pin_number !== undefined) return `pin${port.pin_number}`
+  return "pin"
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +57,7 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = getPreferredPinLabel(port)
 
   const additionalPinLabels: string[] = []
 
@@ -46,8 +69,9 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (isGenericPinLabel(port_hint)) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score > 1 || hasLettersAndDigits(port_hint)) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/test1-basic-circuit.test.tsx
+++ b/tests/test1-basic-circuit.test.tsx
@@ -28,7 +28,7 @@ it("test1 should render a basic circuit", () => {
     convertCircuitJsonToReadableNetlist(circuitJson),
   ).toMatchInlineSnapshot(`
     "COMPONENTS:
-     - R1: 1kÎ© 0402 resistor
+     - R1: 1kΩ 0402 resistor
      - C1: 1nF 0402 capacitor
 
     NET: C1_pos
@@ -37,7 +37,7 @@ it("test1 should render a basic circuit", () => {
 
 
     COMPONENT_PINS:
-    R1 (1kÎ© 0402)
+    R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)
     - pin2(cathode, neg, right): NOT_CONNECTED
 
@@ -47,4 +47,5 @@ it("test1 should render a basic circuit", () => {
     "
   `)
 })
+
 

--- a/tests/test1-basic-circuit.test.tsx
+++ b/tests/test1-basic-circuit.test.tsx
@@ -1,4 +1,4 @@
-import { expect, it } from "bun:test"
+﻿import { expect, it } from "bun:test"
 import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
 import { renderCircuit } from "tests/fixtures/render-circuit"
 
@@ -28,16 +28,16 @@ it("test1 should render a basic circuit", () => {
     convertCircuitJsonToReadableNetlist(circuitJson),
   ).toMatchInlineSnapshot(`
     "COMPONENTS:
-     - R1: 1kΩ 0402 resistor
+     - R1: 1kÎ© 0402 resistor
      - C1: 1nF 0402 capacitor
 
     NET: C1_pos
-      - R1 pin1
-      - C1 pin1 (+)
+      - R1 anode
+      - C1 pos (+)
 
 
     COMPONENT_PINS:
-    R1 (1kΩ 0402)
+    R1 (1kÎ© 0402)
     - pin1(anode, pos, left): NETS(C1_pos)
     - pin2(cathode, neg, right): NOT_CONNECTED
 
@@ -47,3 +47,4 @@ it("test1 should render a basic circuit", () => {
     "
   `)
 })
+

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -45,7 +45,7 @@ it("test2 chip", () => {
   ).toMatchInlineSnapshot(`
     "COMPONENTS:
      - U1: ATMEGA328P, soic8
-     - R1: 1kÎ© 0402 resistor
+     - R1: 1kΩ 0402 resistor
      - C1: 1nF 0402 capacitor
 
     NET: C1_pos
@@ -77,7 +77,7 @@ it("test2 chip", () => {
     - pin7(GPIO5, UART_RX): NOT_CONNECTED
     - pin8(VDD): NETS(V5)
 
-    R1 (1kÎ© 0402)
+    R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)
     - pin2(cathode, neg, right): NETS(U1_SDA)
 
@@ -87,4 +87,5 @@ it("test2 chip", () => {
     "
   `)
 })
+
 

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -1,4 +1,4 @@
-import { expect, it } from "bun:test"
+﻿import { expect, it } from "bun:test"
 import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
 import { renderCircuit } from "tests/fixtures/render-circuit"
 
@@ -45,12 +45,12 @@ it("test2 chip", () => {
   ).toMatchInlineSnapshot(`
     "COMPONENTS:
      - U1: ATMEGA328P, soic8
-     - R1: 1kΩ 0402 resistor
+     - R1: 1kÎ© 0402 resistor
      - C1: 1nF 0402 capacitor
 
     NET: C1_pos
-      - R1 pin1
-      - C1 pin1 (+)
+      - R1 anode
+      - C1 pos (+)
 
     NET: GND
       - U1 GPIO1 (SCL)
@@ -59,7 +59,7 @@ it("test2 chip", () => {
 
     NET: U1_SDA
       - U1 GPIO2 (SDA)
-      - R1 pin2
+      - R1 cathode
 
 
     EMPTY NET PINS:
@@ -77,7 +77,7 @@ it("test2 chip", () => {
     - pin7(GPIO5, UART_RX): NOT_CONNECTED
     - pin8(VDD): NETS(V5)
 
-    R1 (1kΩ 0402)
+    R1 (1kÎ© 0402)
     - pin1(anode, pos, left): NETS(C1_pos)
     - pin2(cathode, neg, right): NETS(U1_SDA)
 
@@ -87,3 +87,4 @@ it("test2 chip", () => {
     "
   `)
 })
+

--- a/tests/test4-pin-label-preference.test.ts
+++ b/tests/test4-pin-label-preference.test.ts
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test"
+import {
+  getPreferredPinLabel,
+  getReadableNameForPin,
+} from "lib/getReadableNameForPin"
+
+const circuitJson = [
+  {
+    type: "source_component",
+    source_component_id: "source_component_1",
+    ftype: "simple_chip",
+    name: "U1",
+  },
+  {
+    type: "source_port",
+    source_port_id: "source_port_1",
+    source_component_id: "source_component_1",
+    pin_number: 14,
+    name: "pin14",
+    port_hints: ["GPIO14", "SDA"],
+  },
+] as any
+
+it("prefers full pin labels over generic numbered labels", () => {
+  const port = circuitJson[1]
+  expect(getPreferredPinLabel(port)).toBe("GPIO14")
+
+  const readable = getReadableNameForPin({
+    circuitJson,
+    source_port_id: "source_port_1",
+  })
+  expect(readable).toContain("U1 GPIO14")
+  expect(readable).not.toContain("U1 pin14")
+})

--- a/tests/test4-pin-label-preference.test.ts
+++ b/tests/test4-pin-label-preference.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
 import {
   getPreferredPinLabel,
   getReadableNameForPin,
@@ -31,4 +32,11 @@ it("prefers full pin labels over generic numbered labels", () => {
   })
   expect(readable).toContain("U1 GPIO14")
   expect(readable).not.toContain("U1 pin14")
+})
+
+it("keeps numeric pin identity in COMPONENT_PINS while exposing descriptive aliases", () => {
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("COMPONENT_PINS:")
+  expect(netlist).toContain("- pin14(GPIO14, SDA): NOT_CONNECTED")
 })


### PR DESCRIPTION
Summary:
- prefer descriptive source port labels such as GPIO14 over generic labels such as pin14
- apply the same preference in readable netlist pin output
- add a focused regression test for the pin-label preference

Tests:
- `npx tsc --noEmit`
- `npm run build --silent`
- `npx bun test tests/test4-pin-label-preference.test.ts`

AI assistance disclosure: AI assistance materially contributed to preparing this patch. I reviewed the changes and remain responsible for the submitted code.

Fixes #4