### PR TITLE
Fix readable chip pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -7,7 +7,10 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
-import { getReadableNameForPin } from "./getReadableNameForPin"
+import {
+  getBestReadablePinName,
+  getReadableNameForPin,
+} from "./getReadableNameForPin"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -156,9 +159,11 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const numericPin =
+          port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+        const mainPin = getBestReadablePinName({ component, port })
         const aliases: string[] = []
+        if (numericPin && numericPin !== mainPin) aliases.push(numericPin)
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,32 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinName = (name: string | undefined): boolean =>
+  Boolean(name?.match(/^(?:pin)?\d+$/i))
+
+export const getBestReadablePinName = ({
+  component,
+  port,
+}: {
+  component: AnyCircuitElement
+  port: SourcePort
+}): string => {
+  const fallbackName = port.name ? port.name : `pin${port.pin_number}`
+
+  if (
+    "ftype" in component &&
+    ["simple_resistor", "simple_capacitor"].includes(component.ftype)
+  ) {
+    return fallbackName
+  }
+
+  if (!isGenericPinName(fallbackName)) return fallbackName
+
+  return (
+    port.port_hints?.find((hint) => !isGenericPinName(hint)) ?? fallbackName
+  )
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +60,7 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = getBestReadablePinName({ component, port })
 
   const additionalPinLabels: string[] = []
 
@@ -46,6 +72,7 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (isGenericPinName(port_hint)) continue
     const score = scorePhrase(port_hint)
     if (score > 1) {
       additionalPinLabels.push(port_hint)

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)

--- a/tests/test4-generic-pin-labels.test.tsx
+++ b/tests/test4-generic-pin-labels.test.tsx
@@ -1,0 +1,70 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses descriptive chip labels instead of generic pin names", () => {
+  const circuitJson: any[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "J1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "HEADER",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GPIO14", "SCL"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["SCL"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: RP2040
+     - J1: HEADER
+
+    NET: U1_SCL
+      - U1 GPIO14 (SCL)
+      - J1 SCL
+
+
+    COMPONENT_PINS:
+    U1 (RP2040)
+    - GPIO14(pin14, SCL): NETS(U1_SCL)
+
+    J1 (HEADER)
+    - SCL(pin1): NETS(U1_SCL)
+    "
+  `)
+})


### PR DESCRIPTION
## Summary

- Prefer descriptive chip port hints such as `GPIO14` over generic labels such as `pin14` in readable netlists.
- Keep the numeric pin as an alias in `COMPONENT_PINS` so the physical pin number is still visible.
- Score known digit-bearing labels like `GPIO1`, `SCL`, and `RX` before applying the generic digit penalty.
- Add regression coverage for generic source-port names with descriptive hints.

## Validation

- `npx bun test`
- `npx bun run build`

/claim #4