### PR TITLE
Prefer readable labels in component pin output

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -156,13 +156,16 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const pinNumberLabel =
+          port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+        const mainPin = port.name ?? pinNumberLabel ?? port.source_port_id
         const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
+        if (pinNumberLabel && pinNumberLabel !== mainPin) {
+          aliases.push(pinNumberLabel)
+        }
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
-          if (hint !== mainPin && hint !== port.name) aliases.push(hint)
+          if (hint !== mainPin && hint !== pinNumberLabel) aliases.push(hint)
         }
         const aliasPart =
           aliases.length > 0

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)

--- a/tests/test4-readable-component-pins.test.ts
+++ b/tests/test4-readable-component-pins.test.ts
@@ -1,0 +1,58 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("prefers readable port names over numeric pin labels in COMPONENT_PINS", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "GPIO23",
+      pin_number: 14,
+      port_hints: ["pin14", "GPIO23"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_1",
+      name: "GND",
+      pin_number: 15,
+      port_hints: ["GND"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(convertCircuitJsonToReadableNetlist(circuitJson)).toContain(
+    "- GPIO23(pin14): NOT_CONNECTED",
+  )
+})
+
+it("falls back to source_port_id when a port has no name or pin number", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_without_label",
+      source_component_id: "source_component_1",
+      name: undefined,
+    },
+  ] as unknown as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("- source_port_without_label: NOT_CONNECTED")
+})


### PR DESCRIPTION
## Summary
- Prefer `source_port.name` over numeric `pinN` labels in the `COMPONENT_PINS` section.
- Keep the numeric pin label as an alias, e.g. `GPIO23(pin14)`, so physical pin information is still present.
- Fall back to `source_port_id` when a port has neither a name nor a pin number, avoiding `undefined` output.

/claim #4
Fixes #4.

## Verification
- `npx bun test tests/test4-readable-component-pins.test.ts`
- `npx biome check lib/convertCircuitJsonToReadableNetlist.ts tests/test2-chip.test.tsx tests/test4-readable-component-pins.test.ts`
- `npx bun run build`
- GitHub CI: Bun Test, Format Check, Type Check, Dependency Check all passed.