### PR TITLE
Fix readable labels for numeric pin names

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -1,10 +1,5 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
@@ -145,9 +140,15 @@ export const convertCircuitJsonToReadableNetlist = (
       const footprint = cadComponent?.footprinter_string
       let header = component.name
       if (component.ftype === "simple_resistor") {
-        header = `${component.name} (${component.display_resistance} ${footprint})`
+        const details = [component.display_resistance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = `${component.name} (${details})`
       } else if (component.ftype === "simple_capacitor") {
-        header = `${component.name} (${component.display_capacitance} ${footprint})`
+        const details = [component.display_capacitance, footprint]
+          .filter(Boolean)
+          .join(" ")
+        header = `${component.name} (${details})`
       } else if (component.manufacturer_part_number) {
         header = `${component.name} (${component.manufacturer_part_number})`
       }

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -1,11 +1,39 @@
 import { su } from "@tscircuit/circuit-json-util"
-import type {
-  AnyCircuitElement,
-  CircuitJson,
-  SourceNet,
-  SourcePort,
-} from "circuit-json"
+import type { AnyCircuitElement, SourcePort } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
+
+const isGenericPinLabel = (
+  label: string | undefined,
+  pinNumber: number | undefined,
+) => {
+  if (!label) return true
+  if (pinNumber === undefined) return false
+
+  const normalizedLabel = label.toLowerCase()
+
+  return normalizedLabel === `pin${pinNumber}` || label === String(pinNumber)
+}
+
+const isSpecificPinLabel = (
+  label: string | undefined,
+  pinNumber: number | undefined,
+) => {
+  if (!label || isGenericPinLabel(label, pinNumber)) return false
+
+  return scorePhrase(label) > 1 || (/[a-z]/i.test(label) && /\d/.test(label))
+}
+
+const getMainPinName = (port: SourcePort) => {
+  if (!isGenericPinLabel(port.name, port.pin_number)) {
+    return port.name
+  }
+
+  const bestHint = port.port_hints?.find((hint) =>
+    isSpecificPinLabel(hint, port.pin_number),
+  )
+
+  return bestHint ?? port.name ?? `Pin${port.pin_number}`
+}
 
 export const getReadableNameForPin = ({
   circuitJson,
@@ -34,7 +62,7 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName = getMainPinName(port)
 
   const additionalPinLabels: string[] = []
 
@@ -46,8 +74,7 @@ export const getReadableNameForPin = ({
 
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (isSpecificPinLabel(port_hint, port.pin_number)) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -36,13 +36,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/test4-specific-numeric-pin-labels.test.ts
+++ b/tests/test4-specific-numeric-pin-labels.test.ts
@@ -1,0 +1,72 @@
+import { expect, it } from "bun:test"
+import type { CircuitJson } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("uses specific numeric pin labels instead of generic pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "RP2040",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      display_resistance: "1k",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "GP14", "GPIO14"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["1", "anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ] as CircuitJson
+
+  const netlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(netlist).not.toContain("undefined")
+  expect(netlist).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: RP2040
+     - R1: 1k resistor
+
+    NET: U1_GPIO14
+      - U1 GP14 (GPIO14)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (RP2040)
+    - pin14(GP14, GPIO14): NETS(U1_GPIO14)
+
+    R1 (1k)
+    - pin1(anode, pos, left): NETS(U1_GPIO14)
+    "
+  `)
+})


### PR DESCRIPTION
/claim #4
Closes #4.

## Summary
- Prefer specific numeric pin hints like GP14/GPIO14 when a source port name is only a generic pin name like pin14
- Score known labels before falling back to the generic numeric-label penalty
- Avoid "undefined" in resistor/capacitor component pin headers when no footprint is present
- Add a regression test for numeric pin labels

## Tests
- bun test