### PR TITLE
Score JAMMA and JVS arcade pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,12 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const arcadeControlPatterns = [/^JAMMA(?:_|$)/i, /^JVS(?:_|$)/i]
+
 export const scorePhrase = (phrase: string) => {
+  if (arcadeControlPatterns.some((pattern) => pattern.test(phrase))) {
+    return 1.18
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/arcade-pin-labels.test.tsx
+++ b/tests/arcade-pin-labels.test.tsx
@@ -1,0 +1,67 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scores arcade cabinet labels before the numeric fallback", () => {
+  expect(scorePhrase("JAMMA_COIN1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("JVS_TX1")).toBeGreaterThan(scorePhrase("neg"))
+})
+
+it("uses JAMMA and JVS labels for readable net names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="JVS-IO"
+        pinLabels={{
+          pin1: ["pin1", "JAMMA_COIN1"],
+          pin2: ["JVS_TX1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <trace from=".U1 .JAMMA_COIN1" to=".R1 .pin1" />
+      <trace from=".U1 .JVS_TX1" to=".R1 .pin2" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: JVS-IO, soic8
+     - R1: 1kΩ 0402 resistor
+
+    NET: U1_JAMMA_COIN1
+      - U1 pin1 (JAMMA_COIN1)
+      - R1 pin1
+
+    NET: U1_JVS_TX1
+      - U1 JVS_TX1
+      - R1 pin2
+
+
+    COMPONENT_PINS:
+    U1 (JVS-IO)
+    - pin1(JAMMA_COIN1): NETS(U1_JAMMA_COIN1)
+    - pin2(JVS_TX1): NETS(U1_JVS_TX1)
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_JAMMA_COIN1)
+    - pin2(cathode, neg, right): NETS(U1_JVS_TX1)
+    "
+  `)
+})


### PR DESCRIPTION
Fixes a focused slice of #4.

/claim #4

Scope: score JAMMA/JVS arcade cabinet labels such as `JAMMA_COIN1` and `JVS_TX1` before the generic numeric fallback, so readable netlists preserve those labels in generated `NET:` names and pin entries instead of preferring low-information passive labels like `pos`/`neg`.

Validation:
- `bun test tests/arcade-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `bun x biome check lib/scorePhrase.ts tests/arcade-pin-labels.test.tsx`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and kept the patch scoped to this label family.