### PR TITLE
Score PC card pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const pcCardPinPattern =
+  /^(?:(?:PCMCIA|PCCARD|PC_CARD|CARDBUS)_(?:REG|CE|OE|WE|WAIT|READY|RESET|IREQ|INPACK|BVD|WP|CD|VS|CCLK|DATA|ADDR|A|D)\d*|(?:CF|COMPACTFLASH)_(?:DASP|IORDY|DMARQ|DMACK|CS|CSEL|REG|OE|WE|DATA|ADDR|A|D)\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (pcCardPinPattern.test(phrase)) {
+    return 1.2
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-pcmcia-compactflash-pin-labels.test.tsx
+++ b/tests/test4-pcmcia-compactflash-pin-labels.test.tsx
@@ -1,0 +1,49 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("preserves PCMCIA and CompactFlash pin labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="PC_CARD_BRIDGE"
+        pinLabels={{
+          pin1: ["PCMCIA_REG1"],
+          pin2: ["PCMCIA_CE1"],
+          pin3: ["PCCARD_WAIT1"],
+          pin4: ["CARDBUS_CCLK1"],
+          pin5: ["CF_DASP1"],
+          pin6: ["CF_IORDY1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+      <resistor resistance="1k" footprint="0402" name="R5" />
+      <resistor resistance="1k" footprint="0402" name="R6" />
+
+      <trace from=".U1 .PCMCIA_REG1" to=".R1 .pin1" />
+      <trace from=".U1 .PCMCIA_CE1" to=".R2 .pin1" />
+      <trace from=".U1 .PCCARD_WAIT1" to=".R3 .pin1" />
+      <trace from=".U1 .CARDBUS_CCLK1" to=".R4 .pin1" />
+      <trace from=".U1 .CF_DASP1" to=".R5 .pin1" />
+      <trace from=".U1 .CF_IORDY1" to=".R6 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_PCMCIA_REG1")
+  expect(netlist).toContain("NET: U1_PCMCIA_CE1")
+  expect(netlist).toContain("NET: U1_PCCARD_WAIT1")
+  expect(netlist).toContain("NET: U1_CARDBUS_CCLK1")
+  expect(netlist).toContain("NET: U1_CF_DASP1")
+  expect(netlist).toContain("NET: U1_CF_IORDY1")
+  expect(netlist).toContain("- U1 PCMCIA_REG1")
+  expect(netlist).toContain("- U1 CF_IORDY1")
+  expect(netlist).toContain("- pin1(PCMCIA_REG1): NETS(U1_PCMCIA_REG1)")
+  expect(netlist).toContain("- pin6(CF_IORDY1): NETS(U1_CF_IORDY1)")
+})


### PR DESCRIPTION
This adds a small scoring slice for PCMCIA / PC Card / CardBus / CompactFlash labels so they do not lose to passive resistor labels when net names are generated.

Covered labels include `PCMCIA_REG1`, `PCMCIA_CE1`, `PCCARD_WAIT1`, `CARDBUS_CCLK1`, `CF_DASP1`, and `CF_IORDY1`.

I checked the issue thread and open PRs for this label family before starting and did not find an overlapping slice.

Verification:
- `bun test tests/test4-pcmcia-compactflash-pin-labels.test.tsx`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #4