### PR TITLE
Score key matrix pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isKeyMatrixPinLabel = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  return (
+    /(^|[_-])(KEYPAD|KEYSCAN|KSCAN|KEYMATRIX|KEY_MATRIX|KBD)([_-]|\d|$)/.test(
+      normalizedPhrase,
+    ) ||
+    /^(KEY|KBD)[_-]?(ROW|COL|IN|OUT|SCAN|INT|WAKE)\d*$/.test(normalizedPhrase)
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isKeyMatrixPinLabel(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/key-matrix-pin-labels.test.tsx
+++ b/tests/key-matrix-pin-labels.test.tsx
@@ -1,0 +1,44 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores keypad and key-matrix pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="KEYSCAN-CTRL"
+        pinLabels={{
+          pin1: ["pin14", "KEY_ROW1"],
+          pin2: ["pin15", "KEY_COL1"],
+          pin3: ["pin16", "KSCAN_IN1"],
+          pin4: ["pin17", "KBD_WAKE1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .KEY_ROW1" to=".R1 > .pin1" />
+      <trace from=".U1 .KEY_COL1" to=".R1 > .pin2" />
+      <trace from=".U1 .KSCAN_IN1" to=".C1 > .pin1" />
+      <trace from=".U1 .KBD_WAKE1" to=".C1 > .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_KEY_ROW1")
+  expect(netlist).toContain("  - U1 pin14 (KEY_ROW1)")
+  expect(netlist).toContain("- pin1(pin14, KEY_ROW1): NETS(U1_KEY_ROW1)")
+
+  expect(netlist).toContain("NET: U1_KEY_COL1")
+  expect(netlist).toContain("  - U1 pin15 (KEY_COL1)")
+
+  expect(netlist).toContain("NET: U1_KSCAN_IN1")
+  expect(netlist).toContain("  - U1 pin16 (KSCAN_IN1)")
+
+  expect(netlist).toContain("NET: U1_KBD_WAKE1")
+  expect(netlist).toContain("  - U1 pin17 (KBD_WAKE1)")
+  expect(netlist).toContain("- pin4(pin17, KBD_WAKE1): NETS(U1_KBD_WAKE1)")
+})


### PR DESCRIPTION
## Summary
- score keypad / key-matrix aliases before the generic digit fallback
- preserve labels such as `KEY_ROW1`, `KEY_COL1`, `KSCAN_IN1`, and `KBD_WAKE1` in generated readable net names and component pin entries
- add focused regression coverage for the key-matrix label slice

## Non-overlap
Searched the issue thread and open PR titles/bodies for key matrix, keypad, keyboard scan, KSCAN, KEY_ROW, KEY_COL, and KBD_WAKE before opening this. This stays separate from joystick/gamepad, PS/2 keyboard, touch-controller, GPIO-expander, and generic connector/header slices.

## Tests
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test tests/key-matrix-pin-labels.test.tsx`
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/key-matrix-pin-labels.test.tsx --write`
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- run build`
- `git diff --check`

/claim #4