### PR TITLE
Fix scoring for numbered pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/score-phrase.test.ts
+++ b/tests/score-phrase.test.ts
@@ -1,0 +1,11 @@
+import { expect, it } from "bun:test"
+import { scorePhrase } from "lib/scorePhrase"
+
+it("scores known pin labels with numbers by their useful words", () => {
+  expect(scorePhrase("GPIO1")).toBeGreaterThan(1)
+  expect(scorePhrase("UART_RX1")).toBeGreaterThan(1)
+})
+
+it("still treats generic numbered pins as low quality", () => {
+  expect(scorePhrase("pin14")).toBeLessThan(1)
+})


### PR DESCRIPTION
Summary
- Score known label words like GPIO/RX/TX before applying the generic digit penalty
- Add regression tests for numbered useful labels and generic pin labels
- Rename the regression test file to satisfy the repo's kebab-case filename rule

Verification
- node_modules\@biomejs\cli-win32-x64\biome.exe check --write
- C:\WINDOWS\TEMP\codex-bun\bun-windows-x64\bun.exe test
- GitHub Actions: format-check, dependency-check, test, and type-check all passed on ea270ec

Fixes #4

/claim #4