### PR TITLE
Score camera lens actuator pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,28 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const cameraLensActuatorSignalPatterns = [
+  /^VCM(?:[_-].*)?$/,
+  /^VOICE[_-]?COIL(?:[_-].*)?$/,
+  /^OIS(?:[_-].*)?$/,
+  /^AUTOFOCUS(?:[_-].*)?$/,
+  /^AF[_-]?(?:EN|PWM|DRV|SDA|SCL|INT|FAULT)\d*(?:[_-].*)?$/,
+  /^LENS[_-]?(?:DRV|POS|FOCUS|HOME|INT)\d*(?:[_-].*)?$/,
+  /^IRIS[_-]?(?:PWM|DRV|STEP|EN)\d*(?:[_-].*)?$/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  // Camera lens actuator labels often include numeric channel indexes.
+  if (
+    cameraLensActuatorSignalPatterns.some((pattern) =>
+      pattern.test(normalizedPhrase),
+    )
+  ) {
+    return 1.25
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-camera-lens-actuator-pin-labels.test.tsx
+++ b/tests/test4-camera-lens-actuator-pin-labels.test.tsx
@@ -1,0 +1,52 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("test4 should preserve camera lens actuator labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn16"
+        manufacturerPartNumber="LC898217"
+        pinLabels={{
+          pin1: ["VCM_OUT1"],
+          pin2: ["VOICE_COIL_P1"],
+          pin3: ["OIS_X1"],
+          pin4: ["AUTOFOCUS_EN1"],
+          pin5: ["AF_PWM1"],
+          pin6: ["LENS_POS1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+      <resistor resistance="1k" footprint="0402" name="R5" />
+      <resistor resistance="1k" footprint="0402" name="R6" />
+
+      <trace from=".U1 .VCM_OUT1" to=".R1 > .pin1" />
+      <trace from=".U1 .VOICE_COIL_P1" to=".R2 > .pin1" />
+      <trace from=".U1 .OIS_X1" to=".R3 > .pin1" />
+      <trace from=".U1 .AUTOFOCUS_EN1" to=".R4 > .pin1" />
+      <trace from=".U1 .AF_PWM1" to=".R5 > .pin1" />
+      <trace from=".U1 .LENS_POS1" to=".R6 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  for (const label of [
+    "VCM_OUT1",
+    "VOICE_COIL_P1",
+    "OIS_X1",
+    "AUTOFOCUS_EN1",
+    "AF_PWM1",
+    "LENS_POS1",
+  ]) {
+    expect(readableNetlist).toContain(`NET: U1_${label}`)
+    expect(readableNetlist).toContain(`NETS(U1_${label})`)
+  }
+
+  expect(readableNetlist).not.toContain("NET: U1_pin")
+})


### PR DESCRIPTION
Fixes part of #4

/claim #4

## Summary
- Add focused scoring for camera lens actuator / autofocus / OIS aliases before the generic numeric fallback.
- Preserve labels such as `VCM_OUT1`, `VOICE_COIL_P1`, `OIS_X1`, `AUTOFOCUS_EN1`, `AF_PWM1`, and `LENS_POS1` in generated readable NET names and component pin entries.
- Keep the scope separate from camera sensor/MIPI CSI interfaces, camera flash/strobe drivers, barcode/rangefinder/optical sensors, thermal imagers, haptics/motors, and generic display/RF/storage label work.

## Validation
- `npx --yes bun test tests/test4-camera-lens-actuator-pin-labels.test.tsx`
- `npx --yes biome check . --write`
- `npx --yes bun test`
- `npx --yes bun run build`
- `git diff --check`