### PR TITLE
Score segment LCD driver pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,25 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const segmentLcdSignalPatterns = [
+  /^LCD[_-]?SEG\d*(?:[_-].*)?$/,
+  /^LCD[_-]?COM\d*(?:[_-].*)?$/,
+  /^SEGMENT[_-]?LCD(?:[_-].*)?$/,
+  /^GLASS[_-]?LCD(?:[_-].*)?$/,
+  /^HT1621(?:[_-].*)?$/,
+  /^VLCD\d*(?:[_-].*)?$/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  // Segment LCD aliases often include numeric segment/common indexes.
+  if (
+    segmentLcdSignalPatterns.some((pattern) => pattern.test(normalizedPhrase))
+  ) {
+    return 1.25
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-segment-lcd-driver-pin-labels.test.tsx
+++ b/tests/test4-segment-lcd-driver-pin-labels.test.tsx
@@ -1,0 +1,52 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("test4 should preserve segment LCD driver labels in generated net names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="HT1621B"
+        pinLabels={{
+          pin1: ["LCD_SEG0"],
+          pin2: ["LCD_COM1"],
+          pin3: ["HT1621_SEG2"],
+          pin4: ["HT1621_COM3"],
+          pin5: ["VLCD1"],
+          pin6: ["GLASS_LCD_BIAS1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+      <resistor resistance="1k" footprint="0402" name="R5" />
+      <resistor resistance="1k" footprint="0402" name="R6" />
+
+      <trace from=".U1 .LCD_SEG0" to=".R1 > .pin1" />
+      <trace from=".U1 .LCD_COM1" to=".R2 > .pin1" />
+      <trace from=".U1 .HT1621_SEG2" to=".R3 > .pin1" />
+      <trace from=".U1 .HT1621_COM3" to=".R4 > .pin1" />
+      <trace from=".U1 .VLCD1" to=".R5 > .pin1" />
+      <trace from=".U1 .GLASS_LCD_BIAS1" to=".R6 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  for (const label of [
+    "LCD_SEG0",
+    "LCD_COM1",
+    "HT1621_SEG2",
+    "HT1621_COM3",
+    "VLCD1",
+    "GLASS_LCD_BIAS1",
+  ]) {
+    expect(readableNetlist).toContain(`NET: U1_${label}`)
+    expect(readableNetlist).toContain(`NETS(U1_${label})`)
+  }
+
+  expect(readableNetlist).not.toContain("NET: U1_pin")
+})


### PR DESCRIPTION
Fixes part of #4

/claim #4

## Summary
- Add focused scoring for segment-LCD / glass-LCD driver aliases before the generic numeric fallback.
- Preserve labels such as `LCD_SEG0`, `LCD_COM1`, `HT1621_SEG2`, `HT1621_COM3`, `VLCD1`, and `GLASS_LCD_BIAS1` in generated readable NET names and component pin entries.
- Keep the scope separate from existing HDMI/DisplayPort, LVDS/eDP, MIPI display/camera, OLED/AMOLED display-bias, LED/backlight, e-paper, and touch-controller label slices.

## Validation
- `npx --yes bun test tests/test4-segment-lcd-driver-pin-labels.test.tsx`
- `npx --yes biome check . --write`
- `npx --yes bun test`
- `npx --yes bun run build`
- `git diff --check`