### PR TITLE
Score JTAG and SWD labels before numeric fallback

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -31,11 +31,25 @@ const wordQualityScore = {
   right: 0.3,
 }
 
+const digitBearingPhraseScores = [
+  {
+    pattern:
+      /(^|[_\-\s])(?:JTAG|SWD|SWDIO|SWCLK|TMS|TCK|TDI|TDO|TRST|NTRST|NJTRST)(?:[_\-\s]?(?:TMS|TCK|TDI|TDO|TRST|SWDIO|SWCLK|SWO|RST))?\d*(?=$|[_\-\s])/,
+    score: 1.19,
+  },
+]
+
 const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  for (const { pattern, score } of digitBearingPhraseScores) {
+    if (pattern.test(normalizedPhrase)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/jtag-swd-labels.test.tsx
+++ b/tests/jtag-swd-labels.test.tsx
@@ -1,0 +1,81 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores digit-bearing JTAG and SWD labels before numeric fallback", () => {
+  expect(scorePhrase("SWDIO1")).toBeGreaterThan(scorePhrase("GPIO1"))
+  expect(scorePhrase("SWCLK1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("JTAG_TMS1")).toBeGreaterThan(scorePhrase("pin14"))
+})
+
+it("uses JTAG and SWD aliases in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="STM32F030"
+        pinLabels={{
+          pin1: ["GPIO1", "SWDIO1"],
+          pin2: ["GPIO2", "SWCLK1"],
+          pin3: ["GPIO3", "JTAG_TMS1"],
+          pin4: ["GPIO4", "JTAG_TCK1"],
+          pin5: ["GND"],
+          pin6: ["VDD"],
+          pin7: ["NC"],
+          pin8: ["RESET"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .GPIO1" to=".R1 .pin1" />
+      <trace from=".U1 .GPIO2" to=".R2 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: STM32F030, soic8
+     - R1: 1kΩ 0402 resistor
+     - R2: 1kΩ 0402 resistor
+
+    NET: U1_SWDIO1
+      - U1 GPIO1 (SWDIO1)
+      - R1 pin1
+
+    NET: U1_SWCLK1
+      - U1 GPIO2 (SWCLK1)
+      - R2 pin1
+
+
+    COMPONENT_PINS:
+    U1 (STM32F030)
+    - pin1(GPIO1, SWDIO1): NETS(U1_SWDIO1)
+    - pin2(GPIO2, SWCLK1): NETS(U1_SWCLK1)
+    - pin3(GPIO3, JTAG_TMS1): NOT_CONNECTED
+    - pin4(GPIO4, JTAG_TCK1): NOT_CONNECTED
+    - pin5(GND): NOT_CONNECTED
+    - pin6(VDD): NOT_CONNECTED
+    - pin7(NC): NOT_CONNECTED
+    - pin8(RESET): NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_SWDIO1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R2 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_SWCLK1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
Fixes #4\n\n/claim #4\n\n## Summary\n- score JTAG/SWD debug-port labels such as SWDIO1, SWCLK1, JTAG_TMS1, and JTAG_TCK1 before the generic digit fallback\n- add focused coverage showing debug-port labels beat GPIO/pin numeric names and appear in readable netlists\n\n## Verification\n- bun test tests/jtag-swd-labels.test.tsx\n- bun test\n- bunx biome check lib/scorePhrase.ts tests/jtag-swd-labels.test.tsx\n- bun run build\n- git diff --check

Payment fallback: PayPal cultofrozen@gmail.com