### PR TITLE
Score DBI display controller pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,27 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const dbiDisplayControllerSignalPatterns = [
+  /^ILI9341(?:[_-].*)?$/,
+  /^ST77(?:35|89)(?:[_-].*)?$/,
+  /^MIPI[_-]?DBI(?:[_-].*)?$/,
+  /^DBI[_-]?(?:D\d+|WR|RD|DC|CS|TE|RST|RESET)\d*(?:[_-].*)?$/,
+  /^LCD[_-]?8080(?:[_-].*)?$/,
+  /^LCD[_-]?(?:WR|RD|DC|TE)\d*(?:[_-].*)?$/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  // TFT DBI/8080 controller labels commonly include numeric bus indexes.
+  if (
+    dbiDisplayControllerSignalPatterns.some((pattern) =>
+      pattern.test(normalizedPhrase),
+    )
+  ) {
+    return 1.25
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-dbi-display-controller-pin-labels.test.tsx
+++ b/tests/test4-dbi-display-controller-pin-labels.test.tsx
@@ -1,0 +1,52 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("test4 should preserve DBI display controller labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn48"
+        manufacturerPartNumber="ILI9341"
+        pinLabels={{
+          pin1: ["ILI9341_WR1"],
+          pin2: ["ST7789_DC1"],
+          pin3: ["ST7735_RD1"],
+          pin4: ["MIPI_DBI_D0"],
+          pin5: ["LCD_8080_D1"],
+          pin6: ["DBI_TE1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+      <resistor resistance="1k" footprint="0402" name="R5" />
+      <resistor resistance="1k" footprint="0402" name="R6" />
+
+      <trace from=".U1 .ILI9341_WR1" to=".R1 > .pin1" />
+      <trace from=".U1 .ST7789_DC1" to=".R2 > .pin1" />
+      <trace from=".U1 .ST7735_RD1" to=".R3 > .pin1" />
+      <trace from=".U1 .MIPI_DBI_D0" to=".R4 > .pin1" />
+      <trace from=".U1 .LCD_8080_D1" to=".R5 > .pin1" />
+      <trace from=".U1 .DBI_TE1" to=".R6 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  for (const label of [
+    "ILI9341_WR1",
+    "ST7789_DC1",
+    "ST7735_RD1",
+    "MIPI_DBI_D0",
+    "LCD_8080_D1",
+    "DBI_TE1",
+  ]) {
+    expect(readableNetlist).toContain(`NET: U1_${label}`)
+    expect(readableNetlist).toContain(`NETS(U1_${label})`)
+  }
+
+  expect(readableNetlist).not.toContain("NET: U1_pin")
+})


### PR DESCRIPTION
Fixes part of #4

/claim #4

## Summary
- Add focused scoring for ILI9341/ST7789/ST7735-style TFT display-controller DBI / 8080 parallel-control aliases before the generic numeric fallback.
- Preserve labels such as `ILI9341_WR1`, `ST7789_DC1`, `ST7735_RD1`, `MIPI_DBI_D0`, `LCD_8080_D1`, and `DBI_TE1` in generated readable NET names and component pin entries.
- Keep the scope separate from segment/glass LCD, HD44780 character LCD, seven-segment drivers, LED/backlight, VGA/TFT RGB parallel display, MIPI/LVDS/eDP/HDMI display links, e-paper, and OLED display-bias work.

## Validation
- `npx --yes bun test tests/test4-dbi-display-controller-pin-labels.test.tsx`
- `npx --yes biome check . --write`
- `npx --yes bun test`
- `npx --yes bun run build`
- `git diff --check`