### PR TITLE
Score automotive audio bus pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,27 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const automotiveAudioBusSignalPatterns = [
+  /^A2B(?:[_-]?(?:AP|AN|BP|BN|P|N|TX|RX|BUS|LINE)\d*)?(?:[_-].*)?$/,
+  /^AD242\d(?:[_-].*)?$/,
+  /^MOST(?:25|50|150)?(?:[_-].*)?$/,
+  /^MOST[_-]?BUS(?:[_-].*)?$/,
+  /^MEDIA[_-]?ORIENTED(?:[_-].*)?$/,
+  /^AUTOMOTIVE[_-]?AUDIO(?:[_-].*)?$/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  // Automotive audio bus labels often carry numeric channel or port indexes.
+  if (
+    automotiveAudioBusSignalPatterns.some((pattern) =>
+      pattern.test(normalizedPhrase),
+    )
+  ) {
+    return 1.25
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-automotive-audio-bus-pin-labels.test.tsx
+++ b/tests/test4-automotive-audio-bus-pin-labels.test.tsx
@@ -1,0 +1,52 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("test4 should preserve automotive audio bus labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn48"
+        manufacturerPartNumber="AD2428W"
+        pinLabels={{
+          pin1: ["A2B_AP1"],
+          pin2: ["A2B_AN1"],
+          pin3: ["AD2428_A2B_BP1"],
+          pin4: ["AD2429_A2B_BN1"],
+          pin5: ["MOST150_TX1"],
+          pin6: ["MOST_BUS_RX1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+      <resistor resistance="1k" footprint="0402" name="R5" />
+      <resistor resistance="1k" footprint="0402" name="R6" />
+
+      <trace from=".U1 .A2B_AP1" to=".R1 > .pin1" />
+      <trace from=".U1 .A2B_AN1" to=".R2 > .pin1" />
+      <trace from=".U1 .AD2428_A2B_BP1" to=".R3 > .pin1" />
+      <trace from=".U1 .AD2429_A2B_BN1" to=".R4 > .pin1" />
+      <trace from=".U1 .MOST150_TX1" to=".R5 > .pin1" />
+      <trace from=".U1 .MOST_BUS_RX1" to=".R6 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  for (const label of [
+    "A2B_AP1",
+    "A2B_AN1",
+    "AD2428_A2B_BP1",
+    "AD2429_A2B_BN1",
+    "MOST150_TX1",
+    "MOST_BUS_RX1",
+  ]) {
+    expect(readableNetlist).toContain(`NET: U1_${label}`)
+    expect(readableNetlist).toContain(`NETS(U1_${label})`)
+  }
+
+  expect(readableNetlist).not.toContain("NET: U1_pin")
+})


### PR DESCRIPTION
Fixes part of #4

/claim #4

## Summary
- Add focused scoring for automotive audio / media bus aliases: A2B / AD242x and MOST labels before the generic numeric fallback.
- Preserve labels such as `A2B_AP1`, `A2B_AN1`, `AD2428_A2B_BP1`, `AD2429_A2B_BN1`, `MOST150_TX1`, and `MOST_BUS_RX1` in generated readable NET names and component pin entries.
- Keep the scope separate from I2S/PDM/DMIC, SoundWire/SLIMbus/SAI/TDM, S/PDIF/TOSLINK/AES3, analog audio/headset/amplifier, CAN/LIN/FlexRay, automotive SerDes, and generic RF/display/storage label work.

## Validation
- `npx --yes bun test tests/test4-automotive-audio-bus-pin-labels.test.tsx`
- `npx --yes biome check . --write`
- `npx --yes bun test`
- `npx --yes bun run build`
- `git diff --check`