### PR TITLE
Score CAUI and XLAUI pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const highLaneEthernetPinPattern =
+  /^(?:(?:CAUI|XLAUI|LAUI)_(?:TXP|TXN|RXP|RXN)\d*|(?:25GBASE|40GBASE|100GBASE)_(?:CR|SR|LR|ER|KR)\d*_(?:TXP|TXN|RXP|RXN|TX|RX)\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (highLaneEthernetPinPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-caui-xlaui-pin-labels.test.tsx
+++ b/tests/test4-caui-xlaui-pin-labels.test.tsx
@@ -1,0 +1,38 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("prefers CAUI XLAUI and high-lane Ethernet labels over passive pin names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="bga196"
+        manufacturerPartNumber="HUNDRED_G_PHY"
+        pinLabels={{
+          pin1: ["CAUI_TXP0"],
+          pin2: ["XLAUI_RXN1"],
+          pin3: ["100GBASE_LR4_TX2"],
+        }}
+      />
+      <resistor resistance="49.9" footprint="0402" name="R1" />
+      <resistor resistance="49.9" footprint="0402" name="R2" />
+      <capacitor capacitance="100nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .CAUI_TXP0" to=".R1 .pin1" />
+      <trace from=".U1 .XLAUI_RXN1" to=".R2 .pin1" />
+      <trace from=".U1 .100GBASE_LR4_TX2" to=".C1 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_CAUI_TXP0")
+  expect(netlist).toContain("NET: U1_XLAUI_RXN1")
+  expect(netlist).toContain("NET: U1_100GBASE_LR4_TX2")
+  expect(netlist).toContain("- pin1(CAUI_TXP0): NETS(U1_CAUI_TXP0)")
+  expect(netlist).toContain("- pin2(XLAUI_RXN1): NETS(U1_XLAUI_RXN1)")
+  expect(netlist).toContain(
+    "- pin3(100GBASE_LR4_TX2): NETS(U1_100GBASE_LR4_TX2)",
+  )
+})


### PR DESCRIPTION
Adds CAUI/XLAUI/LAUI lane labels plus 25GBASE/40GBASE/100GBASE lane-style labels to the net-name scorer before the digit fallback kicks in.

This keeps nets such as CAUI_TXP0, XLAUI_RXN1, and 100GBASE_LR4_TX2 named from the PHY pin instead of the passive component side.

Checked locally:
- bun test tests/test4-caui-xlaui-pin-labels.test.tsx
- bun x biome check lib/scorePhrase.ts tests/test4-caui-xlaui-pin-labels.test.tsx --write
- bun test
- bun x tsc --noEmit
- bun run build
- git diff --check

/claim #4