### PR TITLE
Score quantum control pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -31,11 +31,32 @@ const wordQualityScore = {
   right: 0.3,
 }
 
+// Domain labels often include channel indices; keep these useful words above
+// the generic digit fallback without changing the existing broader scoring.
+const digitBearingWordQualityScore = {
+  QUBIT: 1.25,
+  JOSEPHSON: 1.2,
+  SQUID: 1.2,
+  FLUX: 1.15,
+  READOUT: 1.15,
+  AWG: 1.15,
+  MIXER: 1.15,
+}
+
 const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingWordQualityScoreEntries = Object.entries(
+  digitBearingWordQualityScore,
+).sort((a, b) => b[1] - a[1])
+
 export const scorePhrase = (phrase: string) => {
+  for (const [word, score] of digitBearingWordQualityScoreEntries) {
+    if (phrase.includes(word)) {
+      return score
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/test4-quantum-control-pin-labels.test.tsx
+++ b/tests/test4-quantum-control-pin-labels.test.tsx
@@ -1,0 +1,39 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { scorePhrase } from "lib/scorePhrase"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+it("keeps quantum-control labels with channel numbers in readable net names", () => {
+  expect(scorePhrase("QUBIT_READOUT1")).toBeGreaterThan(scorePhrase("pos"))
+  expect(scorePhrase("FLUX_BIAS1")).toBeGreaterThan(scorePhrase("pos"))
+
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="QCTRL-4"
+        pinLabels={{
+          pin1: ["QUBIT_READOUT1"],
+          pin2: ["FLUX_BIAS1"],
+          pin3: ["SQUID_LOOP1"],
+          pin4: ["JOSEPHSON_BIAS1"],
+        }}
+      />
+      <resistor resistance="1k" footprint="0402" name="R1" />
+      <resistor resistance="1k" footprint="0402" name="R2" />
+
+      <trace from=".U1 .QUBIT_READOUT1" to=".R1 .pin1" />
+      <trace from=".U1 .FLUX_BIAS1" to=".R2 .pin1" />
+    </board>,
+  )
+
+  const readableNetlist = convertCircuitJsonToReadableNetlist(circuitJson)
+
+  expect(readableNetlist).toContain("NET: U1_QUBIT_READOUT1")
+  expect(readableNetlist).toContain("NET: U1_FLUX_BIAS1")
+  expect(readableNetlist).toContain("- U1 QUBIT_READOUT1")
+  expect(readableNetlist).toContain("- U1 FLUX_BIAS1")
+  expect(readableNetlist).not.toContain("NET: R1_pos")
+  expect(readableNetlist).not.toContain("NET: R2_pos")
+})


### PR DESCRIPTION
Fixes part of #4

/claim #4

## Summary
- add focused scoring for quantum-control labels before the generic digit fallback
- preserve digit-bearing aliases such as `QUBIT_READOUT1`, `FLUX_BIAS1`, `SQUID_LOOP1`, and `JOSEPHSON_BIAS1` in generated readable net names and pin entries
- add regression coverage showing those labels beat low-information passive labels such as `pos`

## Non-overlap check
I searched open PRs and the issue #4 comments for `QUANTUM`, `QUBIT`, `FLUX_BIAS`, `SQUID`, `JOSEPHSON`, `AWG_TRIG`, and `IQ_MIXER`; I found no existing quantum-control label slice.

## Verification
- `npx --yes bun@latest test tests/test4-quantum-control-pin-labels.test.tsx`
- `npx --yes bun@latest test`
- `npx --yes bun@latest x biome check lib/scorePhrase.ts tests/test4-quantum-control-pin-labels.test.tsx`
- `npx --yes bun@latest run build`
- `npx --yes bun@latest x tsc --noEmit`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and local verification before opening this PR.