### PR TITLE
Use full chip pin labels in readable netlists

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -145,9 +145,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = `${component.name}${details ? ` (${details})` : ""}`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = `${component.name}${details ? ` (${details})` : ""}`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -47,6 +47,7 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     if (port_hint === String(port.pin_number)) continue
+    if (port_hint.toLowerCase() === `pin${port.pin_number}`) continue
 
     const score = scorePhrase(port_hint)
     if (component.ftype === "simple_chip" || score > 1) {

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -46,8 +46,10 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (port_hint === String(port.pin_number)) continue
+
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (component.ftype === "simple_chip" || score > 1) {
       additionalPinLabels.push(port_hint)
     }
   }
@@ -55,5 +57,5 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${Array.from(new Set(additionalPinLabels)).join(", ")})` : ""}${displayValue}`
 }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,7 +36,7 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
+  if (phrase.match(/^\d+$/)) {
     return 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {

--- a/tests/test4-raw-pin-labels.test.ts
+++ b/tests/test4-raw-pin-labels.test.ts
@@ -1,0 +1,68 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import type { AnyCircuitElement } from "circuit-json"
+
+const rawCircuitJson = [
+  {
+    type: "source_component",
+    ftype: "simple_chip",
+    source_component_id: "source_component_0",
+    name: "U1",
+    manufacturer_part_number: "MCU",
+  },
+  {
+    type: "source_component",
+    ftype: "simple_resistor",
+    source_component_id: "source_component_1",
+    name: "R1",
+    display_resistance: "10kΩ",
+  },
+  {
+    type: "source_port",
+    source_port_id: "source_port_0",
+    source_component_id: "source_component_0",
+    name: "pin14",
+    pin_number: 14,
+    port_hints: ["pin14", "GPIO0", "ADC0"],
+  },
+  {
+    type: "source_port",
+    source_port_id: "source_port_1",
+    source_component_id: "source_component_1",
+    name: "pin1",
+    pin_number: 1,
+    port_hints: ["1", "left"],
+  },
+  {
+    type: "source_trace",
+    source_trace_id: "source_trace_0",
+    connected_source_port_ids: ["source_port_0", "source_port_1"],
+    connected_source_net_ids: [],
+  },
+] as AnyCircuitElement[]
+
+it("uses full chip pin labels in readable nets and omits undefined footprints", () => {
+  const netlist = convertCircuitJsonToReadableNetlist(rawCircuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("U1 pin14 (GPIO0, ADC0)")
+  expect(netlist).toContain("R1 (10kΩ)")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: MCU
+     - R1: 10kΩ resistor
+
+    NET: U1_GPIO0
+      - U1 pin14 (GPIO0, ADC0)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (MCU)
+    - pin14(GPIO0, ADC0): NETS(U1_GPIO0)
+
+    R1 (10kΩ)
+    - pin1(left): NETS(U1_GPIO0)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

## Summary
- Include all chip pin hints in readable pin names so generated nets show labels like `pin14 (GPIO0, ADC0)` instead of only `pin14`.
- Keep numeric-only duplicate hints out of pin labels.
- Avoid printing `undefined` in passive component pin section headers when no footprint is present.
- Improve phrase scoring so labels like `GPIO0` can outrank generic `pin14` when naming generated nets.

## Verification
- `npm exec --yes --package bun -- bun test tests\\test4-raw-pin-labels.test.ts`
- `npm exec --yes --package typescript@^5 -- tsc --noEmit`
- `npm run build`
- `./node_modules/.bin/biome.cmd format lib/convertCircuitJsonToReadableNetlist.ts lib/getReadableNameForPin.ts lib/scorePhrase.ts tests/test4-raw-pin-labels.test.ts`
- `git diff --check`

Note: `bun test` for the whole suite could not complete locally on Windows because the npm-installed tree was missing peer packages loaded by `@tscircuit/core`; the focused regression test avoids that render dependency and passes locally.