### PR TITLE
Score thermal printer pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const thermalPrinterSignalPattern =
+  /(^|[_\W])(THERMAL|PRINTHEAD|PRINT|PAPER|CUTTER|CASH_DRAWER|FEED|PLATEN|STB)(?=$|[_\W]|\d)/i
+
 export const scorePhrase = (phrase: string) => {
+  if (thermalPrinterSignalPattern.test(phrase)) {
+    return 1.15
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-thermal-printer-pin-labels.test.tsx
+++ b/tests/test4-thermal-printer-pin-labels.test.tsx
@@ -1,0 +1,41 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves thermal printer pin labels in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="THERMAL-PRINTER-CTRL"
+        pinLabels={{
+          pin1: ["THERMAL_STB1"],
+          pin2: ["PAPER_OUT1"],
+          pin3: ["CUTTER_HOME1"],
+          pin4: ["CASH_DRAWER1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <resistor resistance="10k" footprint="0402" name="R2" />
+      <resistor resistance="10k" footprint="0402" name="R3" />
+      <resistor resistance="10k" footprint="0402" name="R4" />
+
+      <trace from=".U1 .THERMAL_STB1" to=".R1 .pin1" />
+      <trace from=".U1 .PAPER_OUT1" to=".R2 .pin1" />
+      <trace from=".U1 .CUTTER_HOME1" to=".R3 .pin1" />
+      <trace from=".U1 .CASH_DRAWER1" to=".R4 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_THERMAL_STB1")
+  expect(netlist).toContain("NET: U1_PAPER_OUT1")
+  expect(netlist).toContain("NET: U1_CUTTER_HOME1")
+  expect(netlist).toContain("NET: U1_CASH_DRAWER1")
+  expect(netlist).toContain("U1 THERMAL_STB1")
+  expect(netlist).toContain("U1 PAPER_OUT1")
+  expect(netlist).toContain("U1 CUTTER_HOME1")
+  expect(netlist).toContain("U1 CASH_DRAWER1")
+})


### PR DESCRIPTION
/claim #4

Fixes #4.

This adds a narrow readable-netlist scoring slice for thermal/receipt printer signal labels. Digit-bearing labels such as `THERMAL_STB1`, `PAPER_OUT1`, `CUTTER_HOME1`, and `CASH_DRAWER1` currently hit the generic numeric fallback and can lose to low-information passive labels like `pos`.

Changes:
- Score thermal printer signal families before the generic digit fallback.
- Add regression coverage proving those labels are preserved in generated `NET:` names and readable component pin entries.

I searched current open PR text and issue comments for thermal printer / receipt printer / cash drawer / printhead-style coverage before opening this. This is separate from existing LED/backlight, motor/fan/pump, haptic/piezo, display, key-matrix, and generic numbered-pin slices.

Verification:
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun test tests/test4-thermal-printer-pin-labels.test.tsx`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun test`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun run build`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun x biome check lib/scorePhrase.ts tests/test4-thermal-printer-pin-labels.test.tsx`