### PR TITLE
Score haptic driver pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isHapticPinLabel = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  return /(^|[_-])(HAPTIC|VIB|VIBE|VIBRATOR|LRA|ERM|DRV2605|DRV2604|PIEZO|BUZZER)([_-]|\d|$)/.test(
+    normalizedPhrase,
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isHapticPinLabel(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/haptic-driver-pin-labels.test.tsx
+++ b/tests/haptic-driver-pin-labels.test.tsx
@@ -1,0 +1,44 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores haptic vibrator and piezo driver pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn20"
+        manufacturerPartNumber="HAPTIC-DRV"
+        pinLabels={{
+          pin1: ["pin14", "HAPTIC_EN1"],
+          pin2: ["pin15", "VIB_DRV1"],
+          pin3: ["pin16", "LRA_OUT1"],
+          pin4: ["pin17", "ERM_PWM1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .HAPTIC_EN1" to=".R1 > .pin1" />
+      <trace from=".U1 .VIB_DRV1" to=".R1 > .pin2" />
+      <trace from=".U1 .LRA_OUT1" to=".C1 > .pin1" />
+      <trace from=".U1 .ERM_PWM1" to=".C1 > .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_HAPTIC_EN1")
+  expect(netlist).toContain("  - U1 pin14 (HAPTIC_EN1)")
+  expect(netlist).toContain("- pin1(pin14, HAPTIC_EN1): NETS(U1_HAPTIC_EN1)")
+
+  expect(netlist).toContain("NET: U1_VIB_DRV1")
+  expect(netlist).toContain("  - U1 pin15 (VIB_DRV1)")
+
+  expect(netlist).toContain("NET: U1_LRA_OUT1")
+  expect(netlist).toContain("  - U1 pin16 (LRA_OUT1)")
+
+  expect(netlist).toContain("NET: U1_ERM_PWM1")
+  expect(netlist).toContain("  - U1 pin17 (ERM_PWM1)")
+  expect(netlist).toContain("- pin4(pin17, ERM_PWM1): NETS(U1_ERM_PWM1)")
+})


### PR DESCRIPTION
## Summary
- score haptic / vibrator / piezo-driver aliases before the generic digit fallback
- preserve labels such as `HAPTIC_EN1`, `VIB_DRV1`, `LRA_OUT1`, and `ERM_PWM1` in generated readable net names and component pin entries
- add focused regression coverage for the haptic-driver label slice

## Non-overlap
Searched issue comments and open PR titles/bodies for haptic, vibrator, LRA, ERM, DRV2605, piezo, and buzzer before opening this. This stays separate from motor/servo, pump/fan, vibration-sensor, audio-amplifier, and thermal-printer slices.

## Tests
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test tests/haptic-driver-pin-labels.test.tsx`
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/haptic-driver-pin-labels.test.tsx --write`
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- run build`
- `git diff --check`

/claim #4