### PR TITLE
Score DShot and BLHeli ESC pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,12 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingEscLabelPattern = /\b(?:BI_?DIR_?)?DSHOT|BLHELI|ESC_?TELEM\b/i
+
 export const scorePhrase = (phrase: string) => {
+  if (digitBearingEscLabelPattern.test(phrase)) {
+    return 1.25
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/dshot-blheli-pin-labels.test.tsx
+++ b/tests/dshot-blheli-pin-labels.test.tsx
@@ -1,0 +1,62 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves DShot and BLHeli ESC labels on generic chip pins", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="ESC_MCU"
+        pinLabels={{
+          pin1: ["pin1", "DSHOT1"],
+          pin2: ["pin2", "BLHELI_TELEM1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .pin1" to=".R1 .pin1" />
+      <trace from=".U1 .pin2" to=".R1 .pin2" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: ESC_MCU, soic8
+     - R1: 1kΩ 0402 resistor
+
+    NET: U1_DSHOT1
+      - U1 pin1 (DSHOT1)
+      - R1 pin1
+
+    NET: U1_BLHELI_TELEM1
+      - U1 pin2 (BLHELI_TELEM1)
+      - R1 pin2
+
+
+    COMPONENT_PINS:
+    U1 (ESC_MCU)
+    - pin1(DSHOT1): NETS(U1_DSHOT1)
+    - pin2(BLHELI_TELEM1): NETS(U1_BLHELI_TELEM1)
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_DSHOT1)
+    - pin2(cathode, neg, right): NETS(U1_BLHELI_TELEM1)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- Add a focused scorePhrase path for DShot / BLHeli / ESC telemetry aliases before the generic digit fallback.
- Add regression coverage showing generic chip pins preserve DSHOT1 and BLHELI_TELEM1 in generated NET names, NET pin entries, and COMPONENT_PINS.

## Validation
- Docker: bun test
- Docker: bun x tsc --noEmit
- Docker: bun x biome check lib/scorePhrase.ts tests/dshot-blheli-pin-labels.test.tsx
- Docker: bun run build
- git diff --check HEAD~1..HEAD

This is scoped to ESC protocol/control labels and stays separate from servo RC, BLDC/H-bridge, generic motor/fan, and MAVLink/autopilot label slices.