### PR TITLE
Preserve optocoupler readable labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,14 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const isOptocouplerLabel = (phrase: string) =>
+  /(^|[_-])(OPTOCOUPLER|OPTOISO|OPTOISOLATOR|PC817)([_-]|$)/i.test(phrase)
+
 export const scorePhrase = (phrase: string) => {
+  if (isOptocouplerLabel(phrase)) {
+    return 1.18
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/optocoupler-labels.test.ts
+++ b/tests/optocoupler-labels.test.ts
@@ -1,0 +1,79 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+it("preserves optocoupler labels on generic pins", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "PC817",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "J1",
+      manufacturer_part_number: "ISOLATED-IO",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["OPTOCOUPLER_LED_A1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["OPTOCOUPLER_LED_K1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["OPTOISO_OUT1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      name: "pin2",
+      pin_number: 2,
+      port_hints: ["PC817_C1"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_3", "source_port_4"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_OPTOCOUPLER_LED_A1")
+  expect(netlist).toContain("  - U1 pin14 (OPTOCOUPLER_LED_A1)")
+  expect(netlist).toContain("  - J1 pin1 (OPTOCOUPLER_LED_K1)")
+  expect(netlist).toContain("NET: U1_OPTOISO_OUT1")
+  expect(netlist).toContain("  - U1 pin15 (OPTOISO_OUT1)")
+  expect(netlist).toContain("  - J1 pin2 (PC817_C1)")
+  expect(netlist).toContain(
+    "- pin14(OPTOCOUPLER_LED_A1): NETS(U1_OPTOCOUPLER_LED_A1)",
+  )
+  expect(netlist).toContain("- pin15(OPTOISO_OUT1): NETS(U1_OPTOISO_OUT1)")
+})


### PR DESCRIPTION
/claim #4

## Summary
- score optocoupler and opto-isolator aliases before the generic numeric fallback
- preserve labels such as `OPTOCOUPLER_LED_A1`, `OPTOCOUPLER_LED_K1`, `OPTOISO_OUT1`, and `PC817_C1` in generated readable NET names and component pin entries
- add a focused raw Circuit JSON regression test for the optocoupler label slice

## Non-overlap
I searched current open PR titles/bodies for optocoupler/opto-isolator/PC817-specific coverage and found no submitted PR matching this slice. Nearby ESD/TVS work explicitly leaves optocouplers separate; this stays separate from PLC-style OPTO_IN, digital-isolator, SSR/triac, and generic numbered-pin scopes.

## Validation
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun test tests/optocoupler-labels.test.ts`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun test`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun x biome check lib/scorePhrase.ts tests/optocoupler-labels.test.ts`
- `npm_config_cache=/tmp/npm-cache-codex npx --yes bun run build`
- `git diff --check`