### PR TITLE
Score character LCD pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,23 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const characterLcdSignalPatterns = [
+  /^HD44780(?:[_-].*)?$/,
+  /^CHAR(?:ACTER)?[_-]?LCD(?:[_-].*)?$/,
+  /^LCD[_-]?(?:RS|RW|E|EN|ENABLE)\d*(?:[_-].*)?$/,
+  /^LCD[_-]?D[4-7]\d*(?:[_-].*)?$/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  // Character LCD labels often include pin/control indexes, e.g. LCD_D4.
+  if (
+    characterLcdSignalPatterns.some((pattern) => pattern.test(normalizedPhrase))
+  ) {
+    return 1.25
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-character-lcd-pin-labels.test.tsx
+++ b/tests/test4-character-lcd-pin-labels.test.tsx
@@ -1,0 +1,52 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("test4 should preserve character LCD control and data labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="dip16"
+        manufacturerPartNumber="HD44780"
+        pinLabels={{
+          pin1: ["HD44780_RS1"],
+          pin2: ["HD44780_RW1"],
+          pin3: ["HD44780_E1"],
+          pin4: ["CHARLCD_D4"],
+          pin5: ["LCD_D5"],
+          pin6: ["LCD_ENABLE1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+      <resistor resistance="1k" footprint="0402" name="R5" />
+      <resistor resistance="1k" footprint="0402" name="R6" />
+
+      <trace from=".U1 .HD44780_RS1" to=".R1 > .pin1" />
+      <trace from=".U1 .HD44780_RW1" to=".R2 > .pin1" />
+      <trace from=".U1 .HD44780_E1" to=".R3 > .pin1" />
+      <trace from=".U1 .CHARLCD_D4" to=".R4 > .pin1" />
+      <trace from=".U1 .LCD_D5" to=".R5 > .pin1" />
+      <trace from=".U1 .LCD_ENABLE1" to=".R6 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  for (const label of [
+    "HD44780_RS1",
+    "HD44780_RW1",
+    "HD44780_E1",
+    "CHARLCD_D4",
+    "LCD_D5",
+    "LCD_ENABLE1",
+  ]) {
+    expect(readableNetlist).toContain(`NET: U1_${label}`)
+    expect(readableNetlist).toContain(`NETS(U1_${label})`)
+  }
+
+  expect(readableNetlist).not.toContain("NET: U1_pin")
+})


### PR DESCRIPTION
Fixes part of #4

/claim #4

## Summary
- Add focused scoring for HD44780-style character LCD / 1602/2004 parallel LCD aliases before the generic numeric fallback.
- Preserve labels such as `HD44780_RS1`, `HD44780_RW1`, `HD44780_E1`, `CHARLCD_D4`, `LCD_D5`, and `LCD_ENABLE1` in generated readable NET names and component pin entries.
- Keep the scope separate from segment/glass LCD drivers, seven-segment display drivers, LED/backlight, VGA/TFT parallel RGB display, MIPI/LVDS/eDP/HDMI display links, and e-paper/OLED display-bias work.

## Validation
- `npx --yes bun test tests/test4-character-lcd-pin-labels.test.tsx`
- `npx --yes biome check . --write`
- `npx --yes bun test`
- `npx --yes bun run build`
- `git diff --check`