### PR TITLE
Score CXPI body bus pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,22 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const cxpiBodyBusSignalPatterns = [
+  /^CXPI(?:[_-]?(?:BUS|TX|RX|WAKE|SLP|SLEEP|FAULT|EN)\d*)?(?:[_-].*)?$/,
+  /^CLOCK[_-]?EXTENSION[_-]?PERIPHERAL(?:[_-].*)?$/,
+  /^BODY[_-]?BUS(?:[_-].*)?$/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  // CXPI body-bus labels often carry channel or control indexes.
+  if (
+    cxpiBodyBusSignalPatterns.some((pattern) => pattern.test(normalizedPhrase))
+  ) {
+    return 1.25
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-cxpi-body-bus-pin-labels.test.tsx
+++ b/tests/test4-cxpi-body-bus-pin-labels.test.tsx
@@ -1,0 +1,52 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("test4 should preserve CXPI body bus labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="BD41030FJ"
+        pinLabels={{
+          pin1: ["CXPI_BUS1"],
+          pin2: ["CXPI_TX1"],
+          pin3: ["CXPI_RX1"],
+          pin4: ["CXPI_WAKE1"],
+          pin5: ["CXPI_SLP1"],
+          pin6: ["CXPI_FAULT1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+      <resistor resistance="1k" footprint="0402" name="R5" />
+      <resistor resistance="1k" footprint="0402" name="R6" />
+
+      <trace from=".U1 .CXPI_BUS1" to=".R1 > .pin1" />
+      <trace from=".U1 .CXPI_TX1" to=".R2 > .pin1" />
+      <trace from=".U1 .CXPI_RX1" to=".R3 > .pin1" />
+      <trace from=".U1 .CXPI_WAKE1" to=".R4 > .pin1" />
+      <trace from=".U1 .CXPI_SLP1" to=".R5 > .pin1" />
+      <trace from=".U1 .CXPI_FAULT1" to=".R6 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  for (const label of [
+    "CXPI_BUS1",
+    "CXPI_TX1",
+    "CXPI_RX1",
+    "CXPI_WAKE1",
+    "CXPI_SLP1",
+    "CXPI_FAULT1",
+  ]) {
+    expect(readableNetlist).toContain(`NET: U1_${label}`)
+    expect(readableNetlist).toContain(`NETS(U1_${label})`)
+  }
+
+  expect(readableNetlist).not.toContain("NET: U1_pin")
+})


### PR DESCRIPTION
Fixes part of #4

/claim #4

## Summary
- Add focused scoring for CXPI automotive body-bus aliases before the generic numeric fallback.
- Preserve labels such as `CXPI_BUS1`, `CXPI_TX1`, `CXPI_RX1`, `CXPI_WAKE1`, `CXPI_SLP1`, and `CXPI_FAULT1` in generated readable NET names and component pin entries.
- Keep the scope separate from existing CAN/LIN automotive bus labels, K-line/OBD/J1850/FlexRay diagnostics, SENT/PSI5 and DSI3/AK2H sensor interfaces, HVIL/EVSE, automotive audio/media bus, and generic industrial fieldbus work.

## Validation
- `npx --yes bun test tests/test4-cxpi-body-bus-pin-labels.test.tsx`
- `npx --yes biome check . --write`
- `npx --yes bun test`
- `npx --yes bun run build`
- `git diff --check`