### PR TITLE
fix: include labels for generic chip pins

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -1,11 +1,9 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
+
+const getGenericPinName = (pinNumber?: number) =>
+  pinNumber !== undefined ? `pin${pinNumber}` : undefined
 
 export const getReadableNameForPin = ({
   circuitJson,
@@ -35,6 +33,10 @@ export const getReadableNameForPin = ({
 
   // Format pin description
   const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const genericPinName = getGenericPinName(port.pin_number)
+  const hasGenericPinName =
+    genericPinName !== undefined &&
+    mainPinName.toLowerCase() === genericPinName.toLowerCase()
 
   const additionalPinLabels: string[] = []
 
@@ -46,8 +48,9 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
+    if (port_hint === String(port.pin_number)) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score > 1 || (component.ftype === "simple_chip" && hasGenericPinName)) {
       additionalPinLabels.push(port_hint)
     }
   }
@@ -55,5 +58,6 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  const uniquePinLabels = Array.from(new Set(additionalPinLabels))
+  return `${component.name} ${mainPinName}${uniquePinLabels.length > 0 ? ` (${uniquePinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/tests/get-readable-name-for-pin.test.ts
+++ b/tests/get-readable-name-for-pin.test.ts
@@ -1,0 +1,54 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("includes chip pin labels when the port name is only a generic pin number", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_chip",
+      name: "U1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "GPIO6", "SPI0_SCK"],
+    },
+  ]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson: circuitJson as any,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 pin14 (GPIO6,SPI0_SCK)")
+})
+
+it("does not add low-signal passive component pin hints to net entries", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      ftype: "simple_resistor",
+      name: "R1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["1", "anode", "pos", "left"],
+    },
+  ]
+
+  expect(
+    getReadableNameForPin({
+      circuitJson: circuitJson as any,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("R1 pin1")
+})


### PR DESCRIPTION
Fixes #4

/claim #4

## Summary
- Preserve chip port hints such as `GPIO6` and `SPI0_SCK` when the source port name is only a generic pin name like `pin14`.
- Continue filtering low-signal passive component hints such as `left`, `right`, and `anode` from net entries.
- Add regression coverage for generic chip pin names.

## Test plan
- `npm exec --yes bun@latest -- test`
- `npm exec --yes bun@latest -- run format:check`
- `npm exec --yes bun@latest -- run build`
