### PR TITLE
Fix readable chip pin labels

### DIFF
--- a/lib/convertCircuitJsonToReadableNetlist.ts
+++ b/lib/convertCircuitJsonToReadableNetlist.ts
@@ -9,6 +9,8 @@ import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectiv
 import { generateNetName } from "./generateNetName"
 import { getReadableNameForPin } from "./getReadableNameForPin"
 
+const isGenericPinLabel = (label: string) => /^pin\d+$/i.test(label)
+
 export const convertCircuitJsonToReadableNetlist = (
   circuitJson: AnyCircuitElement[],
 ): string => {
@@ -157,11 +159,14 @@ export const convertCircuitJsonToReadableNetlist = (
         .sort((a, b) => (a.pin_number ?? 0) - (b.pin_number ?? 0))
       for (const port of ports) {
         const mainPin =
-          port.pin_number !== undefined ? `pin${port.pin_number}` : port.name
+          port.pin_number !== undefined
+            ? `pin${port.pin_number}`
+            : (port.name ?? port.port_hints?.[0] ?? port.source_port_id)
         const aliases: string[] = []
         if (port.name && port.name !== mainPin) aliases.push(port.name)
         for (const hint of port.port_hints ?? []) {
           if (hint === String(port.pin_number)) continue
+          if (isGenericPinLabel(hint)) continue
           if (hint !== mainPin && hint !== port.name) aliases.push(hint)
         }
         const aliasPart =

--- a/lib/getReadableNameForPin.ts
+++ b/lib/getReadableNameForPin.ts
@@ -7,6 +7,32 @@ import type {
 } from "circuit-json"
 import { scorePhrase } from "./scorePhrase"
 
+const isGenericPinLabel = (label: string) => /^pin\d+$/i.test(label)
+
+const isNumericPinHint = (hint: string, pinNumber: number | undefined) =>
+  pinNumber !== undefined && hint === String(pinNumber)
+
+const shouldIncludeAdditionalPinLabel = ({
+  hint,
+  mainPinName,
+  componentType,
+  pinNumber,
+}: {
+  hint: string
+  mainPinName: string
+  componentType: string | undefined
+  pinNumber: number | undefined
+}) => {
+  if (hint === mainPinName) return false
+  if (isGenericPinLabel(hint)) return false
+  if (isNumericPinHint(hint, pinNumber)) return false
+
+  const score = scorePhrase(hint)
+  if (score > 1) return true
+
+  return componentType === "simple_chip" && score >= 0.5
+}
+
 export const getReadableNameForPin = ({
   circuitJson,
   source_port_id,
@@ -34,7 +60,8 @@ export const getReadableNameForPin = ({
   )
 
   // Format pin description
-  const mainPinName = port.name ? port.name : `Pin${port.pin_number}`
+  const mainPinName =
+    port.name ?? port.port_hints?.[0] ?? `Pin${port.pin_number ?? ""}`
 
   const additionalPinLabels: string[] = []
 
@@ -45,15 +72,22 @@ export const getReadableNameForPin = ({
   }
 
   for (const port_hint of port.port_hints ?? []) {
-    if (port_hint === mainPinName) continue
-    const score = scorePhrase(port_hint)
-    if (score > 1) {
+    if (
+      shouldIncludeAdditionalPinLabel({
+        hint: port_hint,
+        mainPinName,
+        componentType: component.ftype,
+        pinNumber: port.pin_number,
+      })
+    ) {
       additionalPinLabels.push(port_hint)
     }
   }
 
+  const componentName = component.name ?? component.source_component_id
   const displayValue = component.display_value
     ? ` (${component.display_value})`
     : ""
-  return `${component.name} ${mainPinName}${additionalPinLabels.length > 0 ? ` (${additionalPinLabels.join(",")})` : ""}${displayValue}`
+  const uniqueAdditionalPinLabels = Array.from(new Set(additionalPinLabels))
+  return `${componentName} ${mainPinName}${uniqueAdditionalPinLabels.length > 0 ? ` (${uniqueAdditionalPinLabels.join(",")})` : ""}${displayValue}`
 }

--- a/tests/test4-readable-pin-labels.test.ts
+++ b/tests/test4-readable-pin-labels.test.ts
@@ -1,0 +1,51 @@
+import { expect, it } from "bun:test"
+import { getReadableNameForPin } from "lib/getReadableNameForPin"
+
+it("includes numeric chip pin labels instead of only the generic pin name", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+      name: "U1",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      name: "pin14",
+      pin_number: 14,
+      port_hints: ["14", "pin14", "GPIO10", "SPI1_SCK"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("U1 pin14 (GPIO10,SPI1_SCK)")
+})
+
+it("falls back to stable ids instead of rendering undefined pin names", () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "source_component_0",
+      ftype: "simple_chip",
+    },
+    {
+      type: "source_port",
+      source_port_id: "source_port_0",
+      source_component_id: "source_component_0",
+      port_hints: ["GPIO10"],
+    },
+  ] as any
+
+  expect(
+    getReadableNameForPin({
+      circuitJson,
+      source_port_id: "source_port_0",
+    }),
+  ).toBe("source_component_0 GPIO10")
+})


### PR DESCRIPTION
## Summary
- include numeric chip pin labels like GPIO10 and SPI1_SCK when a port name is only a generic pin name
- avoid rendering undefined by falling back to stable component/port identifiers
- keep generic pin aliases like pin14 out of the component pin alias list

Fixes #4

## Tests
- npx tsc --noEmit
- npx bun test tests/test4-readable-pin-labels.test.ts

Note: npx bun test currently fails in the existing renderer-based tests before this formatter path with @tscircuit/core: TypeError: Attempting to define property on object that is not extensible.