### PR TITLE
Fix readable pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -168,6 +168,7 @@ export const convertCircuitJsonToReadableNetlist = (
         const { primaryLabel, aliases, pinNumberLabel } =
           getReadableLabelsForPin({
             component,
+            includeLowSignalHints: true,
             port,
           })
         const mainPin = pinNumberLabel ?? primaryLabel

--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -7,7 +7,10 @@ import type {
 } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
-import { getReadableNameForPin } from "./getReadableNameForPin"
+import {
+  getReadableLabelsForPin,
+  getReadableNameForPin,
+} from "./getReadableNameForPin"
 
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
@@ -145,9 +148,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = details ? `${component.name} (${details})` : component.name
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }
@@ -156,17 +165,18 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
-        const aliases: string[] = []
-        if (port.name && port.name !== mainPin) aliases.push(port.name)
-        for (const hint of port.port_hints ?? []) {
-          if (hint === String(port.pin_number)) continue
-          if (hint !== mainPin && hint !== port.name) aliases.push(hint)
-        }
+        const { primaryLabel, aliases, pinNumberLabel } =
+          getReadableLabelsForPin({
+            component,
+            port,
+          })
+        const mainPin = pinNumberLabel ?? primaryLabel
+        const componentPinAliases = [primaryLabel, ...aliases].filter(
+          (alias) => alias && alias !== mainPin,
+        )
         const aliasPart =
-          aliases.length > 0
-            ? `(${Array.from(new Set(aliases)).join(", ")})`
+          componentPinAliases.length > 0
+            ? `(${Array.from(new Set(componentPinAliases)).join(", ")})`
             : ""
         const nets = portIdToNetNames[port.source_port_id] ?? []
         const netsPart =

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,95 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const lowSignalPinHints = new Set([
+  "anode",
+  "cathode",
+  "left",
+  "right",
+  "neg",
+  "negative",
+  "pos",
+  "positive",
+])
+
+type PinLabelsByName = Record<string, string | string[] | undefined>
+
+const normalizePinLabel = (label: string) => label.trim()
+
+const isPinNumberOnlyLabel = (label: string, pinNumber?: number) => {
+  if (label.match(/^\d+$/)) return true
+  if (pinNumber === undefined) return false
+  return label.toLowerCase() === `pin${pinNumber}`.toLowerCase()
+}
+
+const getComponentPinLabels = ({
+  component,
+  port,
+}: {
+  component: AnyCircuitElement | undefined
+  port: SourcePort
+}) => {
+  const pinLabels =
+    (component as { pin_labels?: PinLabelsByName; pinLabels?: PinLabelsByName })
+      ?.pin_labels ??
+    (component as { pin_labels?: PinLabelsByName; pinLabels?: PinLabelsByName })
+      ?.pinLabels
+  if (!pinLabels) return []
+
+  const labelKeys = [
+    port.pin_number !== undefined ? `pin${port.pin_number}` : undefined,
+    port.pin_number !== undefined ? String(port.pin_number) : undefined,
+    port.name,
+  ].filter(Boolean) as string[]
+
+  return labelKeys.flatMap((key) => {
+    const labels = pinLabels[key]
+    if (!labels) return []
+    return Array.isArray(labels) ? labels : [labels]
+  })
+}
+
+export const getReadableLabelsForPin = ({
+  component,
+  port,
+}: {
+  component: AnyCircuitElement | undefined
+  port: SourcePort
+}): {
+  primaryLabel: string
+  aliases: string[]
+  pinNumberLabel: string | undefined
+} => {
+  const pinNumberLabel =
+    port.pin_number !== undefined ? `pin${port.pin_number}` : undefined
+  const rawLabels = [
+    port.name,
+    ...(port.port_hints ?? []),
+    ...getComponentPinLabels({ component, port }),
+  ]
+    .filter(Boolean)
+    .map((label) => normalizePinLabel(label as string))
+    .filter(Boolean)
+
+  const uniqueLabels = Array.from(new Set(rawLabels))
+  const semanticLabels = uniqueLabels.filter((label) => {
+    if (isPinNumberOnlyLabel(label, port.pin_number)) return false
+    if (lowSignalPinHints.has(label.toLowerCase()) && scorePhrase(label) <= 1) {
+      return false
+    }
+    return true
+  })
+
+  const primaryLabel = semanticLabels[0] ?? port.name ?? pinNumberLabel ?? ""
+  const aliases = semanticLabels.filter((label) => label !== primaryLabel)
+
+  return {
+    primaryLabel,
+    aliases,
+    pinNumberLabel,
+  }
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +123,10 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const { primaryLabel: mainPinName, aliases } = getReadableLabelsForPin({
+    component,
+    port,
+  })
 
   const additionalPinLabels: string[] = []
 
@@ -44,12 +136,9 @@ export const getReadableNameForPin = ({
     additionalPinLabels.push("-")
   }
 
-  for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
-      additionalPinLabels.push(port_hint)
-    }
+  for (const alias of aliases) {
+    if (alias === mainPinName) continue
+    additionalPinLabels.push(alias)
   }
 
   const displayValue = component.display_value

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -57,9 +57,11 @@ const getComponentPinLabels = ({
 
 export const getReadableLabelsForPin = ({
   component,
+  includeLowSignalHints = false,
   port,
 }: {
   component: AnyCircuitElement | undefined
+  includeLowSignalHints?: boolean
   port: SourcePort
 }): {
   primaryLabel: string
@@ -80,7 +82,11 @@ export const getReadableLabelsForPin = ({
   const uniqueLabels = Array.from(new Set(rawLabels))
   const semanticLabels = uniqueLabels.filter((label) => {
     if (isPinNumberOnlyLabel(label, port.pin_number)) return false
-    if (lowSignalPinHints.has(label.toLowerCase()) && scorePhrase(label) <= 1) {
+    if (
+      !includeLowSignalHints &&
+      lowSignalPinHints.has(label.toLowerCase()) &&
+      scorePhrase(label) <= 1
+    ) {
       return false
     }
     return true

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,7 +36,7 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
+  if (phrase.match(/^\d+$/)) {
     return 0.5
   }
   for (const [word, score] of wordQualityScoreEntries) {

--- a/tests/test4-readable-pin-labels.test.ts
+++ b/tests/test4-readable-pin-labels.test.ts
@@ -1,0 +1,77 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses component pin labels when source ports are named by pin number", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+      ftype: "simple_chip",
+      manufacturer_part_number: "RP2040",
+      pin_labels: {
+        pin14: ["GPIO14", "ADC2"],
+      },
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14"],
+    },
+  ] as AnyCircuitElement[]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 GPIO14 (ADC2)")
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: RP2040
+
+
+    COMPONENT_PINS:
+    U1 (RP2040)
+    - pin14(GPIO14, ADC2): NOT_CONNECTED
+    "
+  `)
+})
+
+it("does not print undefined for passive components without footprints", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "R1",
+      ftype: "simple_resistor",
+      display_resistance: "10kΩ",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      pin_number: 1,
+      port_hints: ["1", "anode", "pos"],
+    },
+  ] as AnyCircuitElement[]
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toContain("R1 (10kΩ)")
+})


### PR DESCRIPTION
/claim #4

## Summary

Fixes #4.

This updates readable netlist output so source ports named only by pin number can still use semantic chip pin labels, e.g. `pin14` can render as `GPIO14 (ADC2)` when the source component carries pin label metadata.

## Root Cause

Pin labels containing digits were scored as low quality, so useful labels such as `GPIO14` were filtered out alongside bare numeric hints like `14`. The component pin listing also preferred `pinN` as the main label and passive component headers could interpolate missing footprints as `undefined`.

## Changes

- Add shared pin label extraction that combines port names, port hints, and component `pin_labels` / `pinLabels`.
- Keep `pinN` in the `COMPONENT_PINS` list while showing semantic labels as aliases.
- Only treat purely numeric labels as low quality, preserving labels such as `GPIO14`.
- Avoid printing `undefined` for passive component pin headers when a footprint is missing.
- Add tests covering semantic chip pin labels and missing passive footprints.

## Validation

- `npm run build`
- `npx tsc --noEmit`
- `npx biome check .`
- `npx --yes bun test`
