### PR TITLE
[codex] Score PCR and microfluidic pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,33 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const pcrMicrofluidicInstrumentationWords = [
+  "PCR",
+  "QPCR",
+  "THERMOCYCLER",
+  "MICROFLUIDIC",
+  "LAB_ON_CHIP",
+  "ELECTROPHORESIS",
+  "GEL_DOC",
+  "SPECTROPHOTOMETER",
+]
+
+const scorePcrMicrofluidicInstrumentationPhrase = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    pcrMicrofluidicInstrumentationWords.some((word) =>
+      normalizedPhrase.includes(word),
+    )
+  ) {
+    return 1.2
+  }
+}
+
 export const scorePhrase = (phrase: string) => {
+  const pcrMicrofluidicScore = scorePcrMicrofluidicInstrumentationPhrase(phrase)
+  if (pcrMicrofluidicScore) {
+    return pcrMicrofluidicScore
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/pcr-microfluidic-pin-labels.test.ts
+++ b/tests/pcr-microfluidic-pin-labels.test.ts
@@ -1,0 +1,87 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores PCR and microfluidic aliases before numeric fallback", () => {
+  expect(scorePhrase("PCR_SYNC1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("QPCR_READY1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("THERMOCYCLER_LID1")).toBeGreaterThan(scorePhrase("pin14"))
+  expect(scorePhrase("MICROFLUIDIC_VALVE1")).toBeGreaterThan(
+    scorePhrase("pin14"),
+  )
+})
+
+it("preserves PCR and microfluidic aliases in readable net output", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_1",
+      name: "U1",
+      manufacturer_part_number: "LAB-AFE",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_2",
+      name: "J1",
+      manufacturer_part_number: "TESTPOINTS",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["PCR_SYNC1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_2",
+      name: "pos",
+      pin_number: 1,
+      port_hints: ["pos"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_1",
+      name: "pin15",
+      pin_number: 15,
+      port_hints: ["MICROFLUIDIC_VALVE1"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_4",
+      source_component_id: "source_component_2",
+      name: "neg",
+      pin_number: 2,
+      port_hints: ["neg"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_1",
+      connected_source_port_ids: ["source_port_1", "source_port_2"],
+      connected_source_net_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_2",
+      connected_source_port_ids: ["source_port_3", "source_port_4"],
+      connected_source_net_ids: [],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).toContain("NET: U1_PCR_SYNC1")
+  expect(netlist).toContain("  - U1 pin14 (PCR_SYNC1)")
+  expect(netlist).toContain("- pin14(PCR_SYNC1): NETS(U1_PCR_SYNC1)")
+  expect(netlist).toContain("NET: U1_MICROFLUIDIC_VALVE1")
+  expect(netlist).toContain("  - U1 pin15 (MICROFLUIDIC_VALVE1)")
+  expect(netlist).toContain(
+    "- pin15(MICROFLUIDIC_VALVE1): NETS(U1_MICROFLUIDIC_VALVE1)",
+  )
+})


### PR DESCRIPTION
## Summary
- score PCR / qPCR / microfluidics lab-instrument aliases before the generic numeric fallback
- preserve labels such as `PCR_SYNC1`, `QPCR_READY1`, `THERMOCYCLER_LID1`, and `MICROFLUIDIC_VALVE1` in readable NET names and pin entries
- add focused regression coverage for generated net names and COMPONENT_PINS output

## Why
Digit-bearing lab-instrument aliases currently fall through to the generic numeric score, so generated readable net names can prefer lower-information labels such as `pos` or physical labels such as `pin14`.

## Validation
- `npx --yes bun@1.3.13 test tests/pcr-microfluidic-pin-labels.test.ts`
- `npx --yes bun@1.3.13 test`
- `npx --yes bun@1.3.13 run build`
- `npx --yes bun@1.3.13 x biome check lib/scorePhrase.ts tests/pcr-microfluidic-pin-labels.test.ts`
- `npx --yes bun@1.3.13 x tsc --noEmit`
- `git diff --check`

/claim #4

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.