### PR TITLE
Score building lighting control pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -13,6 +13,9 @@ const wordQualityScore = {
   SCLK: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  DALI: 1.2,
+  DMX: 1.2,
+  KNX: 1.2,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -35,7 +38,26 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const scoreBuildingLightingLabel = (phrase: string) => {
+  const normalizedPhrase = phrase.toUpperCase()
+  if (
+    normalizedPhrase.includes("DALI") ||
+    normalizedPhrase.includes("DMX512") ||
+    normalizedPhrase.includes("DMX") ||
+    normalizedPhrase.includes("KNX") ||
+    normalizedPhrase.includes("0_10V") ||
+    normalizedPhrase.includes("0-10V")
+  ) {
+    return 1.2
+  }
+}
+
 export const scorePhrase = (phrase: string) => {
+  const buildingLightingLabelScore = scoreBuildingLightingLabel(phrase)
+  if (buildingLightingLabelScore) {
+    return buildingLightingLabelScore
+  }
+
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-building-lighting-labels.test.tsx
+++ b/tests/test4-building-lighting-labels.test.tsx
@@ -1,0 +1,92 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves building lighting control labels with digits", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="CTRL1"
+        footprint="soic8"
+        manufacturerPartNumber="LIGHTCTRL"
+        pinLabels={{
+          pin1: ["DALI2", "pos"],
+          pin2: ["DMX512_OUT1", "pos"],
+          pin3: ["KNX_TP1", "pos"],
+          pin4: ["DIM_0_10V1", "pos"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+      <resistor resistance="1k" footprint="0402" name="R3" />
+      <resistor resistance="1k" footprint="0402" name="R4" />
+
+      <trace from=".CTRL1 .DALI2" to=".R1 > .pin1" />
+      <trace from=".CTRL1 .DMX512_OUT1" to=".R2 > .pin1" />
+      <trace from=".CTRL1 .KNX_TP1" to=".R3 > .pin1" />
+      <trace from=".CTRL1 .DIM_0_10V1" to=".R4 > .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - CTRL1: LIGHTCTRL, soic8
+     - R1: 1kΩ 0402 resistor
+     - R2: 1kΩ 0402 resistor
+     - R3: 1kΩ 0402 resistor
+     - R4: 1kΩ 0402 resistor
+
+    NET: CTRL1_DALI2
+      - CTRL1 DALI2 (+)
+      - R1 pin1
+
+    NET: CTRL1_DMX512_OUT1
+      - CTRL1 DMX512_OUT1 (+)
+      - R2 pin1
+
+    NET: CTRL1_KNX_TP1
+      - CTRL1 KNX_TP1 (+)
+      - R3 pin1
+
+    NET: CTRL1_DIM_0_10V1
+      - CTRL1 DIM_0_10V1 (+)
+      - R4 pin1
+
+
+    COMPONENT_PINS:
+    CTRL1 (LIGHTCTRL)
+    - pin1(DALI2, pos): NETS(CTRL1_DALI2)
+    - pin2(DMX512_OUT1, pos): NETS(CTRL1_DMX512_OUT1)
+    - pin3(KNX_TP1, pos): NETS(CTRL1_KNX_TP1)
+    - pin4(DIM_0_10V1, pos): NETS(CTRL1_DIM_0_10V1)
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(CTRL1_DALI2)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R2 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(CTRL1_DMX512_OUT1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R3 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(CTRL1_KNX_TP1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+
+    R4 (1kΩ 0402)
+    - pin1(anode, pos, left): NETS(CTRL1_DIM_0_10V1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- Score building lighting/control labels (`DALI`, `DMX`, `KNX`, `0-10V`) before the generic digit fallback.
- Preserve digit-bearing labels like `DALI2`, `DMX512_OUT1`, `KNX_TP1`, and `DIM_0_10V1` in generated readable net names.
- Add focused regression coverage for the building-lighting label slice.

## Verification
- `npx bun test`
- `npx biome check .`
- `npx bun run build`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and kept the change scoped to this non-overlapping label slice.

/claim #4