### PR TITLE
Score XFI and SFI pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const ethernetBackplanePinPattern =
+  /^(?:(?:XFI|SFI)_(?:TXP|TXN|RXP|RXN)\d*|(?:KR|KX|KR4|KX4)_(?:TXP|TXN|RXP|RXN|REFCLK|LINK|TRAIN)\d*|(?:10GBASE_KR|1000BASE_KX)_(?:TXP|TXN|RXP|RXN|REFCLK)\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (ethernetBackplanePinPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-xfi-sfi-pin-labels.test.tsx
+++ b/tests/test4-xfi-sfi-pin-labels.test.tsx
@@ -1,0 +1,36 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("prefers XFI SFI and Ethernet backplane labels over passive pin names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="TEN_G_PHY"
+        pinLabels={{
+          pin1: ["XFI_TXP0"],
+          pin2: ["SFI_RXN0"],
+          pin3: ["KR_REFCLK1"],
+        }}
+      />
+      <resistor resistance="49.9" footprint="0402" name="R1" />
+      <resistor resistance="49.9" footprint="0402" name="R2" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .XFI_TXP0" to=".R1 .pin1" />
+      <trace from=".U1 .SFI_RXN0" to=".R2 .pin1" />
+      <trace from=".U1 .KR_REFCLK1" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_XFI_TXP0")
+  expect(netlist).toContain("NET: U1_SFI_RXN0")
+  expect(netlist).toContain("NET: U1_KR_REFCLK1")
+  expect(netlist).toContain("- pin1(XFI_TXP0): NETS(U1_XFI_TXP0)")
+  expect(netlist).toContain("- pin2(SFI_RXN0): NETS(U1_SFI_RXN0)")
+  expect(netlist).toContain("- pin3(KR_REFCLK1): NETS(U1_KR_REFCLK1)")
+})


### PR DESCRIPTION
## Summary
- score XFI, SFI, KR/KX, and 10GBASE backplane link labels before the generic numeric fallback
- add a focused regression covering generated NET names and COMPONENT_PINS output for `XFI_TXP0`, `SFI_RXN0`, and `KR_REFCLK1`

/claim #4

## Verification
- `bun test tests/test4-xfi-sfi-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/test4-xfi-sfi-pin-labels.test.tsx --write`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`