### PR TITLE
Score elevator and escalator pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,21 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingTechnicalWords = [
+  "ELEVATOR",
+  "ESCALATOR",
+  "HALL_CALL",
+  "FLOOR_CALL",
+  "CAR_CALL",
+  "HANDRAIL",
+]
+
 export const scorePhrase = (phrase: string) => {
+  for (const word of digitBearingTechnicalWords) {
+    if (phrase.includes(word)) {
+      return 1.2
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-elevator-escalator-pin-labels.test.tsx
+++ b/tests/test4-elevator-escalator-pin-labels.test.tsx
@@ -1,0 +1,95 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves elevator controller pin labels with digits", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="ELEVATOR_CTRL"
+        pinLabels={{
+          pin1: ["ELEVATOR_CAR1"],
+          pin2: ["HALL_CALL1"],
+          pin3: ["ESCALATOR_STEP1"],
+          pin4: ["HANDRAIL_SPEED1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <capacitor capacitance="1nF" footprint="0402" name="C1" />
+
+      <trace from=".U1 .ELEVATOR_CAR1" to=".R1 .pin1" />
+      <trace from=".U1 .HALL_CALL1" to=".C1 .pin1" />
+      <trace from=".U1 .ESCALATOR_STEP1" to=".R1 .pin2" />
+      <trace from=".U1 .HANDRAIL_SPEED1" to=".C1 .pin2" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: ELEVATOR_CTRL, soic8
+     - R1: 1kΩ 0402 resistor
+     - C1: 1nF 0402 capacitor
+
+    NET: U1_ELEVATOR_CAR1
+      - U1 ELEVATOR_CAR1
+      - R1 pin1
+
+    NET: U1_HALL_CALL1
+      - U1 HALL_CALL1
+      - C1 pin1 (+)
+
+    NET: U1_ESCALATOR_STEP1
+      - U1 ESCALATOR_STEP1
+      - R1 pin2
+
+    NET: U1_HANDRAIL_SPEED1
+      - U1 HANDRAIL_SPEED1
+      - C1 pin2 (-)
+
+
+    COMPONENT_PINS:
+    U1 (ELEVATOR_CTRL)
+    - pin1(ELEVATOR_CAR1): NETS(U1_ELEVATOR_CAR1)
+    - pin2(HALL_CALL1): NETS(U1_HALL_CALL1)
+    - pin3(ESCALATOR_STEP1): NETS(U1_ESCALATOR_STEP1)
+    - pin4(HANDRAIL_SPEED1): NETS(U1_HANDRAIL_SPEED1)
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_ELEVATOR_CAR1)
+    - pin2(cathode, neg, right): NETS(U1_ESCALATOR_STEP1)
+
+    C1 (1nF 0402)
+    - pin1(pos, anode, left): NETS(U1_HALL_CALL1)
+    - pin2(neg, cathode, right): NETS(U1_HANDRAIL_SPEED1)
+    "
+  `)
+})
+
+it("scores elevator and escalator labels before numeric fallback", () => {
+  for (const label of [
+    "ELEVATOR_CAR1",
+    "ESCALATOR_STEP1",
+    "HALL_CALL1",
+    "FLOOR_CALL1",
+    "CAR_CALL1",
+    "HANDRAIL_SPEED1",
+  ]) {
+    expect(scorePhrase(label)).toBeGreaterThan(scorePhrase("pin1"))
+    expect(scorePhrase(label)).toBeGreaterThan(scorePhrase("pos"))
+  }
+})


### PR DESCRIPTION
Fixes #4

/claim #4

This adds a focused scoring slice for elevator and escalator controller labels so digit-bearing aliases such as `ELEVATOR_CAR1`, `HALL_CALL1`, `ESCALATOR_STEP1`, and `HANDRAIL_SPEED1` are preserved in generated readable net names instead of falling through to the generic numeric penalty.

Validation:
- `npx --yes bun test tests\test4-elevator-escalator-pin-labels.test.tsx`
- `npx --yes bun test`
- `npx --yes biome check lib\scorePhrase.ts tests\test4-elevator-escalator-pin-labels.test.tsx`
- `npx --yes bun run build`
- `git diff --check`