### PR TITLE
Score heavy vehicle network pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const heavyVehicleNetworkPinPattern =
+  /^(?:J1939_(?:CANH|CANL|TX|RX|WAKE)\d*|J1708_(?:A|B|TX|RX)\d*|J1587_(?:TX|RX|DATA|WAKE)\d*)$/i
+
 export const scorePhrase = (phrase: string) => {
+  if (heavyVehicleNetworkPinPattern.test(phrase)) {
+    return 1.3
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-heavy-vehicle-network-pin-labels.test.tsx
+++ b/tests/test4-heavy-vehicle-network-pin-labels.test.tsx
@@ -1,0 +1,47 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("uses heavy-vehicle network labels as readable net names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="HEAVY_VEHICLE_GATEWAY"
+        pinLabels={{
+          pin1: ["J1939_CANH1"],
+          pin2: ["J1939_CANL1"],
+          pin3: ["J1708_A1"],
+          pin4: ["J1708_B1"],
+          pin5: ["J1587_TX1"],
+          pin6: ["J1587_RX1"],
+        }}
+      />
+      <resistor name="R1" resistance="1k" footprint="0402" />
+      <resistor name="R2" resistance="1k" footprint="0402" />
+      <resistor name="R3" resistance="1k" footprint="0402" />
+      <resistor name="R4" resistance="1k" footprint="0402" />
+      <resistor name="R5" resistance="1k" footprint="0402" />
+      <resistor name="R6" resistance="1k" footprint="0402" />
+
+      <trace from=".U1 .J1939_CANH1" to=".R1 .pin1" />
+      <trace from=".U1 .J1939_CANL1" to=".R2 .pin1" />
+      <trace from=".U1 .J1708_A1" to=".R3 .pin1" />
+      <trace from=".U1 .J1708_B1" to=".R4 .pin1" />
+      <trace from=".U1 .J1587_TX1" to=".R5 .pin1" />
+      <trace from=".U1 .J1587_RX1" to=".R6 .pin1" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_J1939_CANH1")
+  expect(netlist).toContain("NET: U1_J1939_CANL1")
+  expect(netlist).toContain("NET: U1_J1708_A1")
+  expect(netlist).toContain("NET: U1_J1708_B1")
+  expect(netlist).toContain("NET: U1_J1587_TX1")
+  expect(netlist).toContain("NET: U1_J1587_RX1")
+  expect(netlist).toContain("- pin1(J1939_CANH1): NETS(U1_J1939_CANH1)")
+  expect(netlist).toContain("- pin6(J1587_RX1): NETS(U1_J1587_RX1)")
+})


### PR DESCRIPTION
Adds a narrow scorer guard for J1939 / J1708 / J1587 heavy-vehicle network labels before the generic digit fallback. This keeps truck-gateway nets readable for labels such as `J1939_CANH1`, `J1708_A1`, and `J1587_RX1`.

Verification:
- red-first `bun test tests/test4-heavy-vehicle-network-pin-labels.test.tsx` failed with `R1_pos` through `R6_pos` before the scorer change
- `bun test tests/test4-heavy-vehicle-network-pin-labels.test.tsx`
- `bun x biome check lib/scorePhrase.ts tests/test4-heavy-vehicle-network-pin-labels.test.tsx --write`
- `bun test`
- `bun x tsc --noEmit`
- `bun run build`
- `git diff --check`

/claim #4