### PR TITLE
Score HCSL clock pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -15,6 +15,7 @@ const wordQualityScore = {
   SCL: 1.2,
   RX: 1.15,
   TX: 1.15,
+  HCSL: 1.15,
   GPIO: 1.1,
   cathode: 0.5,
   anode: 0.5,
@@ -36,13 +37,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-hcsl-pin-labels.test.tsx
+++ b/tests/test4-hcsl-pin-labels.test.tsx
@@ -1,0 +1,69 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("keeps HCSL clock labels with lane numbers", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="CLOCK_GEN"
+        pinLabels={{
+          pin1: ["GPIO8", "HCSL_CLK1_P"],
+          pin2: ["GPIO9", "HCSL_CLK1_N"],
+        }}
+      />
+      <chip
+        name="J1"
+        footprint="pinrow2"
+        manufacturerPartNumber="PCIE_REFCLK"
+        pinLabels={{
+          pin1: ["HCSL_CLK1_P"],
+          pin2: ["HCSL_CLK1_N"],
+        }}
+      />
+      <trace from=".U1 .HCSL_CLK1_P" to=".J1 .HCSL_CLK1_P" />
+      <trace from=".U1 .HCSL_CLK1_N" to=".J1 .HCSL_CLK1_N" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: CLOCK_GEN, soic8
+     - J1: PCIE_REFCLK, pinrow2
+
+    NET: U1_HCSL_CLK1_P
+      - U1 GPIO8 (HCSL_CLK1_P)
+      - J1 HCSL_CLK1_P
+
+    NET: U1_HCSL_CLK1_N
+      - U1 GPIO9 (HCSL_CLK1_N)
+      - J1 HCSL_CLK1_N
+
+
+    COMPONENT_PINS:
+    U1 (CLOCK_GEN)
+    - pin1(GPIO8, HCSL_CLK1_P): NETS(U1_HCSL_CLK1_P)
+    - pin2(GPIO9, HCSL_CLK1_N): NETS(U1_HCSL_CLK1_N)
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    J1 (PCIE_REFCLK)
+    - pin1(HCSL_CLK1_P): NETS(U1_HCSL_CLK1_P)
+    - pin2(HCSL_CLK1_N): NETS(U1_HCSL_CLK1_N)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4

This covers a narrow clock-interface case that was still missing: HCSL labels with lane numbers, for example HCSL_CLK1_P and HCSL_CLK1_N.

Before this change, digit-bearing labels could be scored too low before their useful signal was considered. The netlist could fall back to a less helpful GPIO-style name. With this change, HCSL labels are kept in readable net names and pin entries.

Checked locally:
- bun test tests/test4-hcsl-pin-labels.test.tsx
- bun test
- bun x biome check lib/scorePhrase.ts tests/test4-hcsl-pin-labels.test.tsx
- bun run build
- git diff --check