### PR TITLE
Preserve readable chip pin labels

### DIFF
--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,28 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const genericPinHints = new Set([
+  "pin",
+  "left",
+  "right",
+  "top",
+  "bottom",
+  "pos",
+  "positive",
+  "neg",
+  "negative",
+  "anode",
+  "cathode",
+])
+
+const isMeaningfulPinLabel = (hint: string) => {
+  const normalizedHint = hint.trim()
+  if (!normalizedHint) return false
+  if (genericPinHints.has(normalizedHint.toLowerCase())) return false
+  if (/^pin\d+$/i.test(normalizedHint)) return false
+  return /[a-z]/i.test(normalizedHint)
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +56,9 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName =
+    port.name ??
+    (port.pin_number !== undefined ? `Pin${port.pin_number}` : source_port_id)
 
   const additionalPinLabels: string[] = []
 
@@ -47,7 +71,7 @@ export const getReadableNameForPin = ({
   for (const port_hint of port.port_hints ?? []) {
     if (port_hint === mainPinName) continue
     const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (score > 1 || isMeaningfulPinLabel(port_hint)) {
       additionalPinLabels.push(port_hint)
     }
   }

--- a/tests/get-readable-name-for-pin.test.ts
+++ b/tests/get-readable-name-for-pin.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("keeps alphanumeric chip pin labels in readable pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      pin_number: 14,
+      port_hints: ["14", "GP14", "UART_TX", "pin14"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 Pin14 (GP14,UART_TX)")
+})
+
+it("falls back safely when a source port has no name or pin number", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_1",
+      name: "U1",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      port_hints: ["GPIO"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_1",
+    }),
+  ).toBe("U1 source_port_1 (GPIO)")
+})


### PR DESCRIPTION
## Summary
- keep meaningful alphanumeric source port hints in readable pin names, even when they contain digits
- avoid rendering `Pinundefined` by falling back to the source port id when a port has no name or pin number
- add focused regression coverage for both cases

Closes #4

## Verification
- `npx biome check lib/getReadableNameForPin.ts tests/get-readable-name-for-pin.test.ts`
- `npx bun test` — 5 pass, 0 fail
- `npm run build` — ESM and DTS build success

Note: local verification needed `npx bun install` after npm install left some transitive runtime packages unavailable to Bun.