### PR TITLE
Score 1-Wire and Dallas sensor pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -15,6 +15,13 @@ const wordQualityScore = {
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
+  DQ: 1.15,
+  "1WIRE": 1.15,
+  ONEWIRE: 1.15,
+  ONE_WIRE: 1.15,
+  OWI: 1.15,
+  DS18B20: 1.15,
+  DALLAS: 1.15,
   GPIO: 1.1,
   cathode: 0.5,
   anode: 0.5,
@@ -36,13 +43,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-one-wire-pin-labels.test.ts
+++ b/tests/test4-one-wire-pin-labels.test.ts
@@ -1,0 +1,75 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves 1-Wire and Dallas sensor pin labels before numeric fallback", () => {
+  expect(scorePhrase("1WIRE_DQ1")).toBeGreaterThan(scorePhrase("pin1"))
+  expect(scorePhrase("DS18B20_DQ1")).toBeGreaterThan(scorePhrase("pin2"))
+
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "DS2482-100",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      ftype: "simple_chip",
+      name: "U2",
+      manufacturer_part_number: "DS18B20",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["1WIRE_DQ1", "DQ"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["DS18B20_DQ1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: DS2482-100
+     - U2: DS18B20
+
+    NET: U1_1WIRE_DQ1
+      - U1 pin1 (1WIRE_DQ1,DQ)
+      - U2 pin2 (DS18B20_DQ1)
+
+
+    COMPONENT_PINS:
+    U1 (DS2482-100)
+    - pin1(1WIRE_DQ1, DQ): NETS(U1_1WIRE_DQ1)
+
+    U2 (DS18B20)
+    - pin2(DS18B20_DQ1): NETS(U1_1WIRE_DQ1)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- score 1-Wire / Dallas sensor labels before the generic numeric fallback
- preserve aliases like `1WIRE_DQ1`, `DQ`, and `DS18B20_DQ1` in readable net names and component pin output
- add focused regression coverage for generated net names and pin aliases

/claim #4

## Non-overlap
I searched issue comments and PRs for `1WIRE`, `1-Wire`, `ONEWIRE`, `DS18B20`, and `DALLAS` and did not find an existing matching slice. This stays separate from USB, PMIC, RF, display, industrial-bus, and sensor-interface label work.

## Validation
- `npx bun test`
- `npx biome check .`
- `npx tsc --noEmit`
- `npx tsup ./lib/index.ts --format esm --dts`
- `git diff --check`