### PR TITLE
Score USB HID pin aliases

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -7,6 +7,13 @@
  *
  * These unique port names are usually the best indicator of what the net is for
  */
+const digitBearingWordQualityScore = {
+  USBHID: 1.2,
+  HID_: 1.2,
+  BOOT_KBD: 1.15,
+  BOOT_MOUSE: 1.15,
+}
+
 const wordQualityScore = {
   MISO: 1.2,
   MOSI: 1.2,
@@ -34,8 +41,16 @@ const wordQualityScore = {
 const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
+const digitBearingWordQualityScoreEntries = Object.entries(
+  digitBearingWordQualityScore,
+).sort((a, b) => b[1] - a[1])
 
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/usb-hid-pin-labels.test.tsx
+++ b/tests/usb-hid-pin-labels.test.tsx
@@ -1,0 +1,46 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("scores USB HID controller aliases before the numeric fallback", () => {
+  expect(scorePhrase("HID_INT1")).toBeGreaterThan(1)
+  expect(scorePhrase("USBHID_WAKE1")).toBeGreaterThan(1)
+  expect(scorePhrase("BOOT_MOUSE1")).toBeGreaterThan(1)
+})
+
+it("uses USB HID aliases for generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="USB-HID-CTRL"
+        pinLabels={{ pin1: ["HID_INT1"], pin2: ["USBHID_WAKE1"] }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <trace from=".U1 .HID_INT1" to=".R1 .pin1" />
+    </board>,
+  )
+
+  const u1 = circuitJson.find(
+    (element: any) =>
+      element.type === "source_component" && element.name === "U1",
+  ) as any
+  const hidInterruptPort = circuitJson.find(
+    (element: any) =>
+      element.type === "source_port" &&
+      element.source_component_id === u1.source_component_id &&
+      element.name === "HID_INT1",
+  ) as any
+
+  expect(hidInterruptPort).toBeDefined()
+  hidInterruptPort.name = "pin14"
+  hidInterruptPort.pin_number = 14
+  hidInterruptPort.port_hints = ["pin14", "HID_INT1"]
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_HID_INT1")
+  expect(readableNetlist).toContain("  - U1 pin14 (HID_INT1)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- score USB HID / boot keyboard-mouse aliases before the generic numeric fallback
- preserve labels such as `HID_INT1`, `USBHID_WAKE1`, and `BOOT_MOUSE1` in readable NET names and pin entries
- add regression coverage for scoring and readable netlist output from a generic chip pin

## Non-overlap
Exact searches found no matching `HID_INT`, `USBHID`, `BOOT_MOUSE`, or `BOOT_KBD` attempts/PRs. Existing USB-related bounty work covers USB-C, USB PD, USB serial, HSIC/UTMI, and differential pins, not HID controller labels.

## Verification
- `bun test tests/usb-hid-pin-labels.test.tsx`
- `bun test`
- `bun run build`
- `bun x biome check lib/scorePhrase.ts tests/usb-hid-pin-labels.test.tsx`
- `git diff --check`