### PR TITLE
Show chip aliases for generic pin names

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -1,11 +1,40 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
+
+const isUsefulChipPinLabel = ({
+  label,
+  pinNumber,
+}: {
+  label: string
+  pinNumber?: number
+}) => {
+  const normalizedLabel = label.trim()
+  if (!normalizedLabel) return false
+
+  const lowerLabel = normalizedLabel.toLowerCase()
+  const genericHints = new Set([
+    "pin",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "pos",
+    "neg",
+    "positive",
+    "negative",
+    "anode",
+    "cathode",
+  ])
+
+  if (genericHints.has(lowerLabel)) return false
+  if (pinNumber !== undefined) {
+    if (lowerLabel === String(pinNumber)) return false
+    if (lowerLabel === `pin${pinNumber}`) return false
+  }
+
+  return /[a-z]/i.test(normalizedLabel)
+}
 
 export const getReadableNameForPin = ({
   circuitJson,
@@ -47,7 +76,14 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (
+      score > 1 ||
+      (component.ftype === "simple_chip" &&
+        isUsefulChipPinLabel({
+          label: port_hint,
+          pinNumber: port.pin_number,
+        }))
+    ) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
+  if (/^\d+$/.test(phrase) || /^pin\d+$/i.test(phrase)) {
     return 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (/[a-z]/i.test(phrase) && /\d/.test(phrase)) {
+    return 1.05
   }
   return 1
 }

--- a/tests/test4-generic-chip-pin-labels.test.tsx
+++ b/tests/test4-generic-chip-pin-labels.test.tsx
@@ -1,0 +1,35 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("shows useful chip labels when source pins have generic pin names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic16"
+        pinLabels={{
+          pin14: ["GPIO14"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <trace from=".U1 .GPIO14" to=".R1 .pin1" />
+    </board>,
+  )
+
+  const sourcePort = circuitJson.find(
+    (element) => element.type === "source_port" && element.name === "GPIO14",
+  )
+  if (!sourcePort || sourcePort.type !== "source_port") {
+    throw new Error("Expected rendered GPIO14 source port")
+  }
+
+  sourcePort.name = "pin14"
+  sourcePort.port_hints = ["GPIO14", "pin14", "14"]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_GPIO14")
+  expect(netlist).toContain("  - U1 pin14 (GPIO14)")
+  expect(netlist).toContain("- pin14(GPIO14): NETS(U1_GPIO14)")
+})


### PR DESCRIPTION
/claim #4

Fixes #4

Summary:
- treats generic `pinN`/numeric hints as low-value while allowing signal labels with digits such as `GPIO14` to score as useful
- includes useful chip pin aliases beside generic pin names in readable net output
- adds regression coverage for generic chip pin source data

Validation:
- `bunx biome check lib/getReadableNameForPin.ts lib/scorePhrase.ts tests/test4-generic-chip-pin-labels.test.tsx`
- `bun test tests`
- `git diff --cached --check`