### PR TITLE
fix: promote descriptive port_hints over generic pin<N> names + fix scorePhrase digit ordering

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,12 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+// Polarity/directional hints that should never be used as a main pin name.
+// They are already represented by the +/- suffix, or are too generic.
+const POLARITY_HINTS = new Set([
+  "anode", "cathode", "pos", "neg", "positive", "negative", "left", "right",
+])
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -33,11 +39,37 @@ export const getReadableNameForPin = ({
     ["cathode", "neg", "negative"].includes(hint.toLowerCase()),
   )
 
-  // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  // When port.name is a generic "pin<N>" placeholder (e.g. from footprinter),
+  // try to find a more descriptive name from port_hints (e.g. "GP14", "GPIO3").
+  // Exclude polarity/directional hints — those are already shown as +/-.
+  const isGenericPinName =
+    port.name != null && /^pin\d+$/i.test(port.name)
+
+  let mainPinName: string
+  if (isGenericPinName && port.port_hints && port.port_hints.length > 0) {
+    let bestHint: string | null = null
+    let bestScore = -Infinity
+    for (const hint of port.port_hints) {
+      if (!hint) continue
+      if (/^pin\d+$/i.test(hint)) continue  // skip generic pin<N>
+      if (/^\d+$/.test(hint)) continue        // skip bare numbers
+      if (POLARITY_HINTS.has(hint.toLowerCase())) continue  // skip polarity words
+      const score = scorePhrase(hint)
+      if (score > bestScore) {
+        bestScore = score
+        bestHint = hint
+      }
+    }
+    // Accept any non-polarity hint that scores >= 0.5 (includes GP14 with digit score)
+    mainPinName =
+      bestHint != null && bestScore >= 0.5
+        ? bestHint
+        : (port.name ?? `Pin${port.pin_number}`)
+  } else {
+    mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  }
 
   const additionalPinLabels: string[] = []
-
   if (isPositive && component.ftype !== "simple_resistor") {
     additionalPinLabels.push("+")
   } else if (isNegative && component.ftype !== "simple_resistor") {
@@ -45,7 +77,11 @@ export const getReadableNameForPin = ({
   }
 
   for (const port_hint of port.port_hints ?? []) {
+    if (!port_hint) continue
     if (port_hint === mainPinName) continue
+    // Skip generic pin<N> hints and bare digit strings
+    if (/^pin\d+$/i.test(port_hint)) continue
+    if (/^\d+$/.test(port_hint)) continue
     const score = scorePhrase(port_hint)
     if (score > 1) {
       additionalPinLabels.push(port_hint)
@@ -55,5 +91,6 @@ export const getReadableNameForPin = ({
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
+
   return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -30,19 +30,20 @@ const wordQualityScore = {
   left: 0.3,
   right: 0.3,
 }
-
 const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  // Check word quality first, before the digit penalty.
+  // This ensures "GPIO1_RX" scores 1.15 (RX match) instead of 0.5 (digit match).
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test5-pin-labels.test.ts
+++ b/tests/test5-pin-labels.test.ts
@@ -1,0 +1,79 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("promotes descriptive hint over generic pin<N> name in getReadableNameForPin", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      name: "U1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["GP14", "pin14"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_0",
+      name: "pin3",
+      pin_number: 3,
+      port_hints: ["GPIO3", "pin3"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_2",
+      source_component_id: "source_component_0",
+      name: "pin4",
+      pin_number: 4,
+      port_hints: ["UART_RX0", "pin4"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_3",
+      source_component_id: "source_component_0",
+      name: "pin6",
+      pin_number: 6,
+      port_hints: ["GPIO1_RX", "pin6"],
+    },
+  ] as any[]
+
+  // When port.name is "pin14" and best hint is "GP14" (score 0.5 after fix — digit),
+  // the descriptive hint is still better than a generic pin number placeholder
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 GP14")
+
+  // GPIO3 scores 1.1 (GPIO match) — clearly better
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 GPIO3")
+
+  // UART_RX0 scores 1.15 (RX match after scorePhrase fix) — clearly better
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_2",
+    }),
+  ).toBe("U1 UART_RX0")
+
+  // GPIO1_RX: scores 1.15 (RX match) after scorePhrase fix — promoted
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_3",
+    }),
+  ).toBe("U1 GPIO1_RX")
+})


### PR DESCRIPTION
Fixes the two root causes of pin labels showing as `pin14` instead of descriptive names like `GP14`, `GPIO3`, or `UART_RX0`.

## Problem

When a chip is defined with `port.name = "pin14"` (a generic placeholder), the readable netlist outputs `U1 pin14` which is useless. Additionally, hints like `GPIO1_RX` were scoring 0.5 (digit penalty) instead of 1.15 (RX match), so they never appeared as additional labels.

## Fix

### 1. `lib/scorePhrase.ts` — move digit check after word quality check

```diff
-  if (phrase.match(/\d+/)) { return 0.5 }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) { return score }
   }
+  if (phrase.match(/\d+/)) { return 0.5 }
```

Before: `GPIO1_RX` → 0.5 (digit fires first)
After: `GPIO1_RX` → 1.15 (RX match)

### 2. `lib/getReadableNameForPin.ts` — promote best hint when name is `pin<N>`

When `port.name` matches `/^pin\d+$/i` (a generic placeholder with no semantic value), find the highest-scored hint from `port_hints` and use it as `mainPinName`:

```
pin14 + hints["GP14", "pin14"]   → "U1 GP14"
pin3  + hints["GPIO3", "pin3"]   → "U1 GPIO3"
pin4  + hints["UART_RX0", "pin4"] → "U1 UART_RX0"  (scores 1.15 after scorePhrase fix)
pin6  + hints["GPIO1_RX", "pin6"] → "U1 GPIO1_RX"  (scores 1.15 after scorePhrase fix)
```

Also filters out `pin<N>` and bare digit hints from `additionalPinLabels` to avoid redundant output.

### 3. `tests/test5-pin-labels.test.ts` — new test

Covers all four cases above including the `GPIO1_RX` case that required both fixes together.

/claim #4