### PR TITLE
Score RTC pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,22 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isRtcPinLabel = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  return (
+    /(^|[_-])(RTC|RTCC|DS3231|DS1307|PCF8523|PCF8563|RV3028|MCP7940)([_-]|\d|$)/.test(
+      normalizedPhrase,
+    ) ||
+    /(^|[_-])(SQW|ALARM|ALM|32KOUT|32KHZ|CLKOUT|VBAT)([_-]|\d|$)/.test(
+      normalizedPhrase,
+    )
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isRtcPinLabel(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/rtc-clock-pin-labels.test.tsx
+++ b/tests/rtc-clock-pin-labels.test.tsx
@@ -1,0 +1,46 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores RTC clock alarm and backup pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="RTC-CTRL"
+        pinLabels={{
+          pin1: ["pin14", "RTC_INT1"],
+          pin2: ["pin15", "RTC_SQW1"],
+          pin3: ["pin16", "RTC_32KOUT1"],
+          pin4: ["pin17", "PCF8563_ALARM1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .RTC_INT1" to=".R1 > .pin1" />
+      <trace from=".U1 .RTC_SQW1" to=".R1 > .pin2" />
+      <trace from=".U1 .RTC_32KOUT1" to=".C1 > .pin1" />
+      <trace from=".U1 .PCF8563_ALARM1" to=".C1 > .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_RTC_INT1")
+  expect(netlist).toContain("  - U1 pin14 (RTC_INT1)")
+  expect(netlist).toContain("- pin1(pin14, RTC_INT1): NETS(U1_RTC_INT1)")
+
+  expect(netlist).toContain("NET: U1_RTC_SQW1")
+  expect(netlist).toContain("  - U1 pin15 (RTC_SQW1)")
+
+  expect(netlist).toContain("NET: U1_RTC_32KOUT1")
+  expect(netlist).toContain("  - U1 pin16 (RTC_32KOUT1)")
+
+  expect(netlist).toContain("NET: U1_PCF8563_ALARM1")
+  expect(netlist).toContain("  - U1 pin17 (PCF8563_ALARM1)")
+  expect(netlist).toContain(
+    "- pin4(pin17, PCF8563_ALARM1): NETS(U1_PCF8563_ALARM1)",
+  )
+})


### PR DESCRIPTION
## Summary
- score RTC / real-time-clock aliases before the generic digit fallback
- preserve labels such as `RTC_INT1`, `RTC_SQW1`, `RTC_32KOUT1`, and `PCF8563_ALARM1` in generated readable net names and component pin entries
- add focused regression coverage for the RTC label slice

## Non-overlap
Searched the issue thread and open PR titles/bodies for RTC, RTCC, DS3231, DS1307, PCF8523, PCF8563, SQW, ALARM, 32KOUT, and CLKOUT before opening this. This stays separate from existing oscillator, PLL/clockgen, GNSS/PTP time-sync, and watchdog/supervisor slices.

## Tests
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test tests/rtc-clock-pin-labels.test.tsx`
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/rtc-clock-pin-labels.test.tsx --write`
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- run build`
- `git diff --check`

/claim #4