### PR TITLE
Score known pin labels before digit fallback

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,17 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.trim()
+  if (!normalizedPhrase) return 0
+
+  const normalizedUpperPhrase = normalizedPhrase.toUpperCase()
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedUpperPhrase.includes(word.toUpperCase())) {
       return score
     }
+  }
+  if (normalizedPhrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/score-phrase.test.ts
+++ b/tests/score-phrase.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from "bun:test"
+import { generateNetName } from "lib/generateNetName"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores known technical labels before applying the digit fallback", () => {
+  expect(scorePhrase("pin14_3v3")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("gpio10")).toBeGreaterThan(scorePhrase("pin10"))
+  expect(scorePhrase("  vdd1  ")).toBeGreaterThan(scorePhrase("pin1"))
+})
+
+it("uses the more descriptive digit-bearing port hint when generating net names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_chip",
+      name: "U1",
+      manufacturer_part_number: "MCU",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["pin14", "pin14_3v3"],
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_2",
+      ftype: "simple_resistor",
+      name: "R1",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pin1", "pos"],
+    },
+  ] as any
+
+  expect(
+    generateNetName({
+      circuitJson,
+      connectedIds: ["source_port_1", "source_port_2"],
+    }),
+  ).toBe("U1_pin14_3v3")
+})


### PR DESCRIPTION
Fixes #4

/claim #4

## Summary
- Normalize labels before scoring so case and surrounding whitespace do not hide useful names.
- Check known technical vocabulary before applying the generic digit fallback.
- Add focused coverage showing `pin14_3v3`, lowercase `gpio10`, and whitespace-padded `vdd1` score above generic numeric pins, and that generated net names prefer the descriptive hint.

## Validation
- `npx bun test tests\score-phrase.test.ts` -> 2 pass, 0 fail
- `npx tsc --noEmit` -> pass
- `npx tsup .\lib\index.ts --format esm --dts` -> pass
- `npx biome check lib\scorePhrase.ts tests\score-phrase.test.ts` -> pass
- `git diff --check` -> pass

## Note
- `npx bun test` still fails in the existing JSX render fixtures on this Windows/Bun environment with `TypeError: Attempting to define property on object that is not extensible` from `@tscircuit/core` while setting `firstChild.parent`. The new focused test passes before those existing fixture failures.