### PR TITLE
Score wireless module pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,21 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingPhraseScores = [
+  {
+    pattern:
+      /(^|[_\-\s])(?:WIFI|WLAN|ZIGBEE|BLE|BLUETOOTH|RFID|NFC)(?:[_\-\s]?(?:IRQ|INT|RESET|RST|HOST_WAKE|DEV_WAKE|WAKE|ENABLE|EN|BOOT|FIELD|PAIR|STATUS|COEX|REQ|GRANT|TX|RX|DIO|BUSY|CS|SLEEP))*\d*(?=$|[_\-\s])/,
+    score: 1.18,
+  },
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  for (const { pattern, score } of digitBearingPhraseScores) {
+    if (pattern.test(normalizedPhrase)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/wireless-module-labels.test.tsx
+++ b/tests/wireless-module-labels.test.tsx
@@ -1,0 +1,73 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores digit-bearing wireless module labels before numeric fallback", () => {
+  expect(scorePhrase("WIFI_IRQ1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("ZIGBEE_RESET1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("BLE_HOST_WAKE1")).toBeGreaterThan(scorePhrase("pin14"))
+})
+
+it("uses wireless module aliases in readable netlists", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic4"
+        manufacturerPartNumber="ESP32-C6"
+        pinLabels={{
+          pin1: ["GPIO1", "WIFI_IRQ1"],
+          pin2: ["GPIO2", "ZIGBEE_RESET1"],
+          pin3: ["GPIO3", "BLE_HOST_WAKE1"],
+          pin4: ["GPIO4", "RFID_FIELD1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .GPIO1" to=".R1 .pin1" />
+      <trace from=".U1 .GPIO2" to=".R2 .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: ESP32-C6, soic4
+     - R1: 1kΩ 0402 resistor
+     - R2: 1kΩ 0402 resistor
+
+    NET: U1_WIFI_IRQ1
+      - U1 GPIO1 (WIFI_IRQ1)
+      - R1 pin1
+
+    NET: U1_ZIGBEE_RESET1
+      - U1 GPIO2 (ZIGBEE_RESET1)
+      - R2 pin1
+
+
+    COMPONENT_PINS:
+    U1 (ESP32-C6)
+    - pin1(GPIO1, WIFI_IRQ1): NETS(U1_WIFI_IRQ1)
+    - pin2(GPIO2, ZIGBEE_RESET1): NETS(U1_ZIGBEE_RESET1)
+    - pin3(GPIO3, BLE_HOST_WAKE1): NOT_CONNECTED
+    - pin4(GPIO4, RFID_FIELD1): NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_WIFI_IRQ1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R2 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_ZIGBEE_RESET1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- Score WiFi/Zigbee/BLE/RFID/NFC wireless-module control labels before the generic numeric fallback.
- Add focused coverage proving digit-bearing aliases like WIFI_IRQ1 and ZIGBEE_RESET1 drive readable net names and pin labels.

/claim #4

## Verification
- bun test
- bun x biome check lib/scorePhrase.ts tests/wireless-module-labels.test.tsx
- bun run build