### PR TITLE
Preserve BT.656 video bus labels in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,22 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScore = {
+  BT656: 1.2,
+  BT1120: 1.2,
+  CCIR656: 1.2,
+}
+
+const digitBearingWordQualityScoreEntries = Object.entries(
+  digitBearingWordQualityScore,
+).sort((a, b) => b[1] - a[1])
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-video-bus-labels.test.tsx
+++ b/tests/test4-video-bus-labels.test.tsx
@@ -1,0 +1,39 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves BT.656 and BT.1120 video bus labels in net names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="VIDEO-BRIDGE"
+        pinLabels={{
+          pin1: ["BT656_D0"],
+          pin2: ["BT1120_Y7"],
+          pin3: ["CCIR656_CLK1"],
+          pin4: ["GND"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+
+      <trace from=".U1 .BT656_D0" to=".R1 > .pin1" />
+      <trace from=".U1 .BT1120_Y7" to=".R2 > .pin1" />
+      <trace from=".U1 .CCIR656_CLK1" to=".R3 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_BT656_D0")
+  expect(readableNetlist).toContain("NET: U1_BT1120_Y7")
+  expect(readableNetlist).toContain("NET: U1_CCIR656_CLK1")
+  expect(readableNetlist).toContain("- pin1(BT656_D0): NETS(U1_BT656_D0)")
+  expect(readableNetlist).toContain("- pin2(BT1120_Y7): NETS(U1_BT1120_Y7)")
+  expect(readableNetlist).toContain(
+    "- pin3(CCIR656_CLK1): NETS(U1_CCIR656_CLK1)",
+  )
+})


### PR DESCRIPTION
## Summary

- Score digit-bearing BT.656 / BT.1120 / CCIR656 video-bus labels before the generic numeric fallback.
- Add a focused regression test proving those labels are preserved in generated NET names and COMPONENT_PINS output.

## Verification

- `bun test`
- `bun run build`
- `bun run format:check`
- `git diff --check`

Fixes part of #4.