### PR TITLE
Preserve MIPI RFFE readable labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isMipiRffeLabel = (phrase: string) =>
+  /(^|[_-])(MIPI[_-]?RFFE|RFFE)([_-]|$)/i.test(phrase)
+
 export const scorePhrase = (phrase: string) => {
+  if (isMipiRffeLabel(phrase)) {
+    return 1.18
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/rffe-labels.test.ts
+++ b/tests/rffe-labels.test.ts
@@ -1,0 +1,79 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves MIPI RFFE labels on generic pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "RFFE-CONTROLLER",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "U2",
+      manufacturer_part_number: "RF-FRONT-END",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["RFFE_SCLK1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["RFFE_SDATA1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["MIPI_RFFE_SDATA1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["RFFE_VIO1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_3", "source_port_4"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_RFFE_SCLK1")
+  expect(netlist).toContain("  - U1 pin14 (RFFE_SCLK1)")
+  expect(netlist).toContain("  - U2 pin1 (RFFE_SDATA1)")
+  expect(netlist).toContain("NET: U1_MIPI_RFFE_SDATA1")
+  expect(netlist).toContain("  - U1 pin15 (MIPI_RFFE_SDATA1)")
+  expect(netlist).toContain("  - U2 pin2 (RFFE_VIO1)")
+  expect(netlist).toContain("- pin14(RFFE_SCLK1): NETS(U1_RFFE_SCLK1)")
+  expect(netlist).toContain(
+    "- pin15(MIPI_RFFE_SDATA1): NETS(U1_MIPI_RFFE_SDATA1)",
+  )
+})


### PR DESCRIPTION
/claim #4

## Summary
- score MIPI RFFE aliases before the generic numeric fallback
- preserve labels such as `RFFE_SCLK1`, `RFFE_SDATA1`, `MIPI_RFFE_SDATA1`, and `RFFE_VIO1` in generated readable NET names and component pin entries
- add a focused raw Circuit JSON regression test for the RFFE label slice

## Non-overlap
I searched current open PR titles/bodies for RFFE-specific coverage and found no submitted PR matching this slice. This stays separate from existing RF/antenna, sub-GHz radio, LoRa, SATCOM, NFC/RFID, and generic numbered-pin scopes.

## Validation
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun test tests/rffe-labels.test.ts`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun test`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun x biome check lib/scorePhrase.ts tests/rffe-labels.test.ts`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun run build`
- `git diff --check`