### PR TITLE
Fix readable chip pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -7,7 +7,10 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
-import { getReadableNameForPin } from "./getReadableNameForPin"
+import {
+  getReadableNameForPin,
+  getSchematicDisplayLabelForPort,
+} from "./getReadableNameForPin"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -156,9 +159,18 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
+        const pinNumberLabel =
+          port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          (component.ftype === "simple_chip"
+            ? getSchematicDisplayLabelForPort({ circuitJson, port })
+            : undefined) ??
+          pinNumberLabel ??
+          port.name
         const aliases: string[] = []
+        if (pinNumberLabel && pinNumberLabel !== mainPin) {
+          aliases.push(pinNumberLabel)
+        }
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,20 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+export const getSchematicDisplayLabelForPort = ({
+  circuitJson,
+  port,
+}: {
+  circuitJson: AnyCircuitElement[]
+  port: SourcePort
+}): string | undefined => {
+  return su(circuitJson)
+    .schematic_port.list()
+    .find(
+      (schematicPort) => schematicPort.source_port_id === port.source_port_id,
+    )?.display_pin_label
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +48,12 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName =
+    (component.ftype === "simple_chip"
+      ? getSchematicDisplayLabelForPort({ circuitJson, port })
+      : undefined) ??
+    port.name ??
+    `Pin${port.pin_number}`
 
   const additionalPinLabels: string[] = []
 

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)


### PR DESCRIPTION
/claim #4

Fixes #4.

This updates readable netlist generation to prefer schematic display labels for simple chip ports, while keeping pin numbers as aliases in COMPONENT_PINS.

This fixes cases where chip pins were shown as short names like `pin14` instead of the more useful pin label.

Verified with:
- bun test
- bun run build
- bun x biome check lib/getReadableNameForPin.ts lib/convertCircuitJsonToReadableNetlist.ts tests/test2-chip.test.tsx