### PR TITLE
Score Ethernet PHY pin labels in readable netlists

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -11,8 +11,14 @@ const wordQualityScore = {
   MISO: 1.2,
   MOSI: 1.2,
   SCLK: 1.2,
+  RGMII: 1.2,
+  RMII: 1.2,
+  MDIO: 1.2,
+  MDC: 1.2,
   SDA: 1.2,
   SCL: 1.2,
+  CRS: 1.15,
+  COL: 1.15,
   RX: 1.15,
   TX: 1.15,
   GPIO: 1.1,
@@ -36,13 +42,13 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
 )
 
 export const scorePhrase = (phrase: string) => {
-  if (phrase.match(/\d+/)) {
-    return 0.5
-  }
   for (const [word, score] of wordQualityScoreEntries) {
     if (phrase.includes(word)) {
       return score
     }
+  }
+  if (phrase.match(/\d+/)) {
+    return 0.5
   }
   return 1
 }

--- a/tests/ethernet-phy-pin-labels.test.tsx
+++ b/tests/ethernet-phy-pin-labels.test.tsx
@@ -1,0 +1,92 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves numbered ethernet phy pin labels in readable net names", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_component",
+      ftype: "simple_chip",
+      source_component_id: "source_component_0",
+      name: "U1",
+      manufacturer_part_number: "LAN8720A",
+    },
+    {
+      type: "source_component",
+      ftype: "simple_resistor",
+      source_component_id: "source_component_1",
+      name: "R1",
+      resistance: 33,
+      display_resistance: "33Ohm",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_0",
+      pcb_component_id: "pcb_component_0",
+      source_component_id: "source_component_0",
+      footprinter_string: "qfn24",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      layer: "top",
+    },
+    {
+      type: "cad_component",
+      cad_component_id: "cad_component_1",
+      pcb_component_id: "pcb_component_1",
+      source_component_id: "source_component_1",
+      footprinter_string: "0402",
+      position: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      layer: "top",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin11",
+      pin_number: 11,
+      port_hints: ["RGMII_RXD0", "RMII_RXD0"],
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_1",
+      source_component_id: "source_component_1",
+      name: "pin1",
+      pin_number: 1,
+      port_hints: ["anode", "pos", "left"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_0",
+      connected_source_port_ids: ["source_port_0", "source_port_1"],
+      connected_source_net_ids: [],
+    },
+  ]
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: LAN8720A, qfn24
+     - R1: 33Ohm 0402 resistor
+
+    NET: U1_RGMII_RXD0
+      - U1 pin11 (RGMII_RXD0,RMII_RXD0)
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (LAN8720A)
+    - pin11(RGMII_RXD0, RMII_RXD0): NETS(U1_RGMII_RXD0)
+
+    R1 (33Ohm 0402)
+    - pin1(anode, pos, left): NETS(U1_RGMII_RXD0)
+    "
+  `)
+})


### PR DESCRIPTION
Fixes part of #4
/claim #4

## Summary
- Score common Ethernet PHY labels (`RGMII`, `RMII`, `MDIO`, `MDC`, `CRS`, `COL`) before applying the generic digit penalty.
- Preserve numbered labels like `RGMII_RXD0` and `RMII_RXD0` in generated readable net names and pin labels.
- Add a raw Circuit JSON regression test for an Ethernet PHY pin connected through a passive.

## Verification
- `npx --yes bun@latest test tests\ethernet-phy-pin-labels.test.tsx`
- `npx --yes bun@latest x tsc --noEmit`
- `npx --yes @biomejs/biome check lib\scorePhrase.ts tests\ethernet-phy-pin-labels.test.tsx`
- `npx --yes bun@latest run build`
- `git diff --check`

Note: full `npx --yes bun@latest test` is blocked in my local checkout by the existing JSX fixture path: `@tscircuit/core` imports `distanceBetweenCircleAndPolygon` from the installed `@tscircuit/circuit-json-util`, where that export is absent. The new regression test uses raw Circuit JSON and passes independently.

AI-assisted with Codex; I reviewed the diff and validation before submitting.