### PR TITLE
Fix full labels for generic numbered pins

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -8,6 +8,7 @@ import type {
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
+import { scorePhrase } from "./scorePhrase"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -145,9 +146,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }
@@ -157,7 +164,11 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.pin_number !== undefined
+            ? `pin${port.pin_number}`
+            : (port.name ??
+              port.port_hints?.find((hint) => scorePhrase(hint) >= 1) ??
+              "unnamed_pin")
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -25,16 +25,27 @@ export const getReadableNameForPin = ({
   )
   if (!component) return ""
 
+  const portHints = port.port_hints ?? []
+
   // Determine pin polarity from hints
-  const isPositive = port.port_hints?.some((hint) =>
+  const isPositive = portHints.some((hint) =>
     ["anode", "pos", "positive"].includes(hint.toLowerCase()),
   )
-  const isNegative = port.port_hints?.some((hint) =>
+  const isNegative = portHints.some((hint) =>
     ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const firstReadableHint = portHints.find((hint) => scorePhrase(hint) >= 1)
+  const mainPinName =
+    port.name ??
+    (port.pin_number !== undefined ? `Pin${port.pin_number}` : undefined) ??
+    firstReadableHint ??
+    "unnamed_pin"
+  const mainPinNameIsGeneric =
+    port.pin_number !== undefined &&
+    (mainPinName.toLowerCase() === `pin${port.pin_number}` ||
+      mainPinName === String(port.pin_number))
 
   const additionalPinLabels: string[] = []
 
@@ -44,10 +55,17 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
-  for (const port_hint of port.port_hints ?? []) {
+  for (const port_hint of portHints) {
     if (port_hint === mainPinName) continue
+    if (
+      port.pin_number !== undefined &&
+      (port_hint.toLowerCase() === `pin${port.pin_number}` ||
+        port_hint === String(port.pin_number))
+    ) {
+      continue
+    }
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score > 1 || (mainPinNameIsGeneric && score >= 1)) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,19 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
+  if (phrase.match(/^pin\d+$/i) || phrase.match(/^\d+$/)) {
     return 0.5
   }
+
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
   }
+
+  if (phrase.match(/[a-z]/i) && phrase.match(/\d/)) {
+    return 1.05
+  }
+
   return 1
 }

--- a/tests/test4-full-pin-labels.test.ts
+++ b/tests/test4-full-pin-labels.test.ts
@@ -1,0 +1,115 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("includes full labels for generic numbered chip pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      resistance: 1000,
+      display_resistance: "1k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      pin_number: 14,
+      name: "pin14",
+      port_hints: ["GP10", "RUN", "PWM5"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 1,
+      name: "pin1",
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: RP2040
+     - R1: 1k resistor
+
+    NET: U1_GP10
+      - U1 pin14 (GP10,RUN,PWM5)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (RP2040)
+    - pin14(GP10, RUN, PWM5): NETS(U1_GP10)
+
+    R1 (1k)
+    - pin1(anode, pos, left): NETS(U1_GP10)
+    "
+  `)
+})
+
+it("does not print undefined for ports without a name or pin number", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U2",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      port_hints: ["RUN"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 1,
+      name: "pin1",
+      port_hints: ["IO1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as any
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("U1 RUN")
+  expect(netlist).toContain("- RUN: NETS(U2_IO1)")
+})


### PR DESCRIPTION
Fixes #4.

/claim #4

## Summary
- Preserve useful labels such as `GP10`, `RUN`, and `PWM5` when a chip pin's primary name is only a generic numbered label like `pin14`.
- Prefer readable hints for unnamed ports and fall back to `unnamed_pin` instead of producing `Pinundefined`/`undefined` output.
- Avoid printing `undefined` in resistor/capacitor component pin headers when footprint metadata is missing.
- Add regression tests covering the original full-label behavior and the unnamed-port fallback.

## Validation
- `npm install`
- `npx tsc --noEmit`
- `npx biome check lib/convertCircuitJsonToReadableNetlist.ts lib/getReadableNameForPin.ts lib/scorePhrase.ts tests/test4-full-pin-labels.test.ts`
- `npm run build`
- `npm exec --yes --package bun -- bun test tests/test4-full-pin-labels.test.ts`