### PR TITLE
Fix numeric pin labels in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -1,13 +1,46 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+
+type ComponentValueFields = {
+  ftype?: string
+  display_resistance?: string | number
+  resistance?: string | number
+  display_capacitance?: string | number
+  capacitance?: string | number
+}
+
+const compactParts = (
+  parts: Array<string | number | null | undefined>,
+): string[] =>
+  parts
+    .filter(
+      (part): part is string | number =>
+        part !== null && part !== undefined && String(part).trim() !== "",
+    )
+    .map(String)
+
+const getResistorValue = (component: ComponentValueFields) => {
+  if (component.ftype !== "simple_resistor") return undefined
+  return (
+    component.display_resistance ??
+    (component.resistance !== undefined
+      ? `${component.resistance}Ω`
+      : undefined)
+  )
+}
+
+const getCapacitorValue = (component: ComponentValueFields) => {
+  if (component.ftype !== "simple_capacitor") return undefined
+  return (
+    component.display_capacitance ??
+    (component.capacitance !== undefined
+      ? `${component.capacitance}F`
+      : undefined)
+  )
+}
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -36,13 +69,17 @@ export const convertCircuitJsonToReadableNetlist = (
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
+      componentDescription = compactParts([
+        getResistorValue(component),
+        footprint,
+        "resistor",
+      ]).join(" ")
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
+      componentDescription = compactParts([
+        getCapacitorValue(component),
+        footprint,
+        "capacitor",
+      ]).join(" ")
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -145,9 +182,13 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = compactParts([getResistorValue(component), footprint])
+        if (details.length > 0)
+          header = `${component.name} (${details.join(" ")})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = compactParts([getCapacitorValue(component), footprint])
+        if (details.length > 0)
+          header = `${component.name} (${details.join(" ")})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -11,14 +11,23 @@ const wordQualityScore = {
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
+  SCK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
+  GP: 1.1,
+  ADC: 1.1,
+  PWM: 1.1,
+  SPI: 1.1,
+  I2C: 1.1,
   cathode: 0.5,
   anode: 0.5,
   GND: 1.1,
+  VCC: 1.1,
+  VBUS: 1.1,
+  VSYS: 1.1,
   VDD: 1.1,
   AGND: 1.1,
   V5: 1.1,
@@ -36,13 +45,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  const normalizedPhrase = phrase.toUpperCase()
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toUpperCase())) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-numeric-pin-labels.test.tsx
+++ b/tests/test4-numeric-pin-labels.test.tsx
@@ -1,0 +1,72 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses full numeric pin labels in generated net names and pin descriptions", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_u1",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_u1_14",
+      source_component_id: "source_component_u1",
+      pin_number: 14,
+      name: "pin14",
+      port_hints: ["pin14", "GP10", "GPIO10", "SPI1_SCK"],
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_r1",
+      name: "R1",
+      display_resistance: "1kΩ",
+      resistance: 1000,
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_r1_1",
+      source_component_id: "source_component_r1",
+      pin_number: 1,
+      name: "pin1",
+      port_hints: ["pin1", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_u1_14", "source_port_r1_1"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: RP2040
+     - R1: 1kΩ resistor
+
+    NET: U1_SPI1_SCK
+      - U1 pin14 (GP10,GPIO10,SPI1_SCK)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (RP2040)
+    - pin14(GP10, GPIO10, SPI1_SCK): NETS(U1_SPI1_SCK)
+
+    R1 (1kΩ)
+    - pin1(left): NETS(U1_SPI1_SCK)
+    "
+  `)
+})


### PR DESCRIPTION
Fixes #4.

This updates readable net name scoring so meaningful numeric pin labels such as GP10, GPIO10, and SPI1_SCK are preferred over generic labels like pin14. It also avoids printing undefined when passive components do not have footprint/value display fields.

Tested:
- bun test
- bun run build
- bunx biome check lib/scorePhrase.ts lib/convertCircuitJsonToReadableNetlist.ts tests/test4-numeric-pin-labels.test.tsx