### PR TITLE
Score PoE controller pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -8,6 +8,11 @@
  * These unique port names are usually the best indicator of what the net is for
  */
 const wordQualityScore = {
+  POE: 1.3,
+  PSE: 1.25,
+  IEEE8023: 1.25,
+  MPS: 1.2,
+  T2P: 1.2,
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
@@ -36,13 +41,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.toUpperCase()
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-poe-pse-pin-labels.test.tsx
+++ b/tests/test4-poe-pse-pin-labels.test.tsx
@@ -1,0 +1,34 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves PoE and PSE controller aliases in readable netlists", () => {
+  expect(scorePhrase("POE_DET1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("PSE_EN1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("MPS_DET1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("T2P1")).toBeGreaterThan(scorePhrase("pin14"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        manufacturerPartNumber="TPS2378"
+        pinLabels={{
+          pin14: ["POE_DET1", "PSE_EN1", "MPS_DET1", "T2P1"],
+        }}
+      />
+      <resistor resistance="24.9k" footprint="0402" name="R1" />
+      <trace from=".U1 .POE_DET1" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_POE_DET1")
+  expect(readableNetlist).toContain("- U1 POE_DET1 (PSE_EN1,MPS_DET1,T2P1)")
+  expect(readableNetlist).toContain(
+    "- pin14(POE_DET1, PSE_EN1, MPS_DET1, T2P1): NETS(U1_POE_DET1)",
+  )
+})


### PR DESCRIPTION
Summary
- Preserve Power over Ethernet controller aliases in readable netlists.

What changed
- Score PoE/PSE-related labels (`POE`, `PSE`, `IEEE8023`, `MPS`, `T2P`) before the generic numeric fallback.
- Make scoring comparison case-insensitive while preserving the existing fallback behavior.
- Add focused regression coverage for digit-bearing labels such as `POE_DET1`, `PSE_EN1`, `MPS_DET1`, and `T2P1`.

How tested
- `npx --yes bun test tests/test4-poe-pse-pin-labels.test.tsx`
- `npx --yes bun test`
- `npx --yes bun x biome check lib/scorePhrase.ts tests/test4-poe-pse-pin-labels.test.tsx`
- `npx --yes bun run build`
- `git diff --check`

Related issue/bounty
- Fixes part of #4
- /claim #4

Notes
- I searched current open PRs/issues for PoE, PSE, PD detection, and IEEE 802.3 label coverage before opening this; I did not find an existing slice for these aliases.
- AI-assisted with OpenAI Codex; I reviewed the diff and ran local verification before submitting.
