### PR TITLE
fix: show descriptive chip pin hints

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,10 +7,22 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const normalizePinHint = (hint: string) => hint.trim()
+
 const isGenericPinHint = (hint: string) =>
   ["anode", "cathode", "pos", "neg", "positive", "negative"].includes(
-    hint.toLowerCase(),
+    normalizePinHint(hint).toLowerCase(),
   )
+
+const isPinNumberName = (name: string, pin_number: number | undefined) => {
+  const normalizedName = normalizePinHint(name).toLowerCase()
+  if (/^\d+$/.test(normalizedName)) return true
+  if (pin_number === undefined) return /^pin\d+$/.test(normalizedName)
+  return (
+    normalizedName === String(pin_number) ||
+    normalizedName === `pin${pin_number}`
+  )
+}
 
 export const getReadableNameForPin = ({
   circuitJson,
@@ -32,10 +44,12 @@ export const getReadableNameForPin = ({
 
   // Determine pin polarity from hints
   const isPositive = port.port_hints?.some((hint) =>
-    ["anode", "pos", "positive"].includes(hint.toLowerCase()),
+    ["anode", "pos", "positive"].includes(normalizePinHint(hint).toLowerCase()),
   )
   const isNegative = port.port_hints?.some((hint) =>
-    ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
+    ["cathode", "neg", "negative"].includes(
+      normalizePinHint(hint).toLowerCase(),
+    ),
   )
 
   // Format pin description
@@ -49,13 +63,21 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
-  for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    if (port_hint === String(port.pin_number)) continue
-    if (port_hint === `pin${port.pin_number}`) continue
+  const allowLowScoreChipHint =
+    component.ftype === "simple_chip" &&
+    isPinNumberName(mainPinName, port.pin_number)
+
+  for (const raw_port_hint of port.port_hints ?? []) {
+    const port_hint = normalizePinHint(raw_port_hint)
+    const normalized_port_hint = port_hint.toLowerCase()
+    if (port_hint === "") continue
+    if (normalized_port_hint === normalizePinHint(mainPinName).toLowerCase())
+      continue
+    if (normalized_port_hint === String(port.pin_number)) continue
+    if (normalized_port_hint === `pin${port.pin_number}`) continue
     if (isGenericPinHint(port_hint)) continue
     const score = scorePhrase(port_hint)
-    if (score > 1 || component.ftype === "simple_chip") {
+    if (score > 1 || allowLowScoreChipHint) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,11 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinHint = (hint: string) =>
+  ["anode", "cathode", "pos", "neg", "positive", "negative"].includes(
+    hint.toLowerCase(),
+  )
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -46,8 +51,11 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (port_hint === String(port.pin_number)) continue
+    if (port_hint === `pin${port.pin_number}`) continue
+    if (isGenericPinHint(port_hint)) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score > 1 || component.ftype === "simple_chip") {
       additionalPinLabels.push(port_hint)
     }
   }
@@ -55,5 +63,5 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${Array.from(new Set(additionalPinLabels)).join(",")})` : ""}${displayValue}`
 }

--- a/tests/test1-basic-circuit.test.tsx
+++ b/tests/test1-basic-circuit.test.tsx
@@ -4,7 +4,7 @@ import { renderCircuit } from "tests/fixtures/render-circuit"
 
 declare module "bun:test" {
   interface Matchers<T = unknown> {
-    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+    toMatchInlineSnapshot(snapshot?: string | null): void
   }
 }
 

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -4,7 +4,7 @@ import { renderCircuit } from "tests/fixtures/render-circuit"
 
 declare module "bun:test" {
   interface Matchers<T = unknown> {
-    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+    toMatchInlineSnapshot(snapshot?: string | null): void
   }
 }
 

--- a/tests/test3-no-footprint-chip.test.tsx
+++ b/tests/test3-no-footprint-chip.test.tsx
@@ -4,7 +4,7 @@ import { renderCircuit } from "tests/fixtures/render-circuit"
 
 declare module "bun:test" {
   interface Matchers<T = unknown> {
-    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+    toMatchInlineSnapshot(snapshot?: string | null): void
   }
 }
 

--- a/tests/test4-chip-pin-hints.test.tsx
+++ b/tests/test4-chip-pin-hints.test.tsx
@@ -5,7 +5,7 @@ import { getReadableNameForPin } from "lib/getReadableNameForPin"
 
 declare module "bun:test" {
   interface Matchers<T = unknown> {
-    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+    toMatchInlineSnapshot(snapshot?: string | null): void
   }
 }
 

--- a/tests/test4-chip-pin-hints.test.tsx
+++ b/tests/test4-chip-pin-hints.test.tsx
@@ -1,0 +1,72 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("shows descriptive chip pin hints when the port name is only pin number", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "PICO_W",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "LED1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "WS2812B_2020",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GP10_SPI1SCK_I2C1SDA", "pin14", "14"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["DI", "pin3", "3"],
+      source_component_id: "source_component_1",
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+      display_name: ".U1 .GP10_SPI1SCK_I2C1SDA to .LED1 .DI",
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: PICO_W
+     - LED1: WS2812B_2020
+
+    NET: LED1_DI
+      - U1 pin14 (GP10_SPI1SCK_I2C1SDA)
+      - LED1 pin3 (DI)
+
+
+    COMPONENT_PINS:
+    U1 (PICO_W)
+    - pin14(GP10_SPI1SCK_I2C1SDA): NETS(LED1_DI)
+
+    LED1 (WS2812B_2020)
+    - pin3(DI): NETS(LED1_DI)
+    "
+  `)
+})

--- a/tests/test4-chip-pin-hints.test.tsx
+++ b/tests/test4-chip-pin-hints.test.tsx
@@ -1,6 +1,7 @@
 import { expect, it } from "bun:test"
 import type { AnyCircuitElement } from "circuit-json"
 import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
 
 declare module "bun:test" {
   interface Matchers<T = unknown> {
@@ -69,4 +70,46 @@ it("shows descriptive chip pin hints when the port name is only pin number", () 
     - pin3(DI): NETS(LED1_DI)
     "
   `)
+})
+
+it("keeps low-score chip hints targeted to numeric pin names", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "PICO_W",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["DI", "pin14", "14"],
+      source_component_id: "source_component_0",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      name: "DATA",
+      pin_number: 15,
+      port_hints: ["DI", " pos "],
+      source_component_id: "source_component_0",
+    },
+  ]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (DI)")
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 DATA (+)")
 })


### PR DESCRIPTION
## Summary
- include descriptive, non-generic chip `port_hints` in readable NET pin labels when the source port name is only `pinN`
- skip numeric and generic polarity hints so resistor/capacitor-style labels stay clean
- add a regression test for Pico-style pin labels such as `GP10_SPI1SCK_I2C1SDA`

Fixes #4.

## Testing
- `bun test`
- `bun run build`
- `bun run format:check`
- `bunx tsc --noEmit`

Note: This PR was prepared with AI assistance and reviewed/tested locally before submission.