### PR TITLE
Score legacy LAN pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const legacyLanMediaPinPattern =
+  /^(?:ARCNET_(?:TX|RX|DATA|CLK)\d*|TOKEN_RING_(?:TX|RX|DATA|CLK)\d*|ETH_AUI_[A-Z0-9]+|AUI_(?:LINK_TEST|COLL|TX|RX|CD)\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (legacyLanMediaPinPattern.test(phrase)) {
+    return 1.3
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-legacy-lan-pin-labels.test.tsx
+++ b/tests/test4-legacy-lan-pin-labels.test.tsx
@@ -1,0 +1,47 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("uses legacy LAN media labels as readable net names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="LEGACY_LAN_MEDIA"
+        pinLabels={{
+          pin1: ["ARCNET_TX1"],
+          pin2: ["ARCNET_RX1"],
+          pin3: ["TOKEN_RING_TX1"],
+          pin4: ["TOKEN_RING_RX1"],
+          pin5: ["ETH_AUI_COLL1"],
+          pin6: ["AUI_LINK_TEST1"],
+        }}
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <resistor name="R2" resistance="1k" footprint="0402" />
+      <resistor name="R3" resistance="1k" footprint="0402" />
+      <resistor name="R4" resistance="1k" footprint="0402" />
+      <resistor name="R5" resistance="1k" footprint="0402" />
+      <resistor name="R6" resistance="1k" footprint="0402" />
+
+      <trace from=".U1 .ARCNET_TX1" to=".R1 .pin1" />
+      <trace from=".U1 .ARCNET_RX1" to=".R2 .pin1" />
+      <trace from=".U1 .TOKEN_RING_TX1" to=".R3 .pin1" />
+      <trace from=".U1 .TOKEN_RING_RX1" to=".R4 .pin1" />
+      <trace from=".U1 .ETH_AUI_COLL1" to=".R5 .pin1" />
+      <trace from=".U1 .AUI_LINK_TEST1" to=".R6 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_ARCNET_TX1")
+  expect(netlist).toContain("NET: U1_ARCNET_RX1")
+  expect(netlist).toContain("NET: U1_TOKEN_RING_TX1")
+  expect(netlist).toContain("NET: U1_TOKEN_RING_RX1")
+  expect(netlist).toContain("NET: U1_ETH_AUI_COLL1")
+  expect(netlist).toContain("NET: U1_AUI_LINK_TEST1")
+  expect(netlist).toContain("- pin1(ARCNET_TX1): NETS(U1_ARCNET_TX1)")
+  expect(netlist).toContain("- pin6(AUI_LINK_TEST1): NETS(U1_AUI_LINK_TEST1)")
+})


### PR DESCRIPTION
Adds a narrow scorer guard for legacy LAN-media labels before the generic digit fallback. This keeps ARCNET, Token Ring, and Ethernet AUI nets readable for labels such as `ARCNET_TX1`, `TOKEN_RING_RX1`, and `AUI_LINK_TEST1`.

Verification:
- red-first `bun test tests/test4-legacy-lan-pin-labels.test.tsx` failed with `R1_pos` through `R6_pos` before the scorer change
- `bun test tests/test4-legacy-lan-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/test4-legacy-lan-pin-labels.test.tsx --write`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #4