### PR TITLE
Score PATA IDE pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const pataIdePinPattern =
+  /^(?:PATA(?:_[A-Z0-9]+)*|IDE_(?:CS|DIOW|DIOR|IORDY|INTRQ|DMARQ|DASP)\d*|ATA_(?:DIOW|DIOR|IORDY|INTRQ|DMARQ|DASP)\d*|ATAPI_(?:DMARQ|INTRQ|IORDY|DASP)\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (pataIdePinPattern.test(phrase)) {
+    return 1.3
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-pata-ide-pin-labels.test.tsx
+++ b/tests/test4-pata-ide-pin-labels.test.tsx
@@ -1,0 +1,47 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("uses legacy PATA and IDE labels as readable net names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="PATA_IDE_HEADER"
+        pinLabels={{
+          pin1: ["IDE_CS0"],
+          pin2: ["IDE_CS1"],
+          pin3: ["ATA_DIOW1"],
+          pin4: ["ATA_DIOR1"],
+          pin5: ["ATA_IORDY1"],
+          pin6: ["ATAPI_DMARQ1"],
+        }}
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <resistor name="R2" resistance="1k" footprint="0402" />
+      <resistor name="R3" resistance="1k" footprint="0402" />
+      <resistor name="R4" resistance="1k" footprint="0402" />
+      <resistor name="R5" resistance="1k" footprint="0402" />
+      <resistor name="R6" resistance="1k" footprint="0402" />
+
+      <trace from=".U1 .IDE_CS0" to=".R1 .pin1" />
+      <trace from=".U1 .IDE_CS1" to=".R2 .pin1" />
+      <trace from=".U1 .ATA_DIOW1" to=".R3 .pin1" />
+      <trace from=".U1 .ATA_DIOR1" to=".R4 .pin1" />
+      <trace from=".U1 .ATA_IORDY1" to=".R5 .pin1" />
+      <trace from=".U1 .ATAPI_DMARQ1" to=".R6 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_IDE_CS0")
+  expect(netlist).toContain("NET: U1_IDE_CS1")
+  expect(netlist).toContain("NET: U1_ATA_DIOW1")
+  expect(netlist).toContain("NET: U1_ATA_DIOR1")
+  expect(netlist).toContain("NET: U1_ATA_IORDY1")
+  expect(netlist).toContain("NET: U1_ATAPI_DMARQ1")
+  expect(netlist).toContain("- pin1(IDE_CS0): NETS(U1_IDE_CS0)")
+  expect(netlist).toContain("- pin6(ATAPI_DMARQ1): NETS(U1_ATAPI_DMARQ1)")
+})


### PR DESCRIPTION
Adds a narrow scorer guard for legacy PATA / IDE / ATAPI labels before the generic digit fallback. This keeps storage-bus nets readable for labels such as `IDE_CS0`, `ATA_DIOW1`, and `ATAPI_DMARQ1`.

Verification:
- red-first `bun test tests/test4-pata-ide-pin-labels.test.tsx` failed with `R1_pos` through `R6_pos` before the scorer change
- `bun test tests/test4-pata-ide-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/test4-pata-ide-pin-labels.test.tsx --write`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #4