### PR TITLE
Score CANopen and DeviceNet pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,21 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const industrialCanAutomationAliasPatterns = [
+  /\bCANOPEN_?(?:SYNC|EMCY|NMT|PDO|TPDO|RPDO|SDO|HEARTBEAT|HB|TX|RX|CANH|CANL|H|L|DATA)?\d?\b/i,
+  /\bDEVICE_?NET_?(?:CANH|CANL|V\+|V-|SHIELD|DATA|TX|RX|H|L|P|N)?\d?\b/i,
+  /\bDEVICENET_?(?:CANH|CANL|V\+|V-|SHIELD|DATA|TX|RX|H|L|P|N)?\d?\b/i,
+  /\bCONTROL_?NET_?(?:A|B|TX|RX|DATA|SYNC|COAX|TRUNK)?\d?\b/i,
+  /\bCONTROLNET_?(?:A|B|TX|RX|DATA|SYNC|COAX|TRUNK)?\d?\b/i,
+  /\bCIP_?(?:SYNC|MOTION|SAFETY|DATA|TX|RX)\d?\b/i,
+]
+
 export const scorePhrase = (phrase: string) => {
+  if (
+    industrialCanAutomationAliasPatterns.some((pattern) => pattern.test(phrase))
+  ) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/industrial-can-automation-pin-labels.test.tsx
+++ b/tests/industrial-can-automation-pin-labels.test.tsx
@@ -1,0 +1,46 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores CANopen DeviceNet and ControlNet pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="INDUSTRIAL-CAN-CTRL"
+        pinLabels={{
+          pin1: ["pin14", "CANOPEN_SYNC1"],
+          pin2: ["pin15", "DEVICENET_CANH1"],
+          pin3: ["pin16", "CONTROLNET_A1"],
+          pin4: ["pin17", "CIP_SYNC1"],
+        }}
+      />
+      <resistor resistance="120" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .CANOPEN_SYNC1" to=".R1 > .pin1" />
+      <trace from=".U1 .DEVICENET_CANH1" to=".R1 > .pin2" />
+      <trace from=".U1 .CONTROLNET_A1" to=".C1 > .pin1" />
+      <trace from=".U1 .CIP_SYNC1" to=".C1 > .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_CANOPEN_SYNC1")
+  expect(netlist).toContain("  - U1 pin14 (CANOPEN_SYNC1)")
+  expect(netlist).toContain(
+    "- pin1(pin14, CANOPEN_SYNC1): NETS(U1_CANOPEN_SYNC1)",
+  )
+
+  expect(netlist).toContain("NET: U1_DEVICENET_CANH1")
+  expect(netlist).toContain("  - U1 pin15 (DEVICENET_CANH1)")
+
+  expect(netlist).toContain("NET: U1_CONTROLNET_A1")
+  expect(netlist).toContain("  - U1 pin16 (CONTROLNET_A1)")
+
+  expect(netlist).toContain("NET: U1_CIP_SYNC1")
+  expect(netlist).toContain("  - U1 pin17 (CIP_SYNC1)")
+  expect(netlist).toContain("- pin4(pin17, CIP_SYNC1): NETS(U1_CIP_SYNC1)")
+})


### PR DESCRIPTION
## Summary
- score CANopen, DeviceNet, ControlNet, and CIP Sync aliases before the generic digit fallback
- add focused regression coverage proving those labels drive generated NET names and readable pin entries

## Non-overlap
Searched issue comments and PRs for CANopen, DeviceNet, ControlNet, and CIP Sync. Existing slices cover generic CAN/LIN automotive bus, RS-485/Modbus fieldbus, non-CAN industrial fieldbus, industrial Ethernet, and motion networks, but not this CAN-family industrial automation scope.

## Tests
- npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test tests/industrial-can-automation-pin-labels.test.tsx
- npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test
- ./node_modules/.bin/biome check lib/scorePhrase.ts tests/industrial-can-automation-pin-labels.test.tsx
- npm_config_cache=/tmp/npm-cache npm exec --yes bun -- run build
- git diff --check

/claim #4