### PR TITLE
Preserve load-switch readable labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isLoadSwitchLabel = (phrase: string) =>
+  /(^|[_-])(LOADSW|LOAD[_-]?SWITCH|PWR[_-]?SWITCH)([_-]|$)/i.test(phrase)
+
 export const scorePhrase = (phrase: string) => {
+  if (isLoadSwitchLabel(phrase)) {
+    return 1.18
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/load-switch-labels.test.ts
+++ b/tests/load-switch-labels.test.ts
@@ -1,0 +1,79 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves load-switch labels on generic pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "TPS22919",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "J1",
+      manufacturer_part_number: "POWER-RAIL-CONN",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["LOADSW_OUT1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["LOAD_SWITCH_IN1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["PWR_SWITCH_FLT1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["LOADSW_EN1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_3", "source_port_4"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_LOADSW_OUT1")
+  expect(netlist).toContain("  - U1 pin14 (LOADSW_OUT1)")
+  expect(netlist).toContain("  - J1 pin1 (LOAD_SWITCH_IN1)")
+  expect(netlist).toContain("NET: U1_PWR_SWITCH_FLT1")
+  expect(netlist).toContain("  - U1 pin15 (PWR_SWITCH_FLT1)")
+  expect(netlist).toContain("  - J1 pin2 (LOADSW_EN1)")
+  expect(netlist).toContain("- pin14(LOADSW_OUT1): NETS(U1_LOADSW_OUT1)")
+  expect(netlist).toContain(
+    "- pin15(PWR_SWITCH_FLT1): NETS(U1_PWR_SWITCH_FLT1)",
+  )
+})


### PR DESCRIPTION
/claim #4

## Summary
- score load-switch and power-switch aliases before the generic numeric fallback
- preserve labels such as `LOADSW_OUT1`, `LOAD_SWITCH_IN1`, `PWR_SWITCH_FLT1`, and `LOADSW_EN1` in generated readable NET names and component pin entries
- add a focused raw Circuit JSON regression test for the load-switch label slice

## Non-overlap
I searched current open PR titles/bodies for load-switch/power-switch-specific coverage and found no submitted PR matching this slice. This stays separate from existing PMIC control/status, eFuse/hot-swap, power-path, ideal-diode, and generic numbered-pin scopes.

## Validation
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun test tests/load-switch-labels.test.ts`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun test`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun x biome check lib/scorePhrase.ts tests/load-switch-labels.test.ts`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun run build`
- `git diff --check`