### PR TITLE
Score SCSI bus pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const scsiBusSignalPatterns = [
+  /^SCSI(?:[_-].*)?$/,
+  /^FAST[-_]?SCSI(?:[_-].*)?$/,
+  /^ULTRA(?:160|320)(?:[_-].*)?$/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  // Parallel SCSI labels often include control or data line indexes.
+  if (scsiBusSignalPatterns.some((pattern) => pattern.test(normalizedPhrase))) {
+    return 1.25
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-scsi-bus-pin-labels.test.tsx
+++ b/tests/test4-scsi-bus-pin-labels.test.tsx
@@ -1,0 +1,52 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("test4 should preserve SCSI bus labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn48"
+        manufacturerPartNumber="NCR5380"
+        pinLabels={{
+          pin1: ["SCSI_REQ1"],
+          pin2: ["SCSI_ACK1"],
+          pin3: ["SCSI_BSY1"],
+          pin4: ["SCSI_SEL1"],
+          pin5: ["SCSI_ATN1"],
+          pin6: ["SCSI_RST1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+      <resistor resistance="1k" footprint="0402" name="R5" />
+      <resistor resistance="1k" footprint="0402" name="R6" />
+
+      <trace from=".U1 .SCSI_REQ1" to=".R1 > .pin1" />
+      <trace from=".U1 .SCSI_ACK1" to=".R2 > .pin1" />
+      <trace from=".U1 .SCSI_BSY1" to=".R3 > .pin1" />
+      <trace from=".U1 .SCSI_SEL1" to=".R4 > .pin1" />
+      <trace from=".U1 .SCSI_ATN1" to=".R5 > .pin1" />
+      <trace from=".U1 .SCSI_RST1" to=".R6 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  for (const label of [
+    "SCSI_REQ1",
+    "SCSI_ACK1",
+    "SCSI_BSY1",
+    "SCSI_SEL1",
+    "SCSI_ATN1",
+    "SCSI_RST1",
+  ]) {
+    expect(readableNetlist).toContain(`NET: U1_${label}`)
+    expect(readableNetlist).toContain(`NETS(U1_${label})`)
+  }
+
+  expect(readableNetlist).not.toContain("NET: U1_pin")
+})


### PR DESCRIPTION
Fixes part of #4

/claim #4

## Summary
- Add focused scoring for parallel SCSI / legacy SCSI bus aliases before the generic numeric fallback.
- Preserve labels such as `SCSI_REQ1`, `SCSI_ACK1`, `SCSI_BSY1`, `SCSI_SEL1`, `SCSI_ATN1`, and `SCSI_RST1` in generated readable NET names and component pin entries.
- Keep the scope separate from SATA/SAS/UFS/eMMC/SD storage-link work, PCIe/M.2, and GPIB/backplane bus labels.

## Validation
- `npx --yes bun test tests/test4-scsi-bus-pin-labels.test.tsx`
- `npx --yes biome check . --write`
- `npx --yes bun test`
- `npx --yes bun run build`
- `git diff --check`