### PR TITLE
fix: use descriptive pin names as primary label instead of pin numbers

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -156,10 +156,17 @@ export const convertCircuitJsonToReadableNetlist = (
         .filter((p) => p.source_component_id === component.source_component_id)
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
-        const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+        const mainPin = port.name
+          ? port.name
+          : port.pin_number !== undefined
+            ? `pin${port.pin_number}`
+            : ""
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
+        if (port.pin_number !== undefined) {
+          const pinLabel = `pin${port.pin_number}`
+          if (pinLabel !== mainPin) aliases.push(pinLabel)
+        }
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)

--- a/tests/test2-chip.test.tsx
+++ b/tests/test2-chip.test.tsx
@@ -68,14 +68,14 @@ it("test2 chip", () => {
 
     COMPONENT_PINS:
     U1 (ATMEGA328P)
-    - pin1(GND): NETS(GND)
-    - pin2(AGND): NETS(GND)
-    - pin3(GPIO1, SCL): NETS(GND)
-    - pin4(GPIO2, SDA): NETS(U1_SDA)
-    - pin5(GPIO3): NETS(GPIO4)
-    - pin6(GPIO4, UART_TX): NOT_CONNECTED
-    - pin7(GPIO5, UART_RX): NOT_CONNECTED
-    - pin8(VDD): NETS(V5)
+    - GND(pin1): NETS(GND)
+    - AGND(pin2): NETS(GND)
+    - GPIO1(pin3, SCL): NETS(GND)
+    - GPIO2(pin4, SDA): NETS(U1_SDA)
+    - GPIO3(pin5): NETS(GPIO4)
+    - GPIO4(pin6, UART_TX): NOT_CONNECTED
+    - GPIO5(pin7, UART_RX): NOT_CONNECTED
+    - VDD(pin8): NETS(V5)
 
     R1 (1kΩ 0402)
     - pin1(anode, pos, left): NETS(C1_pos)


### PR DESCRIPTION
Hey! Was playing around with the readable netlist output and noticed something off — the COMPONENT_PINS section shows stuff like `pin3(GPIO1)` when it should really be `GPIO1(pin3)`.

Turns out the code was always picking `pin_number` as the main label, even when `port.name` had a much more useful name like `GPIO14` or `GND`. Swapped the priority around:

```
// Before: pin3(GPIO1, SCL) → pin14(GPIO14, UART_TX)
// After:  GPIO1(pin3, SCL) → GPIO14(pin14, UART_TX)
```

Pin number is still preserved as the fallback alias so nothing gets lost. Updated the test snapshot too.

Fixes #4

/claim #4