### PR TITLE
Score smartcard pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isSmartcardPinLabel = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  return (
+    /(^|[_-])(SIM|USIM|ESIM|UICC|ISO7816|SMARTCARD|SMART_CARD)([_-]|\d|$)/.test(
+      normalizedPhrase,
+    ) ||
+    /^(SIM|USIM|ESIM|UICC)(IO|CLK|RST|VCC|DET|PRES)\d*$/.test(normalizedPhrase)
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isSmartcardPinLabel(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/smartcard-sim-pin-labels.test.tsx
+++ b/tests/smartcard-sim-pin-labels.test.tsx
@@ -1,0 +1,46 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores SIM UICC and ISO7816 smartcard pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn24"
+        manufacturerPartNumber="SMARTCARD-IF"
+        pinLabels={{
+          pin1: ["pin14", "SIM_IO1"],
+          pin2: ["pin15", "UICC_CLK1"],
+          pin3: ["pin16", "ISO7816_RST1"],
+          pin4: ["pin17", "SMARTCARD_DET1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .SIM_IO1" to=".R1 > .pin1" />
+      <trace from=".U1 .UICC_CLK1" to=".R1 > .pin2" />
+      <trace from=".U1 .ISO7816_RST1" to=".C1 > .pin1" />
+      <trace from=".U1 .SMARTCARD_DET1" to=".C1 > .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_SIM_IO1")
+  expect(netlist).toContain("  - U1 pin14 (SIM_IO1)")
+  expect(netlist).toContain("- pin1(pin14, SIM_IO1): NETS(U1_SIM_IO1)")
+
+  expect(netlist).toContain("NET: U1_UICC_CLK1")
+  expect(netlist).toContain("  - U1 pin15 (UICC_CLK1)")
+
+  expect(netlist).toContain("NET: U1_ISO7816_RST1")
+  expect(netlist).toContain("  - U1 pin16 (ISO7816_RST1)")
+
+  expect(netlist).toContain("NET: U1_SMARTCARD_DET1")
+  expect(netlist).toContain("  - U1 pin17 (SMARTCARD_DET1)")
+  expect(netlist).toContain(
+    "- pin4(pin17, SMARTCARD_DET1): NETS(U1_SMARTCARD_DET1)",
+  )
+})


### PR DESCRIPTION
## Summary
- score SIM / UICC / ISO7816 smartcard aliases before the generic digit fallback
- preserve labels such as `SIM_IO1`, `UICC_CLK1`, `ISO7816_RST1`, and `SMARTCARD_DET1` in generated readable net names and component pin entries
- add focused regression coverage for the smartcard label slice

## Non-overlap
Searched the issue thread and open PR titles/bodies for SIM, UICC, ISO7816, smartcard, USIM, and eSIM before opening this. Nearby cellular modem and digital-isolator slices explicitly exclude SIM/UICC/ISO7816 labels.

## Tests
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test tests/smartcard-sim-pin-labels.test.tsx`
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/smartcard-sim-pin-labels.test.tsx --write`
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- run build`
- `git diff --check`

/claim #4