### PR TITLE
Score Apple ADB pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const appleDesktopBusPinPattern =
+  /^(?:ADB_(?:DATA|PWR|POWER|RESET|ATTENTION|ATTN|SRQ)\d*|MAC_ADB_[A-Z0-9]+|APPLE_DESKTOP_BUS\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (appleDesktopBusPinPattern.test(phrase)) {
+    return 1.3
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-apple-adb-pin-labels.test.tsx
+++ b/tests/test4-apple-adb-pin-labels.test.tsx
@@ -1,0 +1,49 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("uses Apple Desktop Bus labels as readable net names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="MAC_ADB_CONTROLLER"
+        pinLabels={{
+          pin1: ["ADB_DATA1"],
+          pin2: ["ADB_PWR1"],
+          pin3: ["ADB_RESET1"],
+          pin4: ["ADB_ATTENTION1"],
+          pin5: ["MAC_ADB_DATA1"],
+          pin6: ["APPLE_DESKTOP_BUS1"],
+        }}
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <resistor name="R2" resistance="1k" footprint="0402" />
+      <resistor name="R3" resistance="1k" footprint="0402" />
+      <resistor name="R4" resistance="1k" footprint="0402" />
+      <resistor name="R5" resistance="1k" footprint="0402" />
+      <resistor name="R6" resistance="1k" footprint="0402" />
+
+      <trace from=".U1 .ADB_DATA1" to=".R1 .pin1" />
+      <trace from=".U1 .ADB_PWR1" to=".R2 .pin1" />
+      <trace from=".U1 .ADB_RESET1" to=".R3 .pin1" />
+      <trace from=".U1 .ADB_ATTENTION1" to=".R4 .pin1" />
+      <trace from=".U1 .MAC_ADB_DATA1" to=".R5 .pin1" />
+      <trace from=".U1 .APPLE_DESKTOP_BUS1" to=".R6 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ADB_DATA1")
+  expect(netlist).toContain("NET: U1_ADB_PWR1")
+  expect(netlist).toContain("NET: U1_ADB_RESET1")
+  expect(netlist).toContain("NET: U1_ADB_ATTENTION1")
+  expect(netlist).toContain("NET: U1_MAC_ADB_DATA1")
+  expect(netlist).toContain("NET: U1_APPLE_DESKTOP_BUS1")
+  expect(netlist).toContain("- pin1(ADB_DATA1): NETS(U1_ADB_DATA1)")
+  expect(netlist).toContain(
+    "- pin6(APPLE_DESKTOP_BUS1): NETS(U1_APPLE_DESKTOP_BUS1)",
+  )
+})


### PR DESCRIPTION
Adds a narrow scorer guard for classic Apple Desktop Bus / Mac ADB labels before the generic digit fallback. This keeps old peripheral-bus nets readable for labels such as `ADB_DATA1`, `ADB_RESET1`, and `APPLE_DESKTOP_BUS1`.

Verification:
- red-first `bun test tests/test4-apple-adb-pin-labels.test.tsx` failed with `R1_pos` through `R6_pos` before the scorer change
- `bun test tests/test4-apple-adb-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/test4-apple-adb-pin-labels.test.tsx --write`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #4