### PR TITLE
Score MDIO Ethernet PHY pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,26 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const mdioEthernetPhySignalPatterns = [
+  /^MDIO(?:[_-].*)?$/,
+  /^MDC(?:[_-].*)?$/,
+  /^PHYAD(?:\d+|[_-].*)?$/,
+  /^PHY[_-]?(?:INT|IRQ|RST|RESET|ADDR|AD)(?:\d+|[_-].*)?$/,
+  /^ETH[_-]?PHY(?:[_-].*)?$/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  // Ethernet PHY management labels often include address or line indexes.
+  if (
+    mdioEthernetPhySignalPatterns.some((pattern) =>
+      pattern.test(normalizedPhrase),
+    )
+  ) {
+    return 1.25
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-mdio-ethernet-phy-labels.test.tsx
+++ b/tests/test4-mdio-ethernet-phy-labels.test.tsx
@@ -1,0 +1,52 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("test4 should preserve MDIO and Ethernet PHY management labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn32"
+        manufacturerPartNumber="KSZ9031"
+        pinLabels={{
+          pin1: ["MDIO_DATA1"],
+          pin2: ["MDC_CLK1"],
+          pin3: ["PHYAD0"],
+          pin4: ["PHY_INT1"],
+          pin5: ["PHY_RST1"],
+          pin6: ["ETH_PHY_RESET1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+      <resistor resistance="1k" footprint="0402" name="R5" />
+      <resistor resistance="1k" footprint="0402" name="R6" />
+
+      <trace from=".U1 .MDIO_DATA1" to=".R1 > .pin1" />
+      <trace from=".U1 .MDC_CLK1" to=".R2 > .pin1" />
+      <trace from=".U1 .PHYAD0" to=".R3 > .pin1" />
+      <trace from=".U1 .PHY_INT1" to=".R4 > .pin1" />
+      <trace from=".U1 .PHY_RST1" to=".R5 > .pin1" />
+      <trace from=".U1 .ETH_PHY_RESET1" to=".R6 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  for (const label of [
+    "MDIO_DATA1",
+    "MDC_CLK1",
+    "PHYAD0",
+    "PHY_INT1",
+    "PHY_RST1",
+    "ETH_PHY_RESET1",
+  ]) {
+    expect(readableNetlist).toContain(`NET: U1_${label}`)
+    expect(readableNetlist).toContain(`NETS(U1_${label})`)
+  }
+
+  expect(readableNetlist).not.toContain("NET: U1_pin")
+})


### PR DESCRIPTION
## Summary
- Add a narrow scorePhrase guard for MDIO/MDC Ethernet PHY management aliases.
- Preserve labels such as MDIO_DATA1, MDC_CLK1, PHYAD0, PHY_INT1, PHY_RST1, and ETH_PHY_RESET1 before the numeric fallback can demote them.
- Add focused test4 coverage so generated NET names and COMPONENT_PINS keep those labels.

## Validation
- npx --yes bun test tests/test4-mdio-ethernet-phy-labels.test.tsx
- npx --yes biome check . --write
- npx --yes bun test
- npx --yes bun run build
- git diff --check