### PR TITLE
Fix readable netlist pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -7,7 +7,10 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
-import { getReadableNameForPin } from "./getReadableNameForPin"
+import {
+  getReadableLabelsForPort,
+  getReadableNameForPin,
+} from "./getReadableNameForPin"
 
 const joinDisplayParts = (
   parts: Array<string | number | null | undefined>,
@@ -176,24 +179,7 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const pinNumberLabel =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
-        const mainPin = port.name ?? pinNumberLabel ?? port.source_port_id
-        const aliases: string[] = []
-        if (pinNumberLabel && pinNumberLabel !== mainPin) {
-          aliases.push(pinNumberLabel)
-        }
-        for (const hint of port.port_hints ?? []) {
-          if (hint === String(port.pin_number)) continue
-          if (
-            hint === mainPin ||
-            hint === port.name ||
-            hint === pinNumberLabel
-          ) {
-            continue
-          }
-          aliases.push(hint)
-        }
+        const { primaryLabel, aliases } = getReadableLabelsForPort(port)
         const aliasPart =
           aliases.length > 0
             ? `(${Array.from(new Set(aliases)).join(", ")})`
@@ -201,7 +187,7 @@ export const convertCircuitJsonToReadableNetlist = (
         const nets = portIdToNetNames[port.source_port_id] ?? []
         const netsPart =
           nets.length > 0 ? `NETS(${nets.join(", ")})` : "NOT_CONNECTED"
-        netlist.push(`- ${mainPin}${aliasPart}: ${netsPart}`)
+        netlist.push(`- ${primaryLabel}${aliasPart}: ${netsPart}`)
       }
       netlist.push("")
     }

--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,14 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const joinDisplayParts = (
+  parts: Array<string | number | null | undefined>,
+): string =>
+  parts
+    .filter((part) => part !== undefined && part !== null && part !== "")
+    .map(String)
+    .join(" ")
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -36,13 +44,17 @@ export const convertCircuitJsonToReadableNetlist = (
     const footprint = cadComponent?.footprinter_string
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
-        footprint ? ` ${footprint}` : ""
-      } resistor`
+      componentDescription = joinDisplayParts([
+        component.display_resistance,
+        footprint,
+        "resistor",
+      ])
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
-        footprint ? ` ${footprint}` : ""
-      } capacitor`
+      componentDescription = joinDisplayParts([
+        component.display_capacitance,
+        footprint,
+        "capacitor",
+      ])
     } else if (component.ftype === "simple_chip") {
       const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
@@ -145,9 +157,17 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = joinDisplayParts([
+          component.display_resistance,
+          footprint,
+        ])
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = joinDisplayParts([
+          component.display_capacitance,
+          footprint,
+        ])
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }
@@ -156,13 +176,23 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const pinNumberLabel =
+          port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+        const mainPin = port.name ?? pinNumberLabel ?? port.source_port_id
         const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
+        if (pinNumberLabel && pinNumberLabel !== mainPin) {
+          aliases.push(pinNumberLabel)
+        }
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
-          if (hint !== mainPin && hint !== port.name) aliases.push(hint)
+          if (
+            hint === mainPin ||
+            hint === port.name ||
+            hint === pinNumberLabel
+          ) {
+            continue
+          }
+          aliases.push(hint)
         }
         const aliasPart =
           aliases.length > 0

--- a/lib/generateNetName.ts
+++ b/lib/generateNetName.ts
@@ -62,12 +62,17 @@ export const generateNetName = ({
     )
     .concat(nets.map((n) => n.name))
 
-  const phrases = possibleNames.map((name) => ({
-    name,
-    score: scorePhrase(name),
-  }))
+  const phrases = possibleNames
+    .filter((name): name is string => Boolean(name))
+    .map((name) => ({
+      name,
+      score: scorePhrase(name),
+    }))
 
-  const bestPortName = phrases.sort((a, b) => b.score - a.score)[0].name
+  const bestPhrase = phrases.sort((a, b) => b.score - a.score)[0]
+  if (!bestPhrase) return "unnamed_net"
+
+  const bestPortName = bestPhrase.name
 
   // Find the component that has the best port name
   const bestPort = ports.find(

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,65 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const nonPrimaryPinLabels = new Set([
+  "anode",
+  "cathode",
+  "left",
+  "neg",
+  "negative",
+  "pos",
+  "positive",
+  "right",
+])
+
+const getPinNumberLabel = (port: SourcePort) =>
+  port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+
+const isGenericPinLabel = (label: string, port: SourcePort): boolean => {
+  const normalizedLabel = label.trim().toLowerCase()
+  return (
+    normalizedLabel === String(port.pin_number) ||
+    normalizedLabel === getPinNumberLabel(port)?.toLowerCase()
+  )
+}
+
+const shouldUseAsPrimaryLabel = (label: string, port: SourcePort): boolean => {
+  if (isGenericPinLabel(label, port)) return false
+  if (nonPrimaryPinLabels.has(label.trim().toLowerCase())) return false
+  return scorePhrase(label) > 0.5
+}
+
+const uniqueLabels = (labels: string[]) => Array.from(new Set(labels))
+
+export const getReadableLabelsForPort = (port: SourcePort) => {
+  const pinNumberLabel = getPinNumberLabel(port)
+  const allLabels = [
+    ...(port.name ? [port.name] : []),
+    ...(port.port_hints ?? []),
+  ]
+  const primaryLabel =
+    allLabels.find((label) => shouldUseAsPrimaryLabel(label, port)) ??
+    port.name ??
+    pinNumberLabel ??
+    port.source_port_id
+  const aliases: string[] = []
+
+  if (pinNumberLabel && pinNumberLabel !== primaryLabel) {
+    aliases.push(pinNumberLabel)
+  }
+
+  for (const label of allLabels) {
+    if (label === primaryLabel) continue
+    if (label === pinNumberLabel) continue
+    if (label === String(port.pin_number)) continue
+    if (isGenericPinLabel(label, port)) continue
+    if (nonPrimaryPinLabels.has(label.trim().toLowerCase())) continue
+    aliases.push(label)
+  }
+
+  return { primaryLabel, aliases: uniqueLabels(aliases) }
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +93,7 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const { primaryLabel, aliases } = getReadableLabelsForPort(port)
 
   const additionalPinLabels: string[] = []
 
@@ -44,16 +103,10 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
-  for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
-      additionalPinLabels.push(port_hint)
-    }
-  }
+  additionalPinLabels.push(...aliases)
 
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  return `${component.name} ${primaryLabel}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(", ")})` : ""}${displayValue}`
 }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -22,6 +22,7 @@ const getPinNumberLabel = (port: SourcePort) =>
   port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
 
 const isGenericPinLabel = (label: string, port: SourcePort): boolean => {
+  if (port.pin_number === undefined) return false
   const normalizedLabel = label.trim().toLowerCase()
   return (
     normalizedLabel === String(port.pin_number) ||
@@ -39,6 +40,7 @@ const uniqueLabels = (labels: string[]) => Array.from(new Set(labels))
 
 export const getReadableLabelsForPort = (port: SourcePort) => {
   const pinNumberLabel = getPinNumberLabel(port)
+  const hasGenericPortName = !port.name || isGenericPinLabel(port.name, port)
   const allLabels = [
     ...(port.name ? [port.name] : []),
     ...(port.port_hints ?? []),
@@ -49,9 +51,13 @@ export const getReadableLabelsForPort = (port: SourcePort) => {
     pinNumberLabel ??
     port.source_port_id
   const aliases: string[] = []
+  const displayAliases: string[] = []
 
   if (pinNumberLabel && pinNumberLabel !== primaryLabel) {
     aliases.push(pinNumberLabel)
+    if (hasGenericPortName) {
+      displayAliases.push(pinNumberLabel)
+    }
   }
 
   for (const label of allLabels) {
@@ -59,11 +65,16 @@ export const getReadableLabelsForPort = (port: SourcePort) => {
     if (label === pinNumberLabel) continue
     if (label === String(port.pin_number)) continue
     if (isGenericPinLabel(label, port)) continue
-    if (nonPrimaryPinLabels.has(label.trim().toLowerCase())) continue
     aliases.push(label)
+    if (nonPrimaryPinLabels.has(label.trim().toLowerCase())) continue
+    displayAliases.push(label)
   }
 
-  return { primaryLabel, aliases: uniqueLabels(aliases) }
+  return {
+    primaryLabel,
+    aliases: uniqueLabels(aliases),
+    displayAliases: uniqueLabels(displayAliases),
+  }
 }
 
 export const getReadableNameForPin = ({
@@ -93,7 +104,7 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const { primaryLabel, aliases } = getReadableLabelsForPort(port)
+  const { primaryLabel, displayAliases } = getReadableLabelsForPort(port)
 
   const additionalPinLabels: string[] = []
 
@@ -103,7 +114,7 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
-  additionalPinLabels.push(...aliases)
+  additionalPinLabels.push(...displayAliases)
 
   const displayValue = component.display_value
     ? ` (${component.display_value})`

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,11 +36,12 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
+  const normalizedPhrase = phrase.trim().toLowerCase()
+  if (/^(pin)?\d+$/i.test(normalizedPhrase)) {
     return 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {
-    if (phrase.includes(word)) {
+    if (normalizedPhrase.includes(word.toLowerCase())) {
       return score
     }
   }

--- a/tests/readable-netlist-unit.test.ts
+++ b/tests/readable-netlist-unit.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "../lib/convertCircuitJsonToReadableNetlist"
+
+test("omits undefined details when resistor and capacitor footprints are missing", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "R1",
+      ftype: "simple_resistor",
+      display_resistance: "1k",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "C1",
+      ftype: "simple_capacitor",
+      display_capacitance: "1nF",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+    },
+  ] as unknown as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("R1 (1k)")
+  expect(netlist).toContain("C1 (1nF)")
+})
+
+test("uses descriptive port names before pin numbers in component pin listings", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "R1",
+      ftype: "simple_resistor",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_0",
+      name: "GPIO1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "GPIO1",
+      pin_number: 14,
+      port_hints: ["GPIO1", "SCL"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: ["source_net_0"],
+    },
+  ] as unknown as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: GPIO1")
+  expect(netlist).toContain("  - U1 GPIO1 (SCL)")
+  expect(netlist).toContain("- GPIO1(pin14, SCL): NETS(GPIO1)")
+  expect(netlist).not.toContain("- pin14(GPIO1")
+})

--- a/tests/readable-netlist-unit.test.ts
+++ b/tests/readable-netlist-unit.test.ts
@@ -100,3 +100,55 @@ test("uses descriptive port names before pin numbers in component pin listings",
   expect(netlist).toContain("- GPIO1(pin14, SCL): NETS(GPIO1)")
   expect(netlist).not.toContain("- pin14(GPIO1")
 })
+
+test("prefers descriptive hints when the source port name is a generic pin number", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "R1",
+      ftype: "simple_resistor",
+      display_resistance: "10k",
+    },
+    {
+      type: "source_net",
+      source_net_id: "source_net_0",
+      name: "GPIO1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GPIO1", "SCL"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: ["source_net_0"],
+    },
+  ] as unknown as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("  - U1 GPIO1 (pin14, SCL)")
+  expect(netlist).toContain("- GPIO1(pin14, SCL): NETS(GPIO1)")
+  expect(netlist).not.toContain("U1 pin14 (GPIO1")
+})

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)


### PR DESCRIPTION
## Summary

- avoid rendering `undefined` in resistor/capacitor component pin headers when footprint data is missing
- prefer descriptive source port names in `COMPONENT_PINS`, while keeping pin numbers as aliases
- handle generic source port names like `pin14` by promoting descriptive labels from `port_hints` such as `GPIO1` and `SCL`
- keep connected net entries concise when the source port already has a descriptive name, while preserving pin aliases for generic `pinN` names
- add focused unit coverage for missing footprint details, descriptive chip pin labels, and generic-pin-name fallback
- update the existing chip snapshot for the new descriptive pin output

## Tests

- `npm.cmd exec -- tsc --noEmit`
- `npm.cmd exec -- biome check lib\\scorePhrase.ts lib\\getReadableNameForPin.ts lib\\convertCircuitJsonToReadableNetlist.ts tests\\readable-netlist-unit.test.ts`
- `npm.cmd exec -- tsup .\\lib\\index.ts --format esm --dts`
- `node -e "..."` smoke test against the built package for `pin14` + `GPIO1/SCL` output
- GitHub Actions on `b6117bd`: Bun Test, Type Check, Format Check, and Dependency Check all passing

Note: I could not run `bun test` locally because `bun` is not installed in this Windows environment; the repository's GitHub Actions Bun workflow is passing.

Fixes #4