### PR TITLE
Score industrial fieldbus pin labels

### DIFF
--- a/lib/scorePhrase.ts
+++ b/lib/scorePhrase.ts
@@ -35,7 +35,20 @@ const wordQualityScoreEntries = Object.entries(wordQualityScore).sort(
   (a, b) => b[1] - a[1],
 )
 
+const digitBearingIndustrialBusWords = [
+  "ETHERCAT",
+  "PROFINET",
+  "IOLINK",
+  "IO_LINK",
+  "FIELD_BUS",
+]
+
 export const scorePhrase = (phrase: string) => {
+  for (const word of digitBearingIndustrialBusWords) {
+    if (phrase.includes(word)) {
+      return 1.15
+    }
+  }
   if (phrase.match(/\d+/)) {
     return 0.5
   }

--- a/tests/industrial-bus-labels.test.tsx
+++ b/tests/industrial-bus-labels.test.tsx
@@ -1,0 +1,57 @@
+import { expect, it } from "bun:test"
+import { convertCircuitJsonToReadableNetlist } from "lib/convertCircuitJsonToReadableNetlist"
+import { renderCircuit } from "tests/fixtures/render-circuit"
+
+declare module "bun:test" {
+  interface Matchers<T = unknown> {
+    toMatchInlineSnapshot(snapshot?: string | null): Promise<MatcherResult>
+  }
+}
+
+it("preserves digit-bearing industrial bus labels in generated net names", () => {
+  const circuitJson = renderCircuit(
+    <board width="10mm" height="10mm" routingDisabled>
+      <chip
+        name="U1"
+        footprint="soic8"
+        manufacturerPartNumber="LAN9252"
+        pinLabels={{
+          pin1: ["ETHERCAT_SYNC1"],
+          pin2: ["PROFINET_RX1"],
+        }}
+      />
+      <resistor resistance="10k" footprint="0402" name="R1" />
+
+      <trace from=".U1 .ETHERCAT_SYNC1" to=".R1 > .pin1" />
+    </board>,
+  )
+
+  expect(
+    convertCircuitJsonToReadableNetlist(circuitJson),
+  ).toMatchInlineSnapshot(`
+    "COMPONENTS:
+     - U1: LAN9252, soic8
+     - R1: 10kΩ 0402 resistor
+
+    NET: U1_ETHERCAT_SYNC1
+      - U1 ETHERCAT_SYNC1
+      - R1 pin1
+
+
+    COMPONENT_PINS:
+    U1 (LAN9252)
+    - pin1(ETHERCAT_SYNC1): NETS(U1_ETHERCAT_SYNC1)
+    - pin2(PROFINET_RX1): NOT_CONNECTED
+    - pin3: NOT_CONNECTED
+    - pin4: NOT_CONNECTED
+    - pin5: NOT_CONNECTED
+    - pin6: NOT_CONNECTED
+    - pin7: NOT_CONNECTED
+    - pin8: NOT_CONNECTED
+
+    R1 (10kΩ 0402)
+    - pin1(anode, pos, left): NETS(U1_ETHERCAT_SYNC1)
+    - pin2(cathode, neg, right): NOT_CONNECTED
+    "
+  `)
+})


### PR DESCRIPTION
## Summary
- Score digit-bearing industrial fieldbus labels before the generic numeric fallback.
- Preserve labels such as `ETHERCAT_SYNC1` and `PROFINET_RX1` in generated readable net names instead of lower-information passive hints.
- Add focused regression coverage for the fieldbus label case.

/claim #4

## Tests
- `bun test tests/industrial-bus-labels.test.tsx`
- `bun test`
- `bun run build`
- `git diff --check`
- `git diff --cached --check`