### PR TITLE
fix: resolve undefined in readable netlists and improve pin labels

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "circuit-json-to-readable-netlist",

--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -25,6 +25,13 @@ export const convertCircuitJsonToReadableNetlist = (
 
   // Add COMPONENTS section
   netlist.push("COMPONENTS:")
+  const cleanString = (val: any): string | undefined => {
+    if (val === undefined || val === null) return undefined
+    const s = String(val).trim()
+    if (s === "" || s === "undefined" || s === "null") return undefined
+    return s
+  }
+
   for (const component of source_components) {
     let componentDescription = ""
 
@@ -33,25 +40,29 @@ export const convertCircuitJsonToReadableNetlist = (
       source_component_id: component.source_component_id,
     })
 
-    const footprint = cadComponent?.footprinter_string
+    const footprint = cleanString(cadComponent?.footprinter_string)
+    const manufacturerPartNumber = cleanString(
+      component.manufacturer_part_number,
+    )
 
     if (component.ftype === "simple_resistor") {
-      componentDescription = `${component.display_resistance}${
+      const resistance = cleanString(component.display_resistance) ?? ""
+      componentDescription = `${resistance}${
         footprint ? ` ${footprint}` : ""
-      } resistor`
+      } resistor`.trim()
     } else if (component.ftype === "simple_capacitor") {
-      componentDescription = `${component.display_capacitance}${
+      const capacitance = cleanString(component.display_capacitance) ?? ""
+      componentDescription = `${capacitance}${
         footprint ? ` ${footprint}` : ""
-      } capacitor`
+      } capacitor`.trim()
     } else if (component.ftype === "simple_chip") {
-      const manufacturerPartNumber = component.manufacturer_part_number
       componentDescription = [manufacturerPartNumber, footprint]
         .filter(Boolean)
         .join(", ")
     } else {
-      componentDescription = [component.name, component.type]
-        .filter(Boolean)
-        .join(", ")
+      const compName = cleanString(component.name)
+      const compType = cleanString(component.type)
+      componentDescription = [compName, compType].filter(Boolean).join(", ")
     }
 
     netlist.push(` - ${component.name}: ${componentDescription}`)
@@ -142,14 +153,25 @@ export const convertCircuitJsonToReadableNetlist = (
       const cadComponent = su(circuitJson).cad_component.getWhere({
         source_component_id: component.source_component_id,
       })
-      const footprint = cadComponent?.footprinter_string
+      const footprint = cleanString(cadComponent?.footprinter_string)
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const resistance = cleanString(component.display_resistance)
+        header = `${component.name}${
+          resistance || footprint
+            ? ` (${[resistance, footprint].filter(Boolean).join(" ")})`
+            : ""
+        }`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
-      } else if (component.manufacturer_part_number) {
-        header = `${component.name} (${component.manufacturer_part_number})`
+        const capacitance = cleanString(component.display_capacitance)
+        header = `${component.name}${
+          capacitance || footprint
+            ? ` (${[capacitance, footprint].filter(Boolean).join(" ")})`
+            : ""
+        }`
+      } else {
+        const mfn = cleanString(component.manufacturer_part_number)
+        header = `${component.name}${mfn ? ` (${mfn})` : ""}`
       }
       netlist.push(header)
       const ports = source_ports

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -5,7 +5,6 @@ import type {
   SourceNet,
   SourcePort,
 } from "circuit-json"
-import { scorePhrase } from "./scorePhrase"
 
 export const getReadableNameForPin = ({
   circuitJson,
@@ -44,12 +43,28 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
+  const genericHints = new Set([
+    mainPinName.toLowerCase(),
+    String(port.pin_number),
+    `pin${port.pin_number}`,
+    `pin ${port.pin_number}`,
+    "anode",
+    "cathode",
+    "pos",
+    "positive",
+    "neg",
+    "negative",
+    "left",
+    "right",
+    "top",
+    "bottom",
+  ])
+
   for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
-      additionalPinLabels.push(port_hint)
-    }
+    const hintLower = port_hint.toLowerCase().trim()
+    if (genericHints.has(hintLower)) continue
+    if (additionalPinLabels.includes(port_hint)) continue
+    additionalPinLabels.push(port_hint)
   }
 
   const displayValue = component.display_value

--- a/tests/test4-pin-labels-and-undefined.test.tsx
+++ b/tests/test4-pin-labels-and-undefined.test.tsx
@@ -1,0 +1,85 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("should display descriptive pin labels with numbers and prevent undefined in netlist", () => {
+  const circuitJson = renderCircuit(
+    <board width="50mm" height="50mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="PICO_W"
+        pinLabels={{
+          pin1: ["pin1", "GP11"],
+          pin2: ["pin2", "VBUS"],
+        }}
+      />
+      <chip
+        name="LED16"
+        footprint="soic8"
+        manufacturerPartNumber="WS2812B_2020"
+        pinLabels={{
+          pin3: ["DI"],
+          pin4: ["VDD"],
+        }}
+      />
+      <trace from=".U1 .GP11" to=".LED16 .DI" />
+      <trace from=".U1 .VBUS" to=".LED16 .VDD" />
+    </board>,
+  )
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  // Verify that it doesn't contain "undefined"
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).not.toContain("null")
+
+  // Verify that full descriptive pin labels are present in the nets section
+  expect(netlist).toContain("- U1 pin1 (GP11)")
+  expect(netlist).toContain("- LED16 DI")
+  expect(netlist).toContain("- U1 pin2 (VBUS)")
+  expect(netlist).toContain("- LED16 VDD")
+
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: PICO_W, soic8
+     - LED16: WS2812B_2020, soic8
+
+    NET: LED16_DI
+      - U1 pin1 (GP11)
+      - LED16 DI
+
+    NET: LED16_VDD
+      - U1 pin2 (VBUS)
+      - LED16 VDD
+
+
+    COMPONENT_PINS:
+    U1 (PICO_W)
+    - pin1(GP11): NETS(LED16_DI)
+    - pin2(VBUS): NETS(LED16_VDD)
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    LED16 (WS2812B_2020)
+    - pin1: NOT_CONNECTED
+    - pin2: NOT_CONNECTED
+    - pin3(DI): NETS(LED16_DI)
+    - pin4(VDD): NETS(LED16_VDD)
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
This PR resolves two issues:
1. Prevents any "undefined" or "null" strings from appearing in component descriptions and headers.
2. Displays descriptive pin labels containing numbers (like GP11) by refactoring the getReadableNameForPin function to include all non-generic labels instead of filtering them out using scorePhrase.

/claim #4