### PR TITLE
Score backlight driver pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,19 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isBacklightPinLabel = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  return (
+    /(^|[_-])(BACKLIGHT|BL|WLED|LEDDRV|LED_DRIVER|LP855|TPS611)([_-]|\d|$)/.test(
+      normalizedPhrase,
+    ) || /^(LEDA|LEDK|ILED|LEDSTRING)\d*$/.test(normalizedPhrase)
+  )
+}
+
 export const scorePhrase = (phrase: string) => {
+  if (isBacklightPinLabel(phrase)) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/backlight-driver-pin-labels.test.tsx
+++ b/tests/backlight-driver-pin-labels.test.tsx
@@ -1,0 +1,44 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores display backlight and WLED driver pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn24"
+        manufacturerPartNumber="WLED-BACKLIGHT"
+        pinLabels={{
+          pin1: ["pin14", "BL_PWM1"],
+          pin2: ["pin15", "BACKLIGHT_EN1"],
+          pin3: ["pin16", "LEDK1"],
+          pin4: ["pin17", "WLED_FB1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .BL_PWM1" to=".R1 > .pin1" />
+      <trace from=".U1 .BACKLIGHT_EN1" to=".R1 > .pin2" />
+      <trace from=".U1 .LEDK1" to=".C1 > .pin1" />
+      <trace from=".U1 .WLED_FB1" to=".C1 > .pin2" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_BL_PWM1")
+  expect(netlist).toContain("  - U1 pin14 (BL_PWM1)")
+  expect(netlist).toContain("- pin1(pin14, BL_PWM1): NETS(U1_BL_PWM1)")
+
+  expect(netlist).toContain("NET: U1_BACKLIGHT_EN1")
+  expect(netlist).toContain("  - U1 pin15 (BACKLIGHT_EN1)")
+
+  expect(netlist).toContain("NET: U1_LEDK1")
+  expect(netlist).toContain("  - U1 pin16 (LEDK1)")
+
+  expect(netlist).toContain("NET: U1_WLED_FB1")
+  expect(netlist).toContain("  - U1 pin17 (WLED_FB1)")
+  expect(netlist).toContain("- pin4(pin17, WLED_FB1): NETS(U1_WLED_FB1)")
+})


### PR DESCRIPTION
## Summary
- score display backlight / WLED-driver aliases before the generic digit fallback
- preserve labels such as `BL_PWM1`, `BACKLIGHT_EN1`, `LEDK1`, and `WLED_FB1` in generated readable net names and component pin entries
- add focused regression coverage for the backlight-driver label slice

## Non-overlap
Searched issue comments and open PR titles/bodies for backlight, WLED, BL_PWM, BACKLIGHT_EN, LEDK, LEDA, and LED-driver terms before opening this. This stays separate from addressable LED, analog dimming, segment LCD, DBI display controller, character LCD, and generic display-link slices.

## Tests
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test tests/backlight-driver-pin-labels.test.tsx`
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- test`
- `./node_modules/.bin/biome check lib/scorePhrase.ts tests/backlight-driver-pin-labels.test.tsx --write`
- `npm_config_cache=/tmp/npm-cache npm exec --yes bun -- run build`
- `git diff --check`

/claim #4