### PR TITLE
Use readable pin labels in component pin list

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,24 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const getComponentPinMainLabel = (port: SourcePort): string => {
+  if (port.name) return port.name
+
+  const pinNumberLabel =
+    port.pin_number !== undefined ? String(port.pin_number) : undefined
+
+  const usefulHint = port.port_hints?.find((hint) => {
+    if (!hint) return false
+    if (hint === pinNumberLabel) return false
+    if (hint === `pin${pinNumberLabel}`) return false
+    return true
+  })
+
+  if (usefulHint) return usefulHint
+  if (port.pin_number !== undefined) return `pin${port.pin_number}`
+  return port.source_port_id
+}
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -156,12 +174,15 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const mainPin = getComponentPinMainLabel(port)
         const aliases: string[] = []
+        const pinNumberLabel =
+          port.pin_number !== undefined ? String(port.pin_number) : undefined
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {
-          if (hint === String(port.pin_number)) continue
+          if (!hint) continue
+          if (hint === pinNumberLabel) continue
+          if (hint === `pin${pinNumberLabel}`) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)
         }
         const aliasPart =

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND: NETS(GND)
+    - AGND: NETS(GND)
+    - GPIO1(SCL): NETS(GND)
+    - GPIO2(SDA): NETS(U1_SDA)
+    - GPIO3: NETS(GPIO4)
+    - GPIO4(UART_TX): NOT_CONNECTED
+    - GPIO5(UART_RX): NOT_CONNECTED
+    - VDD: NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)


### PR DESCRIPTION
Fixes #4.

This updates the COMPONENT_PINS section to prefer explicit port names or useful non-numeric port_hints before falling back to pin<number>. That keeps chip pins readable instead of emitting short fallback labels such as pin14.

The aliases still include remaining useful hints and skip numeric pin-number duplicates.

Validation:
- bun test
  - 3 pass, 0 fail
- bun run build was attempted locally, but this Codex environment could not load Rollup's native macOS module (`@rollup/rollup-darwin-arm64`). This appears environment-specific; the test suite passes.
