### PR TITLE
Consolidate recent protocol label scoring

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,41 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const highValueProtocolSignalPatterns = [
+  /^HDQ(?:[_-].*)?$/,
+  /^SDQ(?:[_-].*)?$/,
+  /^BQ27[45](?:[_-].*)?$/,
+  /^FUEL[_-]?GAUGE(?:[_-].*)?$/,
+  /^GAUGE(?:[_-].*)?$/,
+  /^MDIO(?:[_-].*)?$/,
+  /^MDC(?:[_-].*)?$/,
+  /^PHYAD\d*$/,
+  /^PHY[_-].*$/,
+  /^ETH[_-]?PHY(?:[_-].*)?$/,
+  /^DMX(?:512)?(?:[_-].*)?$/,
+  /^RDM(?:[_-].*)?$/,
+  /^DALI(?:[_-].*)?$/,
+  /^ARINC(?:429)?(?:[_-].*)?$/,
+  /^A429(?:[_-].*)?$/,
+  /^MIL(?:1553|STD1553)(?:[_-].*)?$/,
+  /^M1553(?:[_-].*)?$/,
+  /^1553B(?:[_-].*)?$/,
+  /^SENT(?:[_-].*)?$/,
+  /^SPC(?:[_-].*)?$/,
+  /^PSI5(?:[_-].*)?$/,
+]
+
 export const scorePhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+
+  if (
+    highValueProtocolSignalPatterns.some((pattern) =>
+      pattern.test(normalizedPhrase),
+    )
+  ) {
+    return 1.25
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-consolidated-recent-protocol-labels.test.tsx
+++ b/tests/test4-consolidated-recent-protocol-labels.test.tsx
@@ -1,0 +1,130 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+const consolidatedProtocolLabels = [
+  "HDQ_DATA1",
+  "SDQ_DATA1",
+  "BQ274_INT1",
+  "BQ275_BAT_LOW1",
+  "FUEL_GAUGE_ALERT1",
+  "GAUGE_WAKE1",
+  "MDIO_DATA1",
+  "MDC_CLK1",
+  "PHYAD0",
+  "PHY_INT1",
+  "PHY_RST1",
+  "ETH_PHY_RESET1",
+  "DMX512_DATA_P1",
+  "DMX512_DATA_N1",
+  "DMX_BREAK1",
+  "RDM_DIR1",
+  "DALI_BUS1",
+  "DALI_TX1",
+  "ARINC429_TX1",
+  "ARINC_RX1",
+  "A429_LABEL1",
+  "MIL1553_TXP1",
+  "M1553_RXN1",
+  "1553B_STUB1",
+  "SENT_OUT1",
+  "SENT_RX1",
+  "SENT_TX1",
+  "SPC_TRIG1",
+  "PSI5_BUS1",
+  "PSI5_SYNC1",
+]
+
+it("test4 should score recent protocol label families before numeric fallback", () => {
+  for (const label of consolidatedProtocolLabels) {
+    expect(scorePhrase(label)).toBe(1.25)
+  }
+
+  expect(scorePhrase("pin14")).toBe(0.5)
+})
+
+it("test4 should preserve consolidated recent protocol labels", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="qfn24"
+        manufacturerPartNumber="RECENT-PROTO"
+        pinLabels={{
+          pin1: ["HDQ_DATA1"],
+          pin2: ["SDQ_DATA1"],
+          pin3: ["FUEL_GAUGE_ALERT1"],
+          pin4: ["MDIO_DATA1"],
+          pin5: ["MDC_CLK1"],
+          pin6: ["PHYAD0"],
+          pin7: ["DMX512_DATA_P1"],
+          pin8: ["RDM_DIR1"],
+          pin9: ["DALI_BUS1"],
+          pin10: ["ARINC429_TX1"],
+          pin11: ["MIL1553_TXP1"],
+          pin12: ["M1553_RXN1"],
+          pin13: ["SENT_OUT1"],
+          pin14: ["SPC_TRIG1"],
+          pin15: ["PSI5_BUS1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+      <resistor resistance="1k" footprint="0402" name="R5" />
+      <resistor resistance="1k" footprint="0402" name="R6" />
+      <resistor resistance="1k" footprint="0402" name="R7" />
+      <resistor resistance="1k" footprint="0402" name="R8" />
+      <resistor resistance="1k" footprint="0402" name="R9" />
+      <resistor resistance="1k" footprint="0402" name="R10" />
+      <resistor resistance="1k" footprint="0402" name="R11" />
+      <resistor resistance="1k" footprint="0402" name="R12" />
+      <resistor resistance="1k" footprint="0402" name="R13" />
+      <resistor resistance="1k" footprint="0402" name="R14" />
+      <resistor resistance="1k" footprint="0402" name="R15" />
+
+      <trace from=".U1 .HDQ_DATA1" to=".R1 > .pin1" />
+      <trace from=".U1 .SDQ_DATA1" to=".R2 > .pin1" />
+      <trace from=".U1 .FUEL_GAUGE_ALERT1" to=".R3 > .pin1" />
+      <trace from=".U1 .MDIO_DATA1" to=".R4 > .pin1" />
+      <trace from=".U1 .MDC_CLK1" to=".R5 > .pin1" />
+      <trace from=".U1 .PHYAD0" to=".R6 > .pin1" />
+      <trace from=".U1 .DMX512_DATA_P1" to=".R7 > .pin1" />
+      <trace from=".U1 .RDM_DIR1" to=".R8 > .pin1" />
+      <trace from=".U1 .DALI_BUS1" to=".R9 > .pin1" />
+      <trace from=".U1 .ARINC429_TX1" to=".R10 > .pin1" />
+      <trace from=".U1 .MIL1553_TXP1" to=".R11 > .pin1" />
+      <trace from=".U1 .M1553_RXN1" to=".R12 > .pin1" />
+      <trace from=".U1 .SENT_OUT1" to=".R13 > .pin1" />
+      <trace from=".U1 .SPC_TRIG1" to=".R14 > .pin1" />
+      <trace from=".U1 .PSI5_BUS1" to=".R15 > .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  for (const label of [
+    "HDQ_DATA1",
+    "SDQ_DATA1",
+    "FUEL_GAUGE_ALERT1",
+    "MDIO_DATA1",
+    "MDC_CLK1",
+    "PHYAD0",
+    "DMX512_DATA_P1",
+    "RDM_DIR1",
+    "DALI_BUS1",
+    "ARINC429_TX1",
+    "MIL1553_TXP1",
+    "M1553_RXN1",
+    "SENT_OUT1",
+    "SPC_TRIG1",
+    "PSI5_BUS1",
+  ]) {
+    expect(readableNetlist).toContain(`NET: U1_${label}`)
+    expect(readableNetlist).toContain(`NETS(U1_${label})`)
+  }
+
+  expect(readableNetlist).not.toContain("NET: U1_pin")
+})


### PR DESCRIPTION
## Summary
- consolidates five recent focused #4 scoring slices into one mergeable branch
- scores HDQ/SDQ battery gauge, MDIO/MDC Ethernet PHY management, DMX/RDM/DALI lighting control, ARINC/MIL-STD-1553 aerospace bus, and SENT/SPC/PSI5 sensor labels before the generic numeric fallback
- adds a focused regression test covering direct scorePhrase behavior plus readable NET/COMPONENT_PINS output

This is intended as a lower-conflict review path for the already-submitted focused PRs #575, #580, #583, #587, and #590.

/claim #4

## Validation
- npx --yes bun test tests/test4-consolidated-recent-protocol-labels.test.tsx
- npx --yes biome check . --write
- npx --yes bun test
- npx --yes bun run build
- git diff --check