### PR TITLE
fix(scorePhrase): preserve numeric-suffix pin labels like GPIO14, SCL2, TX1

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,16 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
+  // Check for known high-quality words first — a phrase like "GPIO14" or
+  // "SCL2" should inherit the word's score even though it contains digits.
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  // Generic numeric-only or pin-number labels score lower
+  if (phrase.match(/^\d+$/) || phrase.match(/^pin\d+$/i)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-numeric-pin-labels.test.tsx
+++ b/tests/test4-numeric-pin-labels.test.tsx
@@ -1,0 +1,30 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("scorePhrase: GPIO14 should score >= 1.1 (not penalized for digits)", () => {
+  expect(scorePhrase("GPIO14")).toBeGreaterThanOrEqual(1.1)
+})
+
+it("scorePhrase: SCL2 should score >= 1.2 (SCL keyword present)", () => {
+  expect(scorePhrase("SCL2")).toBeGreaterThanOrEqual(1.2)
+})
+
+it("scorePhrase: TX1 should score >= 1.15 (TX keyword present)", () => {
+  expect(scorePhrase("TX1")).toBeGreaterThanOrEqual(1.15)
+})
+
+it("scorePhrase: plain number '14' should score 0.5", () => {
+  expect(scorePhrase("14")).toBe(0.5)
+})
+
+it("scorePhrase: 'pin14' should score 0.5 (generic pin label)", () => {
+  expect(scorePhrase("pin14")).toBe(0.5)
+})


### PR DESCRIPTION
Closes #648

## Bug

The digit check in `scorePhrase` ran **before** the keyword loop, so labels containing both a known keyword and digits (e.g. `GPIO14`, `SCL2`, `UART_TX1`) scored `0.5` and were silently filtered from netlist output.

The existing code comment already described the correct behavior:
> "for example GPIO1 would score 1.1, but GPIO1_RX would score 1.15"

...but the implementation was inverted.

## Fix

Run the keyword loop first. Only apply the digit penalty to purely numeric labels (`"14"`) or generic pin labels (`"pin14"`).

## Tests added

5 unit tests in `tests/test4-numeric-pin-labels.test.tsx` covering:
- `GPIO14` → scores ≥ 1.1 ✅
- `SCL2` → scores ≥ 1.2 ✅  
- `TX1` → scores ≥ 1.15 ✅
- `"14"` → scores 0.5 ✅
- `"pin14"` → scores 0.5 ✅